### PR TITLE
SDK-897: Return unknown and undefined content types as string

### DIFF
--- a/src/yoti_common/attribute.converter.js
+++ b/src/yoti_common/attribute.converter.js
@@ -8,7 +8,6 @@ const ImagePng = require('../data_type/image.png');
 const protoRoot = require('../proto-root');
 const MultiValue = require('../data_type/multi.value');
 
-const CONTENT_TYPE_UNDEFINED = 0;
 const CONTENT_TYPE_STRING = 1;
 const CONTENT_TYPE_JPEG = 2;
 const CONTENT_TYPE_DATE = 3;
@@ -45,9 +44,6 @@ module.exports.AttributeConverter = class AttributeConverter {
     }
 
     switch (contentType) {
-      // UNDEFINED should not be seen, and is used as an error placeholder
-      case CONTENT_TYPE_UNDEFINED:
-        throw new Error('Wrong content type');
       case CONTENT_TYPE_STRING: // STRING means the value is UTF-8 encoded text.
       case CONTENT_TYPE_DATE: // Date as string in RFC3339 format (YYYY-MM-DD).
         return value.toUTF8();
@@ -65,7 +61,8 @@ module.exports.AttributeConverter = class AttributeConverter {
       case CONTENT_TYPE_INT:
         return parseInt(value.toUTF8(), 10);
       default:
-        return value;
+        console.log(`Unknown Content Type '${contentType}', parsing as a String`);
+        return value.toUTF8();
     }
   }
 

--- a/tests/yoti-common.attribute.converter.spec.js
+++ b/tests/yoti-common.attribute.converter.spec.js
@@ -11,6 +11,7 @@ const Buffer = require('safe-buffer').Buffer;
 const sampleMultiValueAttribute = fs.readFileSync('./tests/sample-data/fixtures/attributes/multi-value.txt', 'utf8');
 const protoInst = protoRoot.initializeProtoBufObjects();
 
+const CONTENT_TYPE_UNDEFINED = 0;
 const CONTENT_TYPE_STRING = 1;
 const CONTENT_TYPE_JPEG = 2;
 const CONTENT_TYPE_DATE = 3;
@@ -131,7 +132,7 @@ const assertIsExpectedImage = (image, mimeType, base64Last10) => {
   expect(base64String.substr(base64String.length - 10)).to.equal(base64Last10);
 };
 
-describe('attributeConverter', () => {
+describe('AttributeConverter', () => {
   describe('#convertValueBasedOnContentType', () => {
     it('should return multi value object', () => {
       const multiValue = convertSampleMultiValue();
@@ -140,7 +141,7 @@ describe('attributeConverter', () => {
       assertIsExpectedImage(multiValue.getItems()[0], 'image/jpeg', 'vWgD//2Q==');
       assertIsExpectedImage(multiValue.getItems()[1], 'image/jpeg', '38TVEH/9k=');
     });
-    it('should include all content types', () => {
+    it('should include all content types for multi value', () => {
       const multiValue = AttributeConverter.convertValueBasedOnContentType(
         createTestMultiValue({
           values: [
@@ -171,6 +172,30 @@ describe('attributeConverter', () => {
         CONTENT_TYPE_STRING
       );
       expect(value).to.equal('');
+    });
+    it('should return UTF-8 encoded strings', () => {
+      const protoAttr = createTestAttribute(CONTENT_TYPE_STRING, 'test string');
+      const value = AttributeConverter.convertValueBasedOnContentType(
+        protoAttr.value,
+        CONTENT_TYPE_STRING
+      );
+      expect(value).to.equal('test string');
+    });
+    it('should return UTF-8 encoded strings for undefined content type', () => {
+      const protoAttr = createTestAttribute(CONTENT_TYPE_UNDEFINED, 'test undefined string');
+      const value = AttributeConverter.convertValueBasedOnContentType(
+        protoAttr.value,
+        CONTENT_TYPE_UNDEFINED
+      );
+      expect(value).to.equal('test undefined string');
+    });
+    it('should return UTF-8 encoded strings for unknown content types', () => {
+      const protoAttr = createTestAttribute(100, 'test unknown string');
+      const value = AttributeConverter.convertValueBasedOnContentType(
+        protoAttr.value,
+        100
+      );
+      expect(value).to.equal('test unknown string');
     });
     it('should not allow empty non-string values', () => {
       nonStringContentTypes.forEach((contentType) => {


### PR DESCRIPTION
- Returns UTF-8 encoded string for unknown and undefined content types

>_Note: In order to test log messages we need to introduce a new dependency to spy on the console log calls, such as Chai Spy, Jasmine, Sinon, Jest. I'll open a ticket to look at these, [Jest](https://www.npmjs.com/package/jest) in particular, which is very popular, allows for spying on objects and seems straight forward to switch over to_