### PR TITLE
SDK-578: Add support for multiple age verifications

### DIFF
--- a/examples/profile/views/pages/profile.ejs
+++ b/examples/profile/views/pages/profile.ejs
@@ -4,7 +4,6 @@ const givenNames = profile.getGivenNames();
 const familyName = profile.getFamilyName();
 const phoneNumber = profile.getPhoneNumber();
 const dateOfBirth = profile.getDateOfBirth();
-const ageCondition = profile.getAgeVerified();
 const postalAddress = profile.getPostalAddress();
 const emailAddress = profile.getEmailAddress();
 const nationality = profile.getNationality();
@@ -40,12 +39,6 @@ const attributes = [
     icon: "yoti-icon-calendar"
   },
   {
-    name: "Age verified",
-    preValue: "Age Verification/",
-    prop: ageCondition,
-    icon: "yoti-icon-verified"
-  },
-  {
     name: "Address",
     prop: postalAddress,
     icon: "yoti-icon-address"
@@ -66,6 +59,18 @@ const attributes = [
     icon: "yoti-icon-profile"
   }
 ]
+
+const ageVerifications = profile.getAgeVerifications();
+if (ageVerifications) {
+  ageVerifications.forEach(ageVerification => {
+    attributes.push({
+      name: 'Age Verification',
+      prop: ageVerification.getAttribute(),
+      age_verification: ageVerification,
+      icon: "yoti-icon-verified"
+    });
+  });
+}
 %>
 <!DOCTYPE html>
 <html class="yoti-html">
@@ -148,8 +153,25 @@ const attributes = [
                     <% }) %>
                   </table>
                   <% break;
-                  default: %>
-                    <%= item.prop.getValue() %>
+                  default:
+                    if (item.age_verification) { %>
+                      <table>
+                        <tr>
+                          <td>Check Type</td>
+                          <td><%= item.age_verification.getCheckType() %></td>
+                        </tr>
+                        <tr>
+                          <td>Age</td>
+                          <td><%= item.age_verification.getAge() %></td>
+                        </tr>
+                        <tr>
+                          <td>Result</td>
+                          <td><%= item.age_verification.getResult() %></td>
+                        </tr>
+                      </table>
+                    <% } else { %>
+                      <%= item.prop.getValue() %>
+                    <% } %>
               <% } %>
             </div>
           </div>

--- a/examples/profile/views/pages/profile.ejs
+++ b/examples/profile/views/pages/profile.ejs
@@ -136,7 +136,6 @@ if (ageVerifications) {
 
           <div class="yoti-attribute-value">
             <div class="yoti-attribute-value-text">
-              <%= item.preValue %>
               <% switch (item.prop.getName()) {
                   case 'document_images': %>
                     <% item.prop.getValue().forEach((image) => { %>

--- a/src/data_type/age.verification.js
+++ b/src/data_type/age.verification.js
@@ -1,0 +1,66 @@
+'use strict';
+
+const Validation = require('../yoti_common/validation');
+
+/**
+ * Wraps an 'Age Verify/Condition' attribute to provide behaviour specific
+ * to verifying someone's age.
+ *
+ * @class AgeVerification
+ */
+class AgeVerification {
+  constructor(attribute) {
+    Validation.notNull(attribute, 'attribute');
+    Validation.matchesPattern(attribute.getName(), /^[^:]+:(?!.*:)[0-9]+$/, 'attribute.name');
+    this.attribute = attribute;
+
+    const split = attribute.getName().split(':');
+    this.checkType = split[0];
+
+    this.age = parseInt(split[1], 10);
+    this.result = attribute.getValue() === 'true';
+  }
+
+  /**
+   * The type of age check performed, as specified on Yoti Hub. Currently this might
+   * be 'age_over' or 'age_under'.
+   *
+   * @returns {string}
+   */
+  getCheckType() {
+    return this.checkType;
+  }
+
+  /**
+   * The age that was that checked, as specified on Yoti Hub.
+   *
+   * @returns {integer}
+   */
+  getAge() {
+    return this.age;
+  }
+
+  /**
+   * Whether or not the profile passed the age check.
+   *
+   * @returns {boolean}
+   */
+  getResult() {
+    return this.result;
+  }
+
+  /**
+   * The wrapped profile attribute.
+   *
+   * Use this if you need access to the underlying List of Anchors.
+   *
+   * @returns {Attribute}
+   */
+  getAttribute() {
+    return this.attribute;
+  }
+}
+
+module.exports = {
+  AgeVerification,
+};

--- a/src/data_type/age.verification.js
+++ b/src/data_type/age.verification.js
@@ -22,8 +22,9 @@ class AgeVerification {
   }
 
   /**
-   * The type of age check performed, as specified on Yoti Hub. Currently this might
-   * be 'age_over' or 'age_under'.
+   * The type of age check performed, as specified on Yoti Hub.
+   *
+   * Among the possible values are 'age_over' and 'age_under'.
    *
    * @returns {string}
    */

--- a/src/profile_service/base.profile.js
+++ b/src/profile_service/base.profile.js
@@ -59,8 +59,9 @@ class BaseProfile {
    */
   findAttributesStartingWith(name) {
     Validation.isString(name, 'name');
-    return Object
-      .values(this.getAttributes())
+
+    return Object.keys(this.getAttributes())
+      .map(key => this.getAttributes()[key])
       .filter(attribute => attribute.getName().startsWith(name));
   }
 

--- a/src/profile_service/base.profile.js
+++ b/src/profile_service/base.profile.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { Attribute } = require('../data_type/attribute');
+const Validation = require('../yoti_common/validation');
 
 class BaseProfile {
   /**
@@ -47,6 +48,20 @@ class BaseProfile {
       return Object.prototype.hasOwnProperty.call(this.profileData, prop);
     }
     return false;
+  }
+
+  /**
+   * Find attributes starting with provided name.
+   *
+   * @param {string} name
+   *
+   * @returns {Array}
+   */
+  findAttributesStartingWith(name) {
+    Validation.isString(name, 'name');
+    return Object
+      .values(this.getAttributes())
+      .filter(attribute => attribute.getName().startsWith(name));
   }
 
   /**

--- a/src/profile_service/profile.js
+++ b/src/profile_service/profile.js
@@ -67,10 +67,8 @@ class Profile extends BaseProfile {
    */
   getAgeVerifications() {
     this.findAllAgeVerifications();
-    return Object.keys(this.ageVerifications).reduce((acc, current) => {
-      acc.push(this.ageVerifications[current]);
-      return acc;
-    }, []);
+    return Object.keys(this.ageVerifications)
+      .map(key => this.ageVerifications[key]);
   }
 
   /**

--- a/src/yoti_common/age.js
+++ b/src/yoti_common/age.js
@@ -2,6 +2,9 @@
 
 const AGE_PATTERN = /^age(Under|Over):[1-9][0-9]*$/;
 
+/**
+ * @deprecated replaced by AgeVerification
+ */
 module.exports.Age = class Age {
   constructor(profileData) {
     this.profileData = profileData;

--- a/src/yoti_common/validation.js
+++ b/src/yoti_common/validation.js
@@ -146,7 +146,7 @@ module.exports = class Validation {
    * @param {RegExp} regexp
    * @param {string} name
    *
-   * @throws {RangeError}
+   * @throws {TypeError}
    */
   static matchesPattern(value, regexp, name) {
     this.instanceOf(regexp, RegExp, 'regexp');

--- a/src/yoti_common/validation.js
+++ b/src/yoti_common/validation.js
@@ -142,6 +142,20 @@ module.exports = class Validation {
   }
 
   /**
+   * @param {string} value
+   * @param {RegExp} regexp
+   * @param {string} name
+   *
+   * @throws {RangeError}
+   */
+  static matchesPattern(value, regexp, name) {
+    this.instanceOf(regexp, RegExp, 'regexp');
+    if (value === null || !regexp.test(value)) {
+      throw new TypeError(`'${name}' value '${value}' does not match format '${regexp.toString()}'`);
+    }
+  }
+
+  /**
    * @param {*} value
    * @param {*} minLimit
    * @param {*} maxLimit

--- a/tests/data_type/age.verification.spec.js
+++ b/tests/data_type/age.verification.spec.js
@@ -1,0 +1,51 @@
+const expect = require('chai').expect;
+
+const { AgeVerification } = require('../../src/data_type/age.verification');
+const { Attribute } = require('../../src/data_type/attribute');
+
+const EXPECTED_PATTERN = /^[^:]+:(?!.*:)[0-9]+$/;
+
+describe('AgeVerification', () => {
+  context('when malformed age derivation is provided', () => {
+    it('should throw exception', () => {
+      [
+        '',
+        ':',
+        '18',
+        'age_over:',
+        'age_over:not_int',
+        ':age_over:18',
+        'age_over::18',
+        'age_over:18:',
+        'age_over:18:21',
+      ].forEach((name) => {
+        const attribute = new Attribute({
+          name,
+          value: 'true',
+        });
+        expect(() => new AgeVerification(attribute))
+          .to.throw(TypeError, `'attribute.name' value '${name}' does not match format '${EXPECTED_PATTERN}'`);
+      });
+    });
+  });
+
+  context('when well formed age derivation is provided', () => {
+    const attribute = new Attribute({
+      name: 'any_string_here:21',
+      value: 'true',
+    });
+    const ageVerification = new AgeVerification(attribute);
+    it('should parse check type', () => {
+      expect(ageVerification.getCheckType()).to.equal('any_string_here');
+    });
+    it('should parse age', () => {
+      expect(ageVerification.getAge()).to.equal(21);
+    });
+    it('should parse result', () => {
+      expect(ageVerification.getResult()).to.equal(true);
+    });
+    it('should return provided attribute', () => {
+      expect(ageVerification.getAttribute()).to.equal(attribute);
+    });
+  });
+});

--- a/tests/sample-data/profile-service/profile.json
+++ b/tests/sample-data/profile-service/profile.json
@@ -103,6 +103,34 @@
     "sources": [],
     "verifiers": []
   },
+  "age_under:18":
+  {
+    "name": "age_under:18",
+    "value": "false",
+    "sources": [],
+    "verifiers": []
+  },
+  "age_under:21":
+  {
+    "name": "age_under:21",
+    "value": "true",
+    "sources": [],
+    "verifiers": []
+  },
+  "age_over:18":
+  {
+    "name": "age_over:18",
+    "value": "true",
+    "sources": [],
+    "verifiers": []
+  },
+  "age_over:21":
+  {
+    "name": "age_over:21",
+    "value": "false",
+    "sources": [],
+    "verifiers": []
+  },
   "document_images":
   {
     "name": "document_images",


### PR DESCRIPTION
### Added
- `AgeVerification`
  - `.getCheckType()`
  - `.getAge()`
  - `.getResult()`
  - `.getAttribute()`
- `BaseProfile`
  - `.findAttributesStartingWith()`
- `Profile`
  - `.getAgeVerifications()`
  - `.findAgeOverVerification(age)`
  - `.findAgeUnderVerification(age)`
  - `.findAgeVerification(type, age)` - intended to be used by _findAgeOverVerification_/_findAgeUnderVerification_
  - `.findAllAgeVerifications()`
- `Validation.matchesPattern()`

### Deprecated
- `Profile.getAgeVerified()`
- `Age` found at _yoti_common/age_