### PR TITLE
[SDK-167]: Excluded test folder from published package using .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+example
+test

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yoti",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Yoti NodeJS SDK for back-end integration",
   "author": "Yoti LTD <tech@yoti.com> (https://www.yoti.com/developers)",
   "license": "MIT",


### PR DESCRIPTION
Nothing was required for example project due to the package.json file for that specifying private