### PR TITLE
SDK-909: Include prefix in SDK version

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,12 +16,12 @@
     "test": "node_modules/.bin/istanbul cover node_modules/.bin/mocha tests/*.spec.js"
   },
   "dependencies": {
-    "base64-url": "^2.2.0",
+    "base64-url": "^2.2.1",
     "node-forge": "^0.7.6",
+    "node-rsa": "^1.0.3",
     "protobufjs": "^5.0.3",
     "safe-buffer": "^5.1.2",
     "superagent": "^3.8.3",
-    "node-rsa": "^1.0.3",
     "uuid": "^3.3.2"
   },
   "devDependencies": {

--- a/src/request/index.js
+++ b/src/request/index.js
@@ -55,7 +55,7 @@ module.exports.makeRequest = (httpMethod, endpoint, pem, appId, Payload) => {
     request.set('X-Yoti-Auth-Key', authKey)
       .set('X-Yoti-Auth-Digest', messageSignature)
       .set('X-Yoti-SDK', sdkIdentifier)
-      .set('X-Yoti-SDK-Version', yotiPackage.version)
+      .set('X-Yoti-SDK-Version', `${sdkIdentifier}-${yotiPackage.version}`)
       .set('Content-Type', 'application/json')
       .set('Accept', 'application/json')
       .then((response) => {

--- a/tests/request.spec.js
+++ b/tests/request.spec.js
@@ -43,7 +43,7 @@ describe('YotiResponse', () => {
     context('when making an API request', () => {
       const expectedHeaders = {
         'X-Yoti-SDK': 'Node',
-        'X-Yoti-SDK-Version': yotiPackage.version,
+        'X-Yoti-SDK-Version': `Node-${yotiPackage.version}`,
         'X-Yoti-Auth-Key': new RegExp('^[a-zA-Z0-9/+]{392}$'),
         'X-Yoti-Auth-Digest': new RegExp('^[a-zA-Z0-9/+=]{344}$'),
         'Content-Type': 'application/json',


### PR DESCRIPTION
- Prefixing version with SDK identifier
- Also upped minimum `base64-url` requirement to include [npm audit fixes](https://github.com/joaquimserafim/base64-url/releases/tag/v2.2.1)