### PR TITLE
[SDK-128]: Changed X-SDK to X-Yoti-SDK and updated package

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Your package.json file will then be updated to include:
 
 ```json
 "dependencies": {
-     "yoti" : "2.0.0"
+     "yoti" : "x.x.x"
  }
  ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yoti",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Yoti NodeJS SDK for back-end integration",
   "author": "Yoti LTD <tech@yoti.com> (https://www.yoti.com/developers)",
   "scripts": {

--- a/src/profile_service/index.js
+++ b/src/profile_service/index.js
@@ -49,7 +49,7 @@ exports.getReceipt = (token, pem, applicationId) => {
     	superagent.get(`${server.configuration.connectApi}${endpoint}`)
             .set('X-Yoti-Auth-Key', authKey)
             .set('X-Yoti-Auth-Digest', messageSignature)
-            .set('X-SDK', sdkIdentifier)
+            .set('X-Yoti-SDK', sdkIdentifier)
             .set('Content-Type', 'application/json')
             .set('Accept', 'application/json')
             .query({nonce: nonce})


### PR DESCRIPTION
I changed the README to have the version number as "yoti" : "x.x.x" to prevent having to change this each time. Would you say this makes sense? I'll update on npm, and then install to the example project once this is approved.