### PR TITLE
SDK-568: Deprecate getUserId()

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ yotiClient.getActivityDetails(token).then((activityDetails) => {
 
 ```
 
-Where `yourUserSearchFunction` is a piece of logic in your app that is supposed to find a user, given a _Remember Me Id_.
+Where `yourUserSearchFunction` is a piece of logic in your app that is supposed to find a user, given a _Remember Me ID_.
 No matter if the user is a new or an existing one, Yoti will always provide her/his profile, so you don't necessarily need to store it.
 
 The `profile` object provides a set of attributes corresponding to user attributes. Whether the attributes are present or not depends on the settings you have applied to your app on Yoti Dashboard.

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ yotiClient.getActivityDetails(token).then((activityDetails) => {
     if(activityDetails.getOutcome() == 'SUCCESS') {
         const userProfile = activityDetails.getUserProfile(); // deprecated
         const profile = activityDetails.getProfile();
-        const user = yourUserSearchFunction(activityDetails.getUserId());
+        const user = yourUserSearchFunction(activityDetails.getRememberMeId());
         if(user) {
             // handle login
         } else {
@@ -190,7 +190,7 @@ yotiClient.getActivityDetails(token).then((activityDetails) => {
 
 ```
 
-Where `yourUserSearchFunction` is a piece of logic in your app that is supposed to find a user, given a userId.
+Where `yourUserSearchFunction` is a piece of logic in your app that is supposed to find a user, given a _Remember Me Id_.
 No matter if the user is a new or an existing one, Yoti will always provide her/his profile, so you don't necessarily need to store it.
 
 The `profile` object provides a set of attributes corresponding to user attributes. Whether the attributes are present or not depends on the settings you have applied to your app on Yoti Dashboard.
@@ -297,7 +297,7 @@ yotiClient.getActivityDetails(token).then((activityDetails) => {
 ```
 
 * Activity Details
-  * [X] User ID `.getUserId()`
+  * [X] Remember Me ID `.getRememberMeId()`
   * [X] Parent Remember Me ID `.getParentRememberMeId()`
   * [X] Base64 Selfie Uri `getBase64SelfieUri()`
   * [X] Profile `.getProfile()`

--- a/examples/profile/index.js
+++ b/examples/profile/index.js
@@ -67,7 +67,7 @@ router.get('/profile', (req, res) => {
     }
 
     res.render('pages/profile', {
-      userId: activityDetails.getUserId(),
+      rememberMeId: activityDetails.getRememberMeId(),
       parentRememberMeId: activityDetails.getParentRememberMeId(),
       selfieUri: activityDetails.getBase64SelfieUri(),
       userProfile,

--- a/examples/profile/views/pages/profile.ejs
+++ b/examples/profile/views/pages/profile.ejs
@@ -382,10 +382,10 @@ const userSelfie = profile.getSelfie();
       </td>
     </tr>
     <% } %>
-    <% if (userId) { %>
+    <% if (rememberMeId) { %>
     <tr>
       <th scope="row">Remember Me ID</th>
-      <td colspan="3"><%= userId %></td>
+      <td colspan="3"><%= rememberMeId %></td>
       <td></td>
     </tr>
     <% } %>

--- a/src/profile_service/index.js
+++ b/src/profile_service/index.js
@@ -30,11 +30,61 @@ const ActivityDetails = function main(parsedResponse, decryptedProfile) {
 };
 
 ActivityDetails.prototype = {
-  getUserId() { return this.receipt.remember_me_id; },
+  /**
+   * Return the Remember Me ID.
+   *
+   * @deprecated Replaced by getRememberMeId()
+   */
+  getUserId() { return this.getRememberMeId(); },
+
+  /**
+   * Return the Remember Me ID, which is a unique, stable identifier for
+   * a user in the context of an application.
+   *
+   * You can use it to identify returning users. This value will be different
+   * for the same user in different applications.
+   *
+   * @returns {string}
+   */
+  getRememberMeId() { return this.receipt.remember_me_id; },
+
+  /**
+   * Return the Parent Remember Me ID, which is a unique, stable identifier for a
+   * user in the context of an organisation.
+   *
+   * You can use it to identify returning users. This value is consistent for a
+   * given user across different applications belonging to a single organisation.
+   *
+   * @returns {string}
+   */
   getParentRememberMeId() { return this.receipt.parent_remember_me_id; },
+
+  /**
+   * The user profile returned by Yoti if the request was successful.
+   *
+   * @returns {Object}
+   */
   getUserProfile() { return this.profile; },
-  getProfile() { return this.extendedProfile; }, // This is the new profile object
+
+  /**
+   * The user Profile object.
+   *
+   * @returns {Profile}
+   */
+  getProfile() { return this.extendedProfile; },
+
+  /**
+   * A enum to represent the success state when requesting a profile.
+   *
+   * @returns {string}
+   */
   getOutcome() { return this.receipt.sharing_outcome; },
+
+  /**
+   * Base64 encoded selfie image.
+   *
+   * @returns {string}
+   */
   getBase64SelfieUri() { return this.profile.base64SelfieUri; },
 };
 

--- a/tests/client.spec.js
+++ b/tests/client.spec.js
@@ -16,7 +16,7 @@ describe('yotiClient', () => {
 
   const selfie = fs.readFileSync('./tests/sample-data/fixtures/selfie.txt', 'utf8');
   const phoneNumber = '+447474747474';
-  const userId = 'Hig2yAT79cWvseSuXcIuCLa5lNkAPy70rxetUaeHlTJGmiwc/g1MWdYWYrexWvPU';
+  const rememberMeId = 'Hig2yAT79cWvseSuXcIuCLa5lNkAPy70rxetUaeHlTJGmiwc/g1MWdYWYrexWvPU';
   const parentRememberMeId = 'f5RjVQMyoKOvO/hkv43Ik+t6d6mGfP2tdrNijH4k4qafTG0FSNUgQIvd2Z3Nx1j8';
 
   afterEach((done) => {
@@ -42,7 +42,8 @@ describe('yotiClient', () => {
             const outcome = activityDetails.getOutcome();
 
             expect(profile).to.not.equal(undefined);
-            expect(activityDetails.getUserId()).to.equal(userId);
+            expect(activityDetails.getUserId()).to.equal(rememberMeId);
+            expect(activityDetails.getRememberMeId()).to.equal(rememberMeId);
             expect(activityDetails.getParentRememberMeId()).to.equal(parentRememberMeId);
             expect(profile.phoneNumber).to.equal(phoneNumber);
             expect(`data:image/jpeg;base64,${profile.selfie.toBase64()}`).to.equal(selfie);
@@ -73,7 +74,8 @@ describe('yotiClient', () => {
 
             expect(profile).to.not.equal(undefined);
             expect(profile).to.deep.equal({});
-            expect(activityDetails.getUserId()).to.equal(userId);
+            expect(activityDetails.getUserId()).to.equal(rememberMeId);
+            expect(activityDetails.getRememberMeId()).to.equal(rememberMeId);
             expect(activityDetails.getParentRememberMeId()).to.equal(parentRememberMeId);
             expect(outcome).to.equal('SUCCESS');
 
@@ -101,7 +103,8 @@ describe('yotiClient', () => {
 
             expect(profile).to.not.equal(undefined);
             expect(profile).to.deep.equal({});
-            expect(activityDetails.getUserId()).to.equal(userId);
+            expect(activityDetails.getUserId()).to.equal(rememberMeId);
+            expect(activityDetails.getRememberMeId()).to.equal(rememberMeId);
             expect(activityDetails.getParentRememberMeId()).to.equal(parentRememberMeId);
             expect(outcome).to.equal('SUCCESS');
 
@@ -129,7 +132,8 @@ describe('yotiClient', () => {
 
             expect(profile).to.not.equal(undefined);
             expect(profile).to.deep.equal({});
-            expect(activityDetails.getUserId()).to.equal(userId);
+            expect(activityDetails.getUserId()).to.equal(rememberMeId);
+            expect(activityDetails.getRememberMeId()).to.equal(rememberMeId);
             expect(activityDetails.getParentRememberMeId()).to.equal(parentRememberMeId);
             expect(outcome).to.equal('SUCCESS');
 

--- a/tests/profile-service.spec.js
+++ b/tests/profile-service.spec.js
@@ -14,7 +14,7 @@ describe('profileService', () => {
   });
 
   describe('#getReceipt', () => {
-    const userId = 'Hig2yAT79cWvseSuXcIuCLa5lNkAPy70rxetUaeHlTJGmiwc/g1MWdYWYrexWvPU';
+    const rememberMeId = 'Hig2yAT79cWvseSuXcIuCLa5lNkAPy70rxetUaeHlTJGmiwc/g1MWdYWYrexWvPU';
     const parentRememberMeId = 'f5RjVQMyoKOvO/hkv43Ik+t6d6mGfP2tdrNijH4k4qafTG0FSNUgQIvd2Z3Nx1j8';
 
     context('when the profile has attributes', () => {
@@ -37,7 +37,8 @@ describe('profileService', () => {
             const outcome = receipt.getOutcome();
 
             expect(profile).to.not.equal(undefined);
-            expect(receipt.getUserId()).to.equal(userId);
+            expect(receipt.getUserId()).to.equal(rememberMeId);
+            expect(receipt.getRememberMeId()).to.equal(rememberMeId);
             expect(receipt.getParentRememberMeId()).to.equal(parentRememberMeId);
             expect(profile.phoneNumber).to.equal(phoneNumber);
             expect(`data:image/jpeg;base64,${profile.selfie.toBase64()}`).to.equal(selfie);
@@ -68,7 +69,8 @@ describe('profileService', () => {
 
             expect(profile).to.not.equal(undefined);
             expect(profile).to.deep.equal({});
-            expect(receipt.getUserId()).to.equal(userId);
+            expect(receipt.getUserId()).to.equal(rememberMeId);
+            expect(receipt.getRememberMeId()).to.equal(rememberMeId);
             expect(receipt.getParentRememberMeId()).to.equal(parentRememberMeId);
             expect(outcome).to.equal('SUCCESS');
 
@@ -96,7 +98,8 @@ describe('profileService', () => {
 
             expect(profile).to.not.equal(undefined);
             expect(profile).to.deep.equal({});
-            expect(receipt.getUserId()).to.equal(userId);
+            expect(receipt.getUserId()).to.equal(rememberMeId);
+            expect(receipt.getRememberMeId()).to.equal(rememberMeId);
             expect(receipt.getParentRememberMeId()).to.equal(parentRememberMeId);
             expect(outcome).to.equal('SUCCESS');
 
@@ -124,7 +127,8 @@ describe('profileService', () => {
 
             expect(profile).to.not.equal(undefined);
             expect(profile).to.deep.equal({});
-            expect(receipt.getUserId()).to.equal(userId);
+            expect(receipt.getUserId()).to.equal(rememberMeId);
+            expect(receipt.getRememberMeId()).to.equal(rememberMeId);
             expect(receipt.getParentRememberMeId()).to.equal(parentRememberMeId);
             expect(outcome).to.equal('SUCCESS');
 


### PR DESCRIPTION
- Introduced new `getRememberMeId()` method
- Documented activity details methods and `@deprecated` `getUserId()`
- Update example project to use `getRememberMeId()`