### PR TITLE
[SDK-115]: Added X-SDK identifier to HTTP header sent with API requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,13 +79,13 @@ npm test
 ## Installing the SDK
 
 To import the Yoti SDK inside your project, you can use your favourite dependency management system.
-If you are using NPM, you can use `npm install -S -E yoti-node-sdk` to set the Yoti SDK as a dependency.
+If you are using NPM, you can use `npm install -S -E yoti` to set the Yoti SDK as a dependency.
 
 Your package.json file will then be updated to include:
 
 ```json
 "dependencies": {
-     "yoti-node-sdk" : "2.0.0"
+     "yoti" : "2.0.0"
  }
  ```
 
@@ -94,7 +94,7 @@ Your package.json file will then be updated to include:
 The YotiClient is the SDK entry point. To initialise it you need include the following snippet inside your endpoint initialisation section:
 
 ```javascript
-const YotiClient = require('yoti-node-sdk')
+const YotiClient = require('yoti')
 const CLIENT_SDK_ID = 'your sdk id'
 const PEM = fs.readFileSync(__dirname + "/keys/your-application-pem-file.pem");
 var yotiClient = new YotiClient(CLIENT_SDK_ID, PEM)

--- a/README.md
+++ b/README.md
@@ -59,22 +59,33 @@ If you're planning on using the Node SDK on Windows, you'll need to install a fe
 * [OpenSSL](http://slproweb.com/products/Win32OpenSSL.html) (normal version, not light)
 in the same bitness as your Node.js installation.
     * OpenSSL must be installed in its specific directory (`C:\OpenSSL-Win32` or `C:\OpenSSL-Win64`)
-    * The latest version of OpenSSL (v1.1.x) does not have the `libeay32.dll` file. Install v1.0.2 instead.
+    * The latest version of OpenSSL (v1.1.x) does not have the `libeay32.dll` file. **Install v1.0.2 instead**.
     * If you get `Error: The specified module could not be found.`, copy `libeay32.dll` from the OpenSSL bin directory to this module's bin directory, or to `Windows\System32`.
 * [node-gyp](https://github.com/nodejs/node-gyp) (`npm install -g node-gyp`)
    * Either install Microsoft's [windows-build-tools](https://github.com/felixrieseberg/windows-build-tools) using `npm install --global --production windows-build-tools`
    * Or manually install [Python 2.7](http://www.python.org/download/) and [Visual Studio](https://www.visualstudio.com/downloads/) (or modify an existing installation) and select Common Tools for Visual C++ during setup.
 
+## Working on the SDK
+
+To install the required packages run:
+```shell
+npm install
+```
+To run the tests run:
+```shell
+npm test
+```
+
 ## Installing the SDK
 
 To import the Yoti SDK inside your project, you can use your favourite dependency management system.
-If you are using NPM, you can use `npm install -S -E yoti-node-sdk` to set the Yoti SDK as a dependancy.
+If you are using NPM, you can use `npm install -S -E yoti-node-sdk` to set the Yoti SDK as a dependency.
 
 Your package.json file will then be updated to include:
 
 ```json
 "dependencies": {
-     "yoti-node-sdk" : "1.0.2"
+     "yoti-node-sdk" : "2.0.0"
  }
  ```
 

--- a/example/simple-login/index.js
+++ b/example/simple-login/index.js
@@ -8,7 +8,7 @@ const fs         = require('fs')
 const ejs        = require('ejs')
 const app        = express()
 
-const YotiClient = require('yoti-node-sdk')
+const YotiClient = require('yoti')
 
 
 const port = process.env.PORT || 9443

--- a/example/simple-login/package.json
+++ b/example/simple-login/package.json
@@ -6,7 +6,7 @@
   "author": "Yoti LTD",
   "scripts": {},
   "dependencies": {
-    "yoti-node-sdk" : "1.0.0",
+    "yoti" : "2.0.0",
     "ejs": "2.4.2",
     "express":"4.15.2",
     "body-parser":"1.17.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yoti-node-sdk",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "description": "Yoti NodeJS SDK for back-end integration",
   "author": "Yoti LTD <tech@yoti.com> (https://www.yoti.com/developers)",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "yoti-node-sdk",
+  "name": "yoti",
   "version": "2.0.0",
   "description": "Yoti NodeJS SDK for back-end integration",
   "author": "Yoti LTD <tech@yoti.com> (https://www.yoti.com/developers)",

--- a/src/profile_service/index.js
+++ b/src/profile_service/index.js
@@ -43,11 +43,13 @@ exports.getReceipt = (token, pem, applicationId) => {
     let timestamp =  Date.now();
     let endpoint = `/profile/${token}`;
     let messageSignature = getRSASignatureForMessage(`GET&${endpoint}?nonce=${nonce}&timestamp=${timestamp}&appId=${applicationId}`, pem);
+    let sdkIdentifier = 'Node';
 
     return new Promise((resolve, reject) => {
     	superagent.get(`${server.configuration.connectApi}${endpoint}`)
             .set('X-Yoti-Auth-Key', authKey)
             .set('X-Yoti-Auth-Digest', messageSignature)
+            .set('X-SDK', sdkIdentifier)
             .set('Content-Type', 'application/json')
             .set('Accept', 'application/json')
             .query({nonce: nonce})


### PR DESCRIPTION
Initial PR, once this is approved I can upload the new package, and then update the example project to use this new package. 
I also just added the instructions for installing the dependencies and running the tests.
@Alttaf - is bumping the version to 2.0.0 ok? Based on semantic versioning, I thought this extra header is an incompatible API change, and so 1.1.0 isn't appropriate.
I also just highlighted a part of the instructions in bold, as I missed this when I was scanning through, and it was quite important!