### PR TITLE
SDK-660: Additional test coverage for unknown anchors

### DIFF
--- a/tests/client/index.spec.js
+++ b/tests/client/index.spec.js
@@ -58,6 +58,10 @@ describe('yotiClient', () => {
             expect(extendedProfile.getPhoneNumber().getValue()).to.equal(phoneNumber);
             expect(extendedProfile.getSelfie().getValue().getBase64Content()).to.equal(selfie);
 
+            const phoneNumberAnchor = extendedProfile.getPhoneNumber().getAnchors()[0];
+            expect(phoneNumberAnchor.getType()).to.equal('UNKNOWN');
+            expect(phoneNumberAnchor.getValue()).to.equal('');
+
             expect(applicationProfile.getName().getValue()).to.equal('Node SDK Test');
             expect(applicationProfile.getUrl().getValue()).to.equal('https://example.com');
             expect(applicationProfile.getLogo().getValue().getBase64Content()).to.equal('data:image/jpeg;base64,');

--- a/tests/data_type/attribute.spec.js
+++ b/tests/data_type/attribute.spec.js
@@ -18,11 +18,11 @@ describe('Attribute', () => {
   const unknownAnchor = fs.readFileSync('./tests/sample-data/yoti-common/unknown-anchor.txt', 'utf8');
   const sources = parseAnchorData(dlSourceAnchor).sources;
   const verifiers = parseAnchorData(verifierAnchor).verifiers;
-  const anchors = []
-    .concat(sources)
-    .concat(verifiers)
-    .concat(parseAnchorData(unknownAnchor).unknown);
-
+  const anchors = {
+    sources,
+    verifiers,
+    unknown: parseAnchorData(unknownAnchor).unknown,
+  };
   const attributeObj = new Attribute({
     value: documentDetails,
     name: 'document_details',


### PR DESCRIPTION
>Correction to #67 

- Correction to `Attribute` test - constructor should be passed a key/value Object, but was being passed an array - `concat()` can append both single values and arrays, so the resulting anchor array is the same.
- Additional test coverage for unknown anchors in the existing sample test data.