### PR TITLE
SDK-584: Image object

### DIFF
--- a/src/data_type/image.jpeg.js
+++ b/src/data_type/image.jpeg.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const Image = require('./image');
+
+/**
+ * Image JPEG attribute value.
+ */
+module.exports = class ImageJpeg extends Image {
+  constructor(value) {
+    super(value);
+    this.MIME_TYPE = 'image/jpeg';
+  }
+
+  /**
+   * @inheritdoc
+   */
+  getMimeType() {
+    return this.MIME_TYPE;
+  }
+};

--- a/src/data_type/image.jpeg.js
+++ b/src/data_type/image.jpeg.js
@@ -7,14 +7,6 @@ const Image = require('./image');
  */
 module.exports = class ImageJpeg extends Image {
   constructor(value) {
-    super(value);
-    this.MIME_TYPE = 'image/jpeg';
-  }
-
-  /**
-   * @inheritdoc
-   */
-  getMimeType() {
-    return this.MIME_TYPE;
+    super(value, 'image/jpeg');
   }
 };

--- a/src/data_type/image.js
+++ b/src/data_type/image.js
@@ -1,0 +1,40 @@
+'use strict';
+
+/**
+ * Abstract Image attribute class.
+ */
+module.exports = class Image {
+  constructor(content) {
+    if (new.target === Image) {
+      throw TypeError('new of abstract class Image');
+    }
+    this.content = content;
+  }
+
+  /**
+   * Get the raw image content.
+   *
+   * @returns {ByteBuffer}
+   */
+  getContent() {
+    return this.content;
+  }
+
+  /**
+   * Get the base64 image content.
+   *
+   * @returns {string}
+   */
+  getBase64Content() {
+    return `data:${this.getMimeType()};base64,${this.content.toBase64()}`;
+  }
+
+  /**
+   * Abstract method to return the image mime type.
+   *
+   * @returns {string}
+   */
+  getMimeType() {
+    throw new Error(`${this.constructor.name} must implement getMimeType()`);
+  }
+};

--- a/src/data_type/image.js
+++ b/src/data_type/image.js
@@ -6,7 +6,7 @@
 module.exports = class Image {
   constructor(content) {
     if (new.target === Image) {
-      throw TypeError('new of abstract class Image');
+      throw TypeError('Image is an abstract class, so cannot be instantiated');
     }
     this.content = content;
   }

--- a/src/data_type/image.js
+++ b/src/data_type/image.js
@@ -4,11 +4,21 @@
  * Abstract Image attribute class.
  */
 module.exports = class Image {
-  constructor(content) {
+  /**
+   * Image constructor.
+   *
+   * @param {ByteBuffer} content
+   * @param {string} mimeType
+   */
+  constructor(content, mimeType) {
     if (new.target === Image) {
       throw TypeError('Image is an abstract class, so cannot be instantiated');
     }
+    if (typeof mimeType === 'undefined') {
+      throw TypeError(`${this.constructor.name} must pass mimeType to the Image constructor`);
+    }
     this.content = content;
+    this.mimeType = mimeType;
   }
 
   /**
@@ -30,11 +40,11 @@ module.exports = class Image {
   }
 
   /**
-   * Abstract method to return the image mime type.
+   * Get the image mime type.
    *
    * @returns {string}
    */
   getMimeType() {
-    throw new Error(`${this.constructor.name} must implement getMimeType()`);
+    return this.mimeType;
   }
 };

--- a/src/data_type/image.png.js
+++ b/src/data_type/image.png.js
@@ -7,14 +7,6 @@ const Image = require('./image');
  */
 module.exports = class ImagePng extends Image {
   constructor(value) {
-    super(value);
-    this.MIME_TYPE = 'image/png';
-  }
-
-  /**
-   * @inheritdoc
-   */
-  getMimeType() {
-    return this.MIME_TYPE;
+    super(value, 'image/png');
   }
 };

--- a/src/data_type/image.png.js
+++ b/src/data_type/image.png.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const Image = require('./image');
+
+/**
+ * Image PNG attribute value.
+ */
+module.exports = class ImagePng extends Image {
+  constructor(value) {
+    super(value);
+    this.MIME_TYPE = 'image/png';
+  }
+
+  /**
+   * @inheritdoc
+   */
+  getMimeType() {
+    return this.MIME_TYPE;
+  }
+};

--- a/src/proto-root/proto.attribute.list.js
+++ b/src/proto-root/proto.attribute.list.js
@@ -3,6 +3,8 @@
 const Age = require('../yoti_common/age').Age;
 const { AttributeConverter } = require('../yoti_common/attribute.converter');
 const AnchorProcessor = require('../yoti_common/anchor.processor').AnchorProcessor;
+const constants = require('../yoti_common/constants');
+const Image = require('../data_type/image');
 
 module.exports = {
 
@@ -18,14 +20,17 @@ module.exports = {
       const attrValue = attribute.getValue();
       const attrType = attribute.getContentType();
       const processedAnchors = AnchorProcessor.process(attribute.anchors);
-      const convertedValueByType = this.convertValueBasedOnContentType(attrValue, attrType);
+      const convertedValueByType = AttributeConverter
+        .convertValueBasedOnContentType(attrValue, attrType);
       const attrNameInCamelCase = this.toCamelCase(attrName);
 
-      attrList.push({ [attrNameInCamelCase]: convertedValueByType });
-
-      if (attrName === 'selfie') {
-        const imageUriValue = this.imageUriBasedOnContentType(attrValue, attrType);
-        attrList.push({ base64SelfieUri: imageUriValue });
+      // Handle selfies for backwards compatibility.
+      if (attrName === constants.ATTR_SELFIE && convertedValueByType instanceof Image) {
+        attrList.push({ base64SelfieUri: convertedValueByType.getBase64Content() });
+        attrList.push({ [attrNameInCamelCase]: convertedValueByType.getContent() });
+      }
+      else {
+        attrList.push({ [attrNameInCamelCase]: convertedValueByType });
       }
 
       let attrData = null;

--- a/src/proto-root/utils.js
+++ b/src/proto-root/utils.js
@@ -2,42 +2,4 @@
 
 const ProtoBuf = require('protobufjs');
 
-const UNDEFINED = 0;
-const STRING = 1;
-const JPEG = 2;
-const DATE = 3;
-const PNG = 4;
-const BYTES = 5;
-
 module.exports.toCamelCase = str => ProtoBuf.Util.toCamelCase(str);
-
-module.exports.convertValueBasedOnContentType = (value, contentType) => {
-  switch (contentType) {
-    // UNDEFINED should not be seen, and is used as an error placeholder
-    case UNDEFINED:
-      throw new Error('Wrong content type');
-    case STRING: // STRING means the value is UTF-8 encoded text.
-    case DATE: // Date as string in RFC3339 format (YYYY-MM-DD).
-      return value.toUTF8();
-    case BYTES: {
-      // Convert ByteArray to JSON
-      const attrValue = Buffer.from(value.toArrayBuffer()).toString();
-      return JSON.parse(attrValue);
-    }
-    default:
-      return value;
-  }
-};
-
-module.exports.imageUriBasedOnContentType = (value, contentType) => {
-  switch (contentType) {
-    // JPEG indicates a standard .jpeg image.
-    case JPEG:
-      return `data:image/jpeg;base64,${value.toBase64()}`;
-    // PNG indicates a standard .png image.
-    case PNG:
-      return `data:image/png;base64,${value.toBase64()}`;
-    default:
-      return value.toBase64();
-  }
-};

--- a/src/yoti_common/attribute.converter.js
+++ b/src/yoti_common/attribute.converter.js
@@ -4,6 +4,12 @@ const constants = require('./constants');
 const { DocumentDetails } = require('../data_type/document.details');
 const ImagePng = require('../data_type/image.png');
 const ImageJpeg = require('../data_type/image.jpeg');
+const CONTENT_TYPE_UNDEFINED = 0;
+const CONTENT_TYPE_STRING = 1;
+const CONTENT_TYPE_JPEG = 2;
+const CONTENT_TYPE_DATE = 3;
+const CONTENT_TYPE_PNG = 4;
+const CONTENT_TYPE_BYTES = 5;
 
 module.exports.AttributeConverter = class AttributeConverter {
   static convertValueBasedOnAttributeName(value, attrName) {
@@ -26,19 +32,19 @@ module.exports.AttributeConverter = class AttributeConverter {
 
     switch (contentType) {
       // UNDEFINED should not be seen, and is used as an error placeholder
-      case constants.CONTENT_TYPE_UNDEFINED:
+      case CONTENT_TYPE_UNDEFINED:
         throw new Error('Wrong content type');
-      case constants.CONTENT_TYPE_STRING: // STRING means the value is UTF-8 encoded text.
-      case constants.CONTENT_TYPE_DATE: // Date as string in RFC3339 format (YYYY-MM-DD).
+      case CONTENT_TYPE_STRING: // STRING means the value is UTF-8 encoded text.
+      case CONTENT_TYPE_DATE: // Date as string in RFC3339 format (YYYY-MM-DD).
         return value.toUTF8();
-      case constants.CONTENT_TYPE_BYTES: {
+      case CONTENT_TYPE_BYTES: {
         // Convert ByteArray to JSON
         const attrValue = Buffer.from(value.toArrayBuffer()).toString();
         return JSON.parse(attrValue);
       }
-      case constants.CONTENT_TYPE_JPEG:
+      case CONTENT_TYPE_JPEG:
         return new ImageJpeg(value);
-      case constants.CONTENT_TYPE_PNG:
+      case CONTENT_TYPE_PNG:
         return new ImagePng(value);
       default:
         return value;

--- a/src/yoti_common/attribute.converter.js
+++ b/src/yoti_common/attribute.converter.js
@@ -2,6 +2,8 @@
 
 const constants = require('./constants');
 const { DocumentDetails } = require('../data_type/document.details');
+const ImagePng = require('../data_type/image.png');
+const ImageJpeg = require('../data_type/image.jpeg');
 
 module.exports.AttributeConverter = class AttributeConverter {
   static convertValueBasedOnAttributeName(value, attrName) {
@@ -12,6 +14,32 @@ module.exports.AttributeConverter = class AttributeConverter {
     switch (attrName) {
       case constants.ATTR_DOCUMENT_DETAILS:
         return new DocumentDetails(value);
+      default:
+        return value;
+    }
+  }
+
+  static convertValueBasedOnContentType(value, contentType) {
+    if (!value) {
+      return null;
+    }
+
+    switch (contentType) {
+      // UNDEFINED should not be seen, and is used as an error placeholder
+      case constants.CONTENT_TYPE_UNDEFINED:
+        throw new Error('Wrong content type');
+      case constants.CONTENT_TYPE_STRING: // STRING means the value is UTF-8 encoded text.
+      case constants.CONTENT_TYPE_DATE: // Date as string in RFC3339 format (YYYY-MM-DD).
+        return value.toUTF8();
+      case constants.CONTENT_TYPE_BYTES: {
+        // Convert ByteArray to JSON
+        const attrValue = Buffer.from(value.toArrayBuffer()).toString();
+        return JSON.parse(attrValue);
+      }
+      case constants.CONTENT_TYPE_JPEG:
+        return new ImageJpeg(value);
+      case constants.CONTENT_TYPE_PNG:
+        return new ImagePng(value);
       default:
         return value;
     }

--- a/src/yoti_common/constants.js
+++ b/src/yoti_common/constants.js
@@ -23,10 +23,4 @@ module.exports = Object.freeze({
   ATTR_POSTAL_ADDRESS: 'postal_address',
   ATTR_DOCUMENT_DETAILS: 'document_details',
   ATTR_STRUCTURED_POSTAL_ADDRESS: 'structured_postal_address',
-  CONTENT_TYPE_UNDEFINED: 0,
-  CONTENT_TYPE_STRING: 1,
-  CONTENT_TYPE_JPEG: 2,
-  CONTENT_TYPE_DATE: 3,
-  CONTENT_TYPE_PNG: 4,
-  CONTENT_TYPE_BYTES: 5,
 });

--- a/src/yoti_common/constants.js
+++ b/src/yoti_common/constants.js
@@ -23,4 +23,10 @@ module.exports = Object.freeze({
   ATTR_POSTAL_ADDRESS: 'postal_address',
   ATTR_DOCUMENT_DETAILS: 'document_details',
   ATTR_STRUCTURED_POSTAL_ADDRESS: 'structured_postal_address',
+  CONTENT_TYPE_UNDEFINED: 0,
+  CONTENT_TYPE_STRING: 1,
+  CONTENT_TYPE_JPEG: 2,
+  CONTENT_TYPE_DATE: 3,
+  CONTENT_TYPE_PNG: 4,
+  CONTENT_TYPE_BYTES: 5,
 });

--- a/tests/data-type.image.spec.js
+++ b/tests/data-type.image.spec.js
@@ -23,18 +23,18 @@ const imageTypes = [
 imageTypes.forEach((type) => {
   describe(`${type.imageObj.constructor.name}`, () => {
     context('#getContent()', () => {
-      it('it should return original image content', () => {
+      it('should return original image content', () => {
         expect(type.imageObj.getContent()).to.equal(imageContent);
       });
     });
     context('#getBase64Content()', () => {
-      it('it should return base64 image content', () => {
+      it('should return base64 image content', () => {
         const base64String = `data:${type.mimeType};base64,${imageContent.toBase64()}`;
         expect(type.imageObj.getBase64Content()).to.equal(base64String);
       });
     });
     context('#getMimeType()', () => {
-      it(`it should return ${type.mimeType}`, () => {
+      it(`should return ${type.mimeType}`, () => {
         expect(type.imageObj.getMimeType()).to.equal(type.mimeType);
       });
     });

--- a/tests/data-type.image.spec.js
+++ b/tests/data-type.image.spec.js
@@ -38,8 +38,8 @@ imageTypes.forEach((type) => {
         expect(type.imageObj.getMimeType()).to.equal(type.mimeType);
       });
     });
-    context('when instatiated', () => {
-      it('it should be an instance of Image', () => {
+    context('when instantiated', () => {
+      it('should be an instance of Image', () => {
         expect(type.imageObj).to.be.an.instanceof(Image);
       });
     });

--- a/tests/data-type.image.spec.js
+++ b/tests/data-type.image.spec.js
@@ -1,0 +1,47 @@
+const expect = require('chai').expect;
+const Image = require('../src/data_type/image');
+const ImageJpeg = require('../src/data_type/image.jpeg');
+const ImagePng = require('../src/data_type/image.png');
+
+const imageContent = {
+  toBase64() {
+    return 'test_image_data';
+  },
+};
+
+const imageTypes = [
+  {
+    imageObj: new ImageJpeg(imageContent),
+    mimeType: 'image/jpeg',
+  },
+  {
+    imageObj: new ImagePng(imageContent),
+    mimeType: 'image/png',
+  },
+];
+
+imageTypes.forEach((type) => {
+  describe(`${type.imageObj.constructor.name}`, () => {
+    context('#getContent()', () => {
+      it('it should return original image content', () => {
+        expect(type.imageObj.getContent()).to.equal(imageContent);
+      });
+    });
+    context('#getBase64Content()', () => {
+      it('it should return base64 image content', () => {
+        const base64String = `data:${type.mimeType};base64,${imageContent.toBase64()}`;
+        expect(type.imageObj.getBase64Content()).to.equal(base64String);
+      });
+    });
+    context('#getMimeType()', () => {
+      it(`it should return ${type.mimeType}`, () => {
+        expect(type.imageObj.getMimeType()).to.equal(type.mimeType);
+      });
+    });
+    context('when instatiated', () => {
+      it('it should be an instance of Image', () => {
+        expect(type.imageObj).to.be.an.instanceof(Image);
+      });
+    });
+  });
+});


### PR DESCRIPTION
- _Abstract_ `Image` class providing methods:
  - _Abstract_ `getMimeType()`
  - `getBase64Content()`
  - `getContent()`
- `ImageJpeg`/`ImagePng` classes extend `Image`, and implement `getMimeType()`

### Backwards compatibility:
- Kept `getBase64SelfieUri()`, but is now using `Image::getBase64Content()`
- `selfie` property continues to return image content (rather than new `Image` object), but is now using `Image::getContent()`