### PR TITLE
SDK-990: Add timestamp getter to activity details

### DIFF
--- a/src/profile_service/activity.details.js
+++ b/src/profile_service/activity.details.js
@@ -145,6 +145,15 @@ class ActivityDetails {
   getReceiptId() {
     return this.receipt.receipt_id;
   }
+
+  /**
+   * Time and date of the sharing activity
+   *
+   * @returns {Date}
+   */
+  getTimestamp() {
+    return new Date(this.receipt.timestamp);
+  }
 }
 
 module.exports = {

--- a/tests/profile_service/activity.details.spec.js
+++ b/tests/profile_service/activity.details.spec.js
@@ -141,4 +141,14 @@ describe('ActivityDetails', () => {
       expect(activityDetails.getBase64SelfieUri()).to.equal('test_base64_encoded_uri');
     });
   });
+  describe('#getTimestamp', () => {
+    const activityDetails = new ActivityDetails({
+      receipt: {
+        timestamp: '2003-11-04T12:51:07Z',
+      },
+    });
+    it('should return timestamp value', () => {
+      expect(activityDetails.getTimestamp().toUTCString()).to.equal('Tue, 04 Nov 2003 12:51:07 GMT');
+    });
+  });
 });

--- a/tests/profile_service/index.spec.js
+++ b/tests/profile_service/index.spec.js
@@ -42,6 +42,8 @@ describe('profileService', () => {
             expect(receipt.getUserId()).to.equal(rememberMeId);
             expect(receipt.getRememberMeId()).to.equal(rememberMeId);
             expect(receipt.getParentRememberMeId()).to.equal(parentRememberMeId);
+            expect(receipt.getTimestamp()).to.be.a('Date');
+            expect(receipt.getTimestamp().toUTCString()).to.equal('Tue, 19 Jul 2016 08:55:38 GMT');
             expect(profile.phoneNumber).to.equal(phoneNumber);
             expect(`data:image/jpeg;base64,${profile.selfie.toBase64()}`).to.equal(selfie);
             expect(receipt.getBase64SelfieUri()).to.equal(selfie);


### PR DESCRIPTION
### Added
- `ActivityDetails.getTimestamp()`