### PR TITLE
SDK-670: Send X-Yoti-SDK-Version header

### DIFF
--- a/src/request/index.js
+++ b/src/request/index.js
@@ -4,6 +4,7 @@ const uuid = require('uuid');
 const superagent = require('superagent');
 const config = require('../../config');
 const yotiCommon = require('../yoti_common');
+const yotiPackage = require('../../package.json');
 
 const supportedMethods = ['POST', 'PUT', 'PATCH', 'GET', 'DELETE'];
 
@@ -54,6 +55,7 @@ module.exports.makeRequest = (httpMethod, endpoint, pem, appId, Payload) => {
     request.set('X-Yoti-Auth-Key', authKey)
       .set('X-Yoti-Auth-Digest', messageSignature)
       .set('X-Yoti-SDK', sdkIdentifier)
+      .set('X-Yoti-SDK-Version', yotiPackage.version)
       .set('Content-Type', 'application/json')
       .set('Accept', 'application/json')
       .then((response) => {

--- a/tests/request.spec.js
+++ b/tests/request.spec.js
@@ -47,22 +47,22 @@ describe('YotiResponse', () => {
         'X-Yoti-Auth-Key': new RegExp('^[a-zA-Z0-9]+'),
         'X-Yoti-Auth-Digest': new RegExp('^[a-zA-Z0-9]+'),
         'Content-Type': 'application/json',
-        'Accept': 'application/json',
+        Accept: 'application/json',
       };
-      Object.keys(expectedHeaders).forEach(header => {
+      Object.keys(expectedHeaders).forEach((header) => {
         beforeEach((done) => {
-          let apiUri = new RegExp(`^/api/v1/${header}/stub?`);
+          const apiUri = new RegExp(`^/api/v1/${header}/stub?`);
 
           // Return success result when correct headers are provided.
-          nock(`${config.yoti.connectApi}/${header}`)
+          nock(`${config.yoti.connectApi}`)
             .matchHeader(header, expectedHeaders[header])
             .get(apiUri)
-            .reply(200, {'result': 'correct header'});
+            .reply(200, { result: 'correct header' });
 
           // Return failure result if the header isn't matched.
-          nock(`${config.yoti.connectApi}/${header}`)
+          nock(`${config.yoti.connectApi}`)
             .get(apiUri)
-            .reply(200, {'result': 'incorrect header'});
+            .reply(200, { result: 'incorrect header' });
 
           done();
         });

--- a/tests/request.spec.js
+++ b/tests/request.spec.js
@@ -44,8 +44,8 @@ describe('YotiResponse', () => {
       const expectedHeaders = {
         'X-Yoti-SDK': 'Node',
         'X-Yoti-SDK-Version': yotiPackage.version,
-        'X-Yoti-Auth-Key': new RegExp('^[a-zA-Z0-9]+'),
-        'X-Yoti-Auth-Digest': new RegExp('^[a-zA-Z0-9]+'),
+        'X-Yoti-Auth-Key': new RegExp('^[a-zA-Z0-9/+]{392}$'),
+        'X-Yoti-Auth-Digest': new RegExp('^[a-zA-Z0-9/+=]{344}$'),
         'Content-Type': 'application/json',
         Accept: 'application/json',
       };

--- a/tests/request.spec.js
+++ b/tests/request.spec.js
@@ -50,26 +50,25 @@ describe('YotiResponse', () => {
         'Accept': 'application/json',
       };
       Object.keys(expectedHeaders).forEach(header => {
-        let headerValue = expectedHeaders[header];
-        let apiUri = new RegExp('^/api/v1/' + header + '/stub?');
-
         beforeEach((done) => {
+          let apiUri = new RegExp(`^/api/v1/${header}/stub?`);
+
           // Return success result when correct headers are provided.
-          nock(`${config.yoti.connectApi}` + '/' + header)
-            .matchHeader(header, headerValue)
+          nock(`${config.yoti.connectApi}/${header}`)
+            .matchHeader(header, expectedHeaders[header])
             .get(apiUri)
             .reply(200, {'result': 'correct header'});
 
           // Return failure result if the header isn't matched.
-          nock(`${config.yoti.connectApi}` + '/' + header)
+          nock(`${config.yoti.connectApi}/${header}`)
             .get(apiUri)
             .reply(200, {'result': 'incorrect header'});
 
           done();
         });
 
-        it('should have the correct ' + header + ' header', (done) => {
-          request.makeRequest('GET', '/' + header + '/stub', privateKeyFile, 'stub-app-id', new Payload(''))
+        it(`should have the correct ${header} header`, (done) => {
+          request.makeRequest('GET', `/${header}/stub`, privateKeyFile, 'stub-app-id', new Payload(''))
             .then((response) => {
               expect(response.parsedResponse.result).to.equal('correct header');
               done();


### PR DESCRIPTION
- Sending `package.json` version in `X-Yoti-SDK-Version`, e.g. `3.2.0`

> I can change this to use a constant defined in `src/request/index.js` if that's preferable?