### PR TITLE
SDK-998: Return all attributes as Object

### DIFF
--- a/src/profile_service/base.profile.js
+++ b/src/profile_service/base.profile.js
@@ -30,13 +30,13 @@ class BaseProfile {
   /**
    * Return all attributes for the profile.
    *
-   * @returns {Attribute[]}
+   * @returns {Object.<string, Attribute>}
    */
   getAttributes() {
-    return Object.keys(this.profileData).reduce((attributes, attrName) => {
-      attributes.push(this.getAttribute(attrName));
-      return attributes;
-    }, []);
+    return Object.keys(this.profileData).reduce((acc, current) => {
+      acc[current] = this.getAttribute(current);
+      return acc;
+    }, {});
   }
 
   /**

--- a/tests/profile_service/application.profile.spec.js
+++ b/tests/profile_service/application.profile.spec.js
@@ -40,12 +40,12 @@ describe('ApplicationProfile', () => {
   describe('#getAttributes', () => {
     it('should return all attributes', () => {
       const attributes = profileObj.getAttributes();
-      expect(attributes.length).to.be.equal(4);
-      attributes.forEach((attribute) => {
-        expect(attribute).to.instanceOf(Attribute);
+      expect(Object.keys(attributes).length).to.be.equal(4);
+      Object.keys(attributes).forEach((attributeName) => {
+        expect(attributes[attributeName]).to.instanceOf(Attribute);
       });
-      expect(attributes[0].getName()).to.equal('application_name');
-      expect(attributes[0].getValue()).to.equal('TEST APPLICATION');
+      expect(attributes.application_name.getName()).to.equal('application_name');
+      expect(attributes.application_name.getValue()).to.equal('TEST APPLICATION');
     });
   });
 });

--- a/tests/profile_service/profile.spec.js
+++ b/tests/profile_service/profile.spec.js
@@ -114,12 +114,12 @@ describe('Profile', () => {
   describe('#getAttributes', () => {
     it('should return all attributes', () => {
       const attributes = profileObj.getAttributes();
-      expect(attributes.length).to.be.equal(12);
-      attributes.forEach((attribute) => {
-        expect(attribute).to.instanceOf(Attribute);
+      expect(Object.keys(attributes).length).to.be.equal(12);
+      Object.keys(attributes).forEach((attributeName) => {
+        expect(attributes[attributeName]).to.instanceOf(Attribute);
       });
-      expect(attributes[0].getName()).to.equal('gender');
-      expect(attributes[0].getValue()).to.equal('TEST MALE');
+      expect(attributes.gender.getName()).to.equal('gender');
+      expect(attributes.gender.getValue()).to.equal('TEST MALE');
     });
   });
 });


### PR DESCRIPTION
>Correction to #69 

- Returns all attributes as `{Object.<string, Attribute>}`