### PR TITLE
 SDK-1000: Return date object with microsecond accuracy

### DIFF
--- a/src/data_type/date.js
+++ b/src/data_type/date.js
@@ -1,11 +1,30 @@
 /**
- * Formats date part with zero padding.
+ * Formats date part padded with leading zeros.
  *
  * @param {*} part
  * @param {number} length
+ *
+ * @returns {string}
+ *   Date part with leading zeros, e.g. `04`
  */
 function formatDatePart(part, length) {
-  return part.toString().padStart(length, '0');
+  const padding = length - part.toString().length;
+  const zeros = '0'.repeat(padding > 0 ? padding : 0);
+  return `${zeros}${part}`;
+}
+
+/**
+ * Adds microseconds to seconds and format with leading zeros.
+ *
+ * @param {number} seconds
+ * @param {number} microseconds
+ *
+ * @returns {string}
+ *   Seconds with microseconds in format `{SS}.{mmmmmm}`
+ */
+function formatSecondsWithMicroseconds(seconds, microseconds) {
+  const secondsWithMicroseconds = (seconds + (microseconds / 1000000));
+  return formatDatePart(secondsWithMicroseconds.toFixed(6), 9);
 }
 
 /**
@@ -40,10 +59,11 @@ class YotiDate extends Date {
   getMicrosecondTime() {
     const hours = formatDatePart(this.getUTCHours(), 2);
     const minutes = formatDatePart(this.getUTCMinutes());
-    const secondsWithMicroseconds = (this.getUTCSeconds() + (this.getMicroseconds() / 1000000))
-      .toFixed(6)
-      .padStart(9, '0');
-    return `${hours}:${minutes}:${secondsWithMicroseconds}`;
+    const secondsMicroseconds = formatSecondsWithMicroseconds(
+      this.getUTCSeconds(),
+      this.getMicroseconds()
+    );
+    return `${hours}:${minutes}:${secondsMicroseconds}`;
   }
 
   /**

--- a/src/data_type/date.js
+++ b/src/data_type/date.js
@@ -5,7 +5,7 @@
  */
 class YotiDate extends Date {
   /**
-   * @param {Number} timestamp
+   * @param {number} timestamp
    */
   constructor(timestamp) {
     super(Math.round(timestamp / 1000));
@@ -13,9 +13,9 @@ class YotiDate extends Date {
   }
 
   /**
-   * Returns microseconds.
+   * Returns a number, between 0 and 999999, representing the microseconds.
    *
-   * @returns {Number}
+   * @returns {number}
    */
   getMicroseconds() {
     return this.microseconds;

--- a/src/data_type/date.js
+++ b/src/data_type/date.js
@@ -1,4 +1,14 @@
 /**
+ * Formats date part with zero padding.
+ *
+ * @param {*} part
+ * @param {number} length
+ */
+function formatDatePart(part, length) {
+  return part.toString().padStart(length, '0');
+}
+
+/**
  * Date object with microsecond accuracy.
  *
  * @class YotiDate
@@ -19,6 +29,34 @@ class YotiDate extends Date {
    */
   getMicroseconds() {
     return this.microseconds;
+  }
+
+  /**
+   * Time with microseconds.
+   *
+   * @returns {string}
+   *   Time in format `{HH}:{MM}:{SS}.{mmmmmm}`
+   */
+  getMicrosecondTime() {
+    const hours = formatDatePart(this.getUTCHours(), 2);
+    const minutes = formatDatePart(this.getUTCMinutes());
+    const secondsWithMicroseconds = (this.getUTCSeconds() + (this.getMicroseconds() / 1000000))
+      .toFixed(6)
+      .padStart(9, '0');
+    return `${hours}:${minutes}:${secondsWithMicroseconds}`;
+  }
+
+  /**
+   * Returns ISO 8601 UTC timestamp with microseconds.
+   *
+   * @returns {string}
+   *   Timestamp in format `{YYYY}-{DD}-{MM}T{HH}:{MM}:{SS}.{mmmmmm}Z`
+   */
+  getMicrosecondTimestamp() {
+    const year = formatDatePart(this.getUTCFullYear(), 4);
+    const month = formatDatePart(this.getUTCMonth(), 2);
+    const day = formatDatePart(this.getUTCDate(), 2);
+    return `${year}-${month}-${day}T${this.getMicrosecondTime()}Z`;
   }
 }
 

--- a/src/data_type/date.js
+++ b/src/data_type/date.js
@@ -74,7 +74,7 @@ class YotiDate extends Date {
    */
   getMicrosecondTimestamp() {
     const year = formatDatePart(this.getUTCFullYear(), 4);
-    const month = formatDatePart(this.getUTCMonth(), 2);
+    const month = formatDatePart(this.getUTCMonth() + 1, 2);
     const day = formatDatePart(this.getUTCDate(), 2);
     return `${year}-${month}-${day}T${this.getMicrosecondTime()}Z`;
   }

--- a/src/data_type/date.js
+++ b/src/data_type/date.js
@@ -1,0 +1,27 @@
+/**
+ * Date object with microsecond accuracy.
+ *
+ * @class YotiDate
+ */
+class YotiDate extends Date {
+  /**
+   * @param {Number} timestamp
+   */
+  constructor(timestamp) {
+    super(Math.round(timestamp / 1000));
+    this.microseconds = timestamp % 1000000;
+  }
+
+  /**
+   * Returns microseconds.
+   *
+   * @returns {Number}
+   */
+  getMicroseconds() {
+    return this.microseconds;
+  }
+}
+
+module.exports = {
+  YotiDate,
+};

--- a/src/data_type/signed.timestamp.js
+++ b/src/data_type/signed.timestamp.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { YotiDate } = require('../data_type/date');
+
 /**
  * SignedTimestamp is a timestamp associated with a message that has a
  * cryptographic signature proving that it was issued by the correct authority.
@@ -9,10 +11,14 @@
 class YotiSignedTimeStamp {
   /**
    * @param {number} version
-   * @param {Date} timestamp
+   * @param {YotiDate} timestamp
    */
   constructor(version, timestamp) {
     this.version = version;
+
+    if (!(timestamp instanceof YotiDate)) {
+      throw new TypeError('timestamp must be instance of YotiDate');
+    }
     this.timestamp = timestamp;
   }
 
@@ -26,7 +32,7 @@ class YotiSignedTimeStamp {
   /**
    * The actual timestamp with microsecond-level accuracy.
    *
-   * @returns {Date}
+   * @returns {YotiDate}
    */
   getTimestamp() { return this.timestamp; }
 }

--- a/src/yoti_common/anchor.processor.js
+++ b/src/yoti_common/anchor.processor.js
@@ -4,6 +4,7 @@ const forge = require('node-forge');
 const protoRoot = require('../proto-root');
 const { YotiAnchor } = require('../data_type/anchor');
 const { YotiSignedTimeStamp } = require('../data_type/signed.timestamp');
+const { YotiDate } = require('../data_type/date');
 
 /**
  * Mapping of anchor types.
@@ -191,13 +192,8 @@ class AnchorProcessor {
     if (signedTimestampByteBuffer) {
       const signedTimestampBuffer = signedTimestampByteBuffer.toBuffer();
       const signedTimestamp = protoInst.decodeSignedTimeStamp(signedTimestampBuffer);
-      const strTs = signedTimestamp.timestamp.toString();
-      const tsMicro = Number(strTs);
-      const tsMilliSeconds = Math.round(tsMicro / 1000);
-      const dateTime = new Date(tsMilliSeconds);
-
       version = signedTimestamp.getVersion();
-      timestamp = dateTime;
+      timestamp = new YotiDate(Number(signedTimestamp.timestamp.toString()));
     }
     return new YotiSignedTimeStamp(version, timestamp);
   }

--- a/tests/data_type/anchor.spec.js
+++ b/tests/data_type/anchor.spec.js
@@ -1,10 +1,11 @@
 const expect = require('chai').expect;
 
 const { YotiAnchor } = require('../../src/data_type/anchor');
+const { YotiDate } = require('../../src/data_type/date');
 const { YotiSignedTimeStamp } = require('../../src/data_type/signed.timestamp');
 
 describe('YotiAnchor', () => {
-  const signedTimestamp = new YotiSignedTimeStamp(1, new Date('2003-11-04T12:51:07Z'));
+  const signedTimestamp = new YotiSignedTimeStamp(1, new YotiDate(1067950267923530));
   const originServerCerts = [{
     version: 2,
     signatureOid: '1.2.840.113549.1.1.11',

--- a/tests/data_type/date.spec.js
+++ b/tests/data_type/date.spec.js
@@ -1,0 +1,18 @@
+const { expect } = require('chai');
+const { YotiDate } = require('../../src/data_type/date');
+
+describe('YotiDate', () => {
+  const date = new YotiDate(1067950267923530);
+
+  context('#toUTCString()', () => {
+    it('should return Tue, 04 Nov 2003 12:51:07 GMT', () => {
+      expect(date.toUTCString()).to.equal('Tue, 04 Nov 2003 12:51:07 GMT');
+    });
+  });
+
+  context('#getMicroseconds()', () => {
+    it('should return 923530', () => {
+      expect(date.getMicroseconds()).to.equal(923530);
+    });
+  });
+});

--- a/tests/data_type/date.spec.js
+++ b/tests/data_type/date.spec.js
@@ -14,7 +14,7 @@ describe('YotiDate', () => {
     it('should return 923530', () => {
       expect(date.getMicroseconds()).to.equal(923530);
       expect(date.getMicrosecondTime()).to.equal('12:51:07.923530');
-      expect(date.getMicrosecondTimestamp()).to.equal('2003-10-04T12:51:07.923530Z');
+      expect(date.getMicrosecondTimestamp()).to.equal('2003-11-04T12:51:07.923530Z');
     });
   });
 });

--- a/tests/data_type/date.spec.js
+++ b/tests/data_type/date.spec.js
@@ -13,6 +13,8 @@ describe('YotiDate', () => {
   context('#getMicroseconds()', () => {
     it('should return 923530', () => {
       expect(date.getMicroseconds()).to.equal(923530);
+      expect(date.getMicrosecondTime()).to.equal('12:51:07.923530');
+      expect(date.getMicrosecondTimestamp()).to.equal('2003-10-04T12:51:07.923530Z');
     });
   });
 });

--- a/tests/data_type/signed.timestamp.spec.js
+++ b/tests/data_type/signed.timestamp.spec.js
@@ -23,7 +23,7 @@ describe('YotiSignedTimeStamp', () => {
       expect(timestamp).to.be.instanceOf(YotiDate);
       expect(timestamp).to.be.instanceOf(Date);
       expect(timestamp.toUTCString()).to.equal('Tue, 04 Nov 2003 12:51:07 GMT');
-      expect(timestamp.getMicrosecondTimestamp()).to.equal('2003-10-04T12:51:07.923530Z');
+      expect(timestamp.getMicrosecondTimestamp()).to.equal('2003-11-04T12:51:07.923530Z');
     });
   });
 });

--- a/tests/data_type/signed.timestamp.spec.js
+++ b/tests/data_type/signed.timestamp.spec.js
@@ -23,7 +23,7 @@ describe('YotiSignedTimeStamp', () => {
       expect(timestamp).to.be.instanceOf(YotiDate);
       expect(timestamp).to.be.instanceOf(Date);
       expect(timestamp.toUTCString()).to.equal('Tue, 04 Nov 2003 12:51:07 GMT');
-      expect(timestamp.getMicroseconds()).to.equal(923530);
+      expect(timestamp.getMicrosecondTimestamp()).to.equal('2003-10-04T12:51:07.923530Z');
     });
   });
 });

--- a/tests/data_type/signed.timestamp.spec.js
+++ b/tests/data_type/signed.timestamp.spec.js
@@ -1,19 +1,29 @@
-const expect = require('chai').expect;
-
+const { expect } = require('chai');
+const { YotiDate } = require('../../src/data_type/date');
 const { YotiSignedTimeStamp } = require('../../src/data_type/signed.timestamp');
 
 describe('YotiSignedTimeStamp', () => {
-  const signedTimestamp = new YotiSignedTimeStamp(1, new Date('2003-11-04T12:51:07Z'));
+  const signedTimestamp = new YotiSignedTimeStamp(1, new YotiDate(1067950267923530));
 
+  context('#constructor()', () => {
+    it('should only accept YotiDate as timestamp', () => {
+      expect(() => new YotiSignedTimeStamp(0, new Date()))
+        .to.throw(TypeError, 'timestamp must be instance of YotiDate');
+    });
+  });
   context('#getVersion()', () => {
-    it('it should return 1', () => {
+    it('should return 1', () => {
       expect(signedTimestamp.getVersion()).to.equal(1);
     });
   });
   context('#getTimestamp()', () => {
-    it('it should return Date object', () => {
-      expect(signedTimestamp.getTimestamp()).to.be.a('Date');
-      expect(signedTimestamp.getTimestamp().toUTCString()).to.equal('Tue, 04 Nov 2003 12:51:07 GMT');
+    it('should return Date object', () => {
+      const timestamp = signedTimestamp.getTimestamp();
+      expect(timestamp).to.be.a('Date');
+      expect(timestamp).to.be.instanceOf(YotiDate);
+      expect(timestamp).to.be.instanceOf(Date);
+      expect(timestamp.toUTCString()).to.equal('Tue, 04 Nov 2003 12:51:07 GMT');
+      expect(timestamp.getMicroseconds()).to.equal(923530);
     });
   });
 });

--- a/tests/yoti_common/anchor.processor.spec.js
+++ b/tests/yoti_common/anchor.processor.spec.js
@@ -46,7 +46,7 @@ describe('anchorProcessor', () => {
         expect(timestamp).to.be.a('Date');
         expect(timestamp).to.be.instanceOf(Date);
         expect(timestamp.toUTCString()).to.equal(expectedTimestamp);
-        expect(timestamp.getMicrosecondTimestamp()).to.equal('2018-03-12T13:14:32.835537Z');
+        expect(timestamp.getMicrosecondTimestamp()).to.equal('2018-04-12T13:14:32.835537Z');
       });
 
       it('should return 1.2.840.113549.1.1.11 as signature Oid', () => {
@@ -80,7 +80,7 @@ describe('anchorProcessor', () => {
         expect(timestamp).to.be.a('Date');
         expect(timestamp).to.be.instanceOf(Date);
         expect(timestamp.toUTCString()).to.equal(expectedTimestamp);
-        expect(timestamp.getMicrosecondTimestamp()).to.equal('2018-03-11T12:13:04.095238Z');
+        expect(timestamp.getMicrosecondTimestamp()).to.equal('2018-04-11T12:13:04.095238Z');
       });
 
       it('should return 1.2.840.113549.1.1.11 as signature Oid', () => {

--- a/tests/yoti_common/anchor.processor.spec.js
+++ b/tests/yoti_common/anchor.processor.spec.js
@@ -42,8 +42,11 @@ describe('anchorProcessor', () => {
 
       it('should return Thu, 12 Apr 2018 13:14:32 GMT as timestamp', () => {
         const expectedTimestamp = 'Thu, 12 Apr 2018 13:14:32 GMT';
-        const anchorDate = firstSource.getSignedTimeStamp().getTimestamp().toUTCString();
-        expect(expectedTimestamp).to.equal(anchorDate);
+        const timestamp = firstSource.getSignedTimeStamp().getTimestamp();
+        expect(timestamp).to.be.a('Date');
+        expect(timestamp).to.be.instanceOf(Date);
+        expect(timestamp.toUTCString()).to.equal(expectedTimestamp);
+        expect(timestamp.getMicroseconds()).to.equal(835537);
       });
 
       it('should return 1.2.840.113549.1.1.11 as signature Oid', () => {
@@ -73,8 +76,11 @@ describe('anchorProcessor', () => {
 
       it('should return Wed, 11 Apr 2018 12:13:04 GMT as timestamp', () => {
         const expectedTimestamp = 'Wed, 11 Apr 2018 12:13:04 GMT';
-        const anchorDate = firstVerifier.getSignedTimeStamp().getTimestamp().toUTCString();
-        expect(expectedTimestamp).to.equal(anchorDate);
+        const timestamp = firstVerifier.getSignedTimeStamp().getTimestamp();
+        expect(timestamp).to.be.a('Date');
+        expect(timestamp).to.be.instanceOf(Date);
+        expect(timestamp.toUTCString()).to.equal(expectedTimestamp);
+        expect(timestamp.getMicroseconds()).to.equal(95238);
       });
 
       it('should return 1.2.840.113549.1.1.11 as signature Oid', () => {

--- a/tests/yoti_common/anchor.processor.spec.js
+++ b/tests/yoti_common/anchor.processor.spec.js
@@ -46,7 +46,7 @@ describe('anchorProcessor', () => {
         expect(timestamp).to.be.a('Date');
         expect(timestamp).to.be.instanceOf(Date);
         expect(timestamp.toUTCString()).to.equal(expectedTimestamp);
-        expect(timestamp.getMicroseconds()).to.equal(835537);
+        expect(timestamp.getMicrosecondTimestamp()).to.equal('2018-03-12T13:14:32.835537Z');
       });
 
       it('should return 1.2.840.113549.1.1.11 as signature Oid', () => {
@@ -80,7 +80,7 @@ describe('anchorProcessor', () => {
         expect(timestamp).to.be.a('Date');
         expect(timestamp).to.be.instanceOf(Date);
         expect(timestamp.toUTCString()).to.equal(expectedTimestamp);
-        expect(timestamp.getMicroseconds()).to.equal(95238);
+        expect(timestamp.getMicrosecondTimestamp()).to.equal('2018-03-11T12:13:04.095238Z');
       });
 
       it('should return 1.2.840.113549.1.1.11 as signature Oid', () => {


### PR DESCRIPTION
### Added
- `YotiDate` extending `Date`, providing methods:
  - `getMicroseconds()` - Number between 0 and 999999, representing the microseconds.
  - `getMicrosecondTimestamp()` - Returns ISO 8601 UTC timestamp with microseconds.
  - `getMicrosecondTime()` - Time with microseconds.

### Changed
- `YotiSignedTimeStamp.getTimestamp()` now returns `YotiDate`:
  - `timestamp.getTimestamp() instanceof Date` **>** `TRUE` _(Unchanged)_
  - `timestamp.getTimestamp() instanceof YotiDate` **>** `TRUE` _(New)_
  - `typeof timestamp.getTimestamp()` **>** `object` _(Unchanged)_
  - `timestamp.getTimestamp().constructor.name` **>** `YotiDate` _(was `Date`)_
      _Should this be considered a breaking change?_