### PR TITLE
SDK-1072: Add issuing authority getter

### DIFF
--- a/examples/profile/views/pages/dynamic-share.ejs
+++ b/examples/profile/views/pages/dynamic-share.ejs
@@ -19,7 +19,7 @@
           alt="Yoti"/>
       </div>
 
-      <h1 class="yoti-top-header">We now accept Yoti</h1>
+      <h1 class="yoti-top-header">Dynamic Share Example</h1>
 
       <div class="yoti-sdk-integration-section">
         <div id="yoti-share-button"></div>

--- a/examples/profile/views/pages/profile.ejs
+++ b/examples/profile/views/pages/profile.ejs
@@ -159,6 +159,10 @@ if (ageVerifications) {
                       <td><%= item.prop.getValue().getIssuingCountry() %></td>
                     </tr>
                     <tr>
+                      <td>Issuing Authority</td>
+                      <td><%= item.prop.getValue().getIssuingAuthority() %></td>
+                    </tr>
+                    <tr>
                       <td>Document Number</td>
                       <td><%= item.prop.getValue().getDocumentNumber() %></td>
                     </tr>

--- a/src/data_type/document.details.js
+++ b/src/data_type/document.details.js
@@ -43,19 +43,49 @@ module.exports.DocumentDetails = class DocumentDetails {
     }
   }
 
+  /**
+   * Type of the document e.g. PASSPORT | DRIVING_LICENCE | NATIONAL_ID | PASS_CARD
+   *
+   * @returns {null|string}
+   */
   getType() {
     return this.type;
   }
 
+  /**
+   * ISO-3166-1 alpha-3 country code, e.g. “GBR“
+   *
+   * @returns {null|string}
+   */
   getIssuingCountry() {
     return this.issuingCountry;
   }
 
+  /**
+   * Document number (may include letters) from the document.
+   *
+   * @returns {null|string}
+   */
   getDocumentNumber() {
     return this.documentNumber;
   }
 
+  /**
+   * Expiration date of the document in Date format. If the document does not expire, this
+   * field will not be present. The time part of this Date will default to 00:00:00.
+   *
+   * @returns {null|Date}
+   */
   getExpirationDate() {
     return this.expirationDate;
+  }
+
+  /**
+   * Can either be a country code (for a state), or the name of the issuing authority.
+   *
+   * @returns {null|string}
+   */
+  getIssuingAuthority() {
+    return this.issuingAuthority;
   }
 };

--- a/tests/data_type/document.details.spec.js
+++ b/tests/data_type/document.details.spec.js
@@ -31,30 +31,30 @@ describe('documentDetails', () => {
   context('when value is four words', () => {
     it('it should parse one optional attribute', () => {
       const documentDetails = new DocumentDetails('PASSPORT GBR 01234567 2020-01-01');
-      expect(documentDetails.type).to.equal('PASSPORT');
-      expect(documentDetails.issuingCountry).to.equal('GBR');
-      expect(documentDetails.documentNumber).to.equal('01234567');
-      expect(documentDetails.expirationDate.toISOString().slice(0, 10)).to.equal('2020-01-01');
+      expect(documentDetails.getType()).to.equal('PASSPORT');
+      expect(documentDetails.getIssuingCountry()).to.equal('GBR');
+      expect(documentDetails.getDocumentNumber()).to.equal('01234567');
+      expect(documentDetails.getExpirationDate().toISOString().slice(0, 10)).to.equal('2020-01-01');
     });
   });
   context('when value is five words', () => {
     it('it should parse two optional attributes', () => {
       const documentDetails = new DocumentDetails('DRIVING_LICENCE GBR 1234abc 2016-05-01 DVLA');
-      expect(documentDetails.type).to.equal('DRIVING_LICENCE');
-      expect(documentDetails.issuingCountry).to.equal('GBR');
-      expect(documentDetails.documentNumber).to.equal('1234abc');
-      expect(documentDetails.expirationDate.toISOString().slice(0, 10)).to.equal('2016-05-01');
-      expect(documentDetails.issuingAuthority).to.equal('DVLA');
+      expect(documentDetails.getType()).to.equal('DRIVING_LICENCE');
+      expect(documentDetails.getIssuingCountry()).to.equal('GBR');
+      expect(documentDetails.getDocumentNumber()).to.equal('1234abc');
+      expect(documentDetails.getExpirationDate().toISOString().slice(0, 10)).to.equal('2016-05-01');
+      expect(documentDetails.getIssuingAuthority()).to.equal('DVLA');
     });
   });
   context('when value is more than five words', () => {
     it('it should parse only two optional attributes', () => {
       const documentDetails = new DocumentDetails('DRIVING_LICENCE GBR 1234abc 2016-05-01 DVLA someThirdAttribute');
-      expect(documentDetails.type).to.equal('DRIVING_LICENCE');
-      expect(documentDetails.issuingCountry).to.equal('GBR');
-      expect(documentDetails.documentNumber).to.equal('1234abc');
-      expect(documentDetails.expirationDate.toISOString().slice(0, 10)).to.equal('2016-05-01');
-      expect(documentDetails.issuingAuthority).to.equal('DVLA');
+      expect(documentDetails.getType()).to.equal('DRIVING_LICENCE');
+      expect(documentDetails.getIssuingCountry()).to.equal('GBR');
+      expect(documentDetails.getDocumentNumber()).to.equal('1234abc');
+      expect(documentDetails.getExpirationDate().toISOString().slice(0, 10)).to.equal('2016-05-01');
+      expect(documentDetails.getIssuingAuthority()).to.equal('DVLA');
     });
   });
   context('when value has invalid country 13', () => {
@@ -70,11 +70,11 @@ describe('documentDetails', () => {
   context('when expiration Date is set to dash (-)', () => {
     it('it should return NULL for date value', () => {
       const documentDetails = new DocumentDetails('PASS_CARD GBR 22719564893 - CITIZENCARD');
-      expect(documentDetails.type).to.equal('PASS_CARD');
-      expect(documentDetails.issuingCountry).to.equal('GBR');
-      expect(documentDetails.documentNumber).to.equal('22719564893');
-      expect(documentDetails.expirationDate).to.equal(null);
-      expect(documentDetails.issuingAuthority).to.equal('CITIZENCARD');
+      expect(documentDetails.getType()).to.equal('PASS_CARD');
+      expect(documentDetails.getIssuingCountry()).to.equal('GBR');
+      expect(documentDetails.getDocumentNumber()).to.equal('22719564893');
+      expect(documentDetails.getExpirationDate()).to.equal(null);
+      expect(documentDetails.getIssuingAuthority()).to.equal('CITIZENCARD');
     });
   });
   context('when there is an invalid date', () => {


### PR DESCRIPTION
### Added
- `DocumentDetails.getIssuingAuthority()`