### PR TITLE
SDK-852: SonarQube/Jest

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,5 @@
 module.exports = {
-  "plugins": ["node"],
+  "plugins": ["node", "jest"],
   "extends": ["plugin:node/recommended", "airbnb-base"],
   rules: {
     "node/exports-style": ["error", "module.exports"],
@@ -16,7 +16,7 @@ module.exports = {
   },
   env: {
     "node": true,
-    "mocha": true
+    "jest/globals": true
   },
   "overrides": [{
     "files": "\"./tests/**/*.spec.js\"",

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ examples/profile/static/YotiSelfie.jpeg
 coverage
 idea
 .idea
+.scannerwork

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,8 @@ jobs:
       node_js: "node"
       os: linux
       install:
+        - rm package-lock.json
         - npm install
-        - npm --depth=9999 update
       script:
         - npm test
     - <<: *test-compatibility

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,16 +45,14 @@ jobs:
     - stage: Lint Examples
       name: AML Check
       node_js: "10"
-      install:
+      script:
         - cd ./examples/aml-check
         - npm update
-      script:
         - npm run lint
     - name: Profile
       node_js: "10"
-      install:
+      script:
         - cd ./examples/profile
         - npm update
-      script:
         - npm run lint
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,8 @@ jobs:
       node_js: "node"
       os: linux
       install:
-        - rm package-lock.json
         - npm install
+        - npm update
       script:
         - npm test
     - <<: *test-compatibility

--- a/package-lock.json
+++ b/package-lock.json
@@ -2281,8 +2281,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2303,14 +2302,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2325,20 +2322,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2455,8 +2449,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2468,7 +2461,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2483,7 +2475,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2491,14 +2482,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2517,7 +2506,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2598,8 +2586,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2611,7 +2598,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2697,8 +2683,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2734,7 +2719,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2754,7 +2738,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2798,14 +2781,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -480,12 +480,6 @@
         "@types/istanbul-lib-report": "*"
       }
     },
-    "@types/json-schema": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.3.tgz",
-      "integrity": "sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A==",
-      "dev": true
-    },
     "@types/stack-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
@@ -506,47 +500,6 @@
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-13.1.0.tgz",
       "integrity": "sha512-gCubfBUZ6KxzoibJ+SCUc/57Ms1jz5NjHe4+dI2krNmU5zCPAphyLJYyTOg06ueIyfj+SaCUqmzun7ImlxDcKg==",
       "dev": true
-    },
-    "@typescript-eslint/experimental-utils": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-1.13.0.tgz",
-      "integrity": "sha512-zmpS6SyqG4ZF64ffaJ6uah6tWWWgZ8m+c54XXgwFtUv0jNz8aJAVx8chMCvnk7yl6xwn8d+d96+tWp7fXzTuDg==",
-      "dev": true,
-      "requires": {
-        "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/typescript-estree": "1.13.0",
-        "eslint-scope": "^4.0.0"
-      },
-      "dependencies": {
-        "eslint-scope": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
-          "integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
-          "dev": true,
-          "requires": {
-            "esrecurse": "^4.1.0",
-            "estraverse": "^4.1.1"
-          }
-        }
-      }
-    },
-    "@typescript-eslint/typescript-estree": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-1.13.0.tgz",
-      "integrity": "sha512-b5rCmd2e6DCC6tCTN9GSUAuxdYwCM/k/2wdjHGrIRGPSJotWMCe/dGpi66u42bhuh8q3QBzqM4TMA1GUUCJvdw==",
-      "dev": true,
-      "requires": {
-        "lodash.unescape": "4.0.1",
-        "semver": "5.5.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
-          "dev": true
-        }
-      }
     },
     "abab": {
       "version": "2.0.1",
@@ -678,6 +631,16 @@
       "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
       "dev": true
+    },
+    "array-includes": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
+      "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.7.0"
+      }
     },
     "array-unique": {
       "version": "0.3.2",
@@ -1020,12 +983,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
-      "dev": true
-    },
-    "builtin-modules": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
       "dev": true
     },
     "bytebuffer": {
@@ -1772,21 +1729,22 @@
       }
     },
     "eslint-plugin-import": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.9.0.tgz",
-      "integrity": "sha1-JgAu+/ylmJtyiKwEdQi9JPIXsWk=",
+      "version": "2.18.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.18.2.tgz",
+      "integrity": "sha512-5ohpsHAiUBRNaBWAF08izwUGlbrJoJJ+W9/TBwsGoR1MnlgfwMIKrFeSjWbt6moabiXW9xNvtFz+97KHRfI4HQ==",
       "dev": true,
       "requires": {
-        "builtin-modules": "^1.1.1",
+        "array-includes": "^3.0.3",
         "contains-path": "^0.1.0",
-        "debug": "^2.6.8",
+        "debug": "^2.6.9",
         "doctrine": "1.5.0",
-        "eslint-import-resolver-node": "^0.3.1",
-        "eslint-module-utils": "^2.1.1",
-        "has": "^1.0.1",
-        "lodash": "^4.17.4",
-        "minimatch": "^3.0.3",
-        "read-pkg-up": "^2.0.0"
+        "eslint-import-resolver-node": "^0.3.2",
+        "eslint-module-utils": "^2.4.0",
+        "has": "^1.0.3",
+        "minimatch": "^3.0.4",
+        "object.values": "^1.1.0",
+        "read-pkg-up": "^2.0.0",
+        "resolve": "^1.11.0"
       },
       "dependencies": {
         "debug": {
@@ -1817,13 +1775,10 @@
       }
     },
     "eslint-plugin-jest": {
-      "version": "22.17.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-22.17.0.tgz",
-      "integrity": "sha512-WT4DP4RoGBhIQjv+5D0FM20fAdAUstfYAf/mkufLNTojsfgzc5/IYW22cIg/Q4QBavAZsROQlqppiWDpFZDS8Q==",
-      "dev": true,
-      "requires": {
-        "@typescript-eslint/experimental-utils": "^1.13.0"
-      }
+      "version": "21.27.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-21.27.2.tgz",
+      "integrity": "sha512-0E4OIgBJVlAmf1KfYFtZ3gYxgUzC5Eb3Jzmrc9ikI1OY+/cM8Kh72Ti7KfpeHNeD3HJNf9SmEfmvQLIz44Hrhw==",
+      "dev": true
     },
     "eslint-plugin-node": {
       "version": "6.0.1",
@@ -2281,7 +2236,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2302,12 +2258,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2322,17 +2280,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2449,7 +2410,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2461,6 +2423,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2475,6 +2438,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2482,12 +2446,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2506,6 +2472,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2586,7 +2553,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2598,6 +2566,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2683,7 +2652,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2719,6 +2689,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2738,6 +2709,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2781,12 +2753,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -4526,12 +4500,6 @@
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
       "dev": true
     },
-    "lodash.unescape": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.1.tgz",
-      "integrity": "sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=",
-      "dev": true
-    },
     "long": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
@@ -4936,6 +4904,18 @@
       "dev": true,
       "requires": {
         "isobject": "^3.0.1"
+      }
+    },
+    "object.values": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.0.tgz",
+      "integrity": "sha512-8mf0nKLAoFX6VlNVdhGj31SVYpaNFtUnuoOXWyFEstsWRgU837AK+JYM0iAxwkSzGRbwn8cbFmgbyxj1j4VbXg==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.12.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3"
       }
     },
     "once": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,10 +4,554 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "abbrev": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
-      "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
+    "@babel/code-frame": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
+      "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "^7.0.0"
+      }
+    },
+    "@babel/core": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.6.0.tgz",
+      "integrity": "sha512-FuRhDRtsd6IptKpHXAa+4WPZYY2ZzgowkbLBecEDDSje1X/apG7jQM33or3NdOmjXBKWGOg4JmSiRfUfuTtHXw==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.5.5",
+        "@babel/generator": "^7.6.0",
+        "@babel/helpers": "^7.6.0",
+        "@babel/parser": "^7.6.0",
+        "@babel/template": "^7.6.0",
+        "@babel/traverse": "^7.6.0",
+        "@babel/types": "^7.6.0",
+        "convert-source-map": "^1.1.0",
+        "debug": "^4.1.0",
+        "json5": "^2.1.0",
+        "lodash": "^4.17.13",
+        "resolve": "^1.3.2",
+        "semver": "^5.4.1",
+        "source-map": "^0.5.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
+    "@babel/generator": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.6.0.tgz",
+      "integrity": "sha512-Ms8Mo7YBdMMn1BYuNtKuP/z0TgEIhbcyB8HVR6PPNYp4P61lMsABiS4A3VG1qznjXVCf3r+fVHhm4efTYVsySA==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.6.0",
+        "jsesc": "^2.5.1",
+        "lodash": "^4.17.13",
+        "source-map": "^0.5.0",
+        "trim-right": "^1.0.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
+    "@babel/helper-function-name": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
+      "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-get-function-arity": "^7.0.0",
+        "@babel/template": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-get-function-arity": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
+      "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-plugin-utils": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
+      "integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA==",
+      "dev": true
+    },
+    "@babel/helper-split-export-declaration": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
+      "integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.4.4"
+      }
+    },
+    "@babel/helpers": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.6.0.tgz",
+      "integrity": "sha512-W9kao7OBleOjfXtFGgArGRX6eCP0UEcA2ZWEWNkJdRZnHhW4eEbeswbG3EwaRsnQUAEGWYgMq1HsIXuNNNy2eQ==",
+      "dev": true,
+      "requires": {
+        "@babel/template": "^7.6.0",
+        "@babel/traverse": "^7.6.0",
+        "@babel/types": "^7.6.0"
+      }
+    },
+    "@babel/highlight": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.5.0.tgz",
+      "integrity": "sha512-7dV4eu9gBxoM0dAnj/BCFDW9LFU0zvTrkq0ugM7pnHEgguOEeOz1so2ZghEdzviYzQEED0r4EAgpsBChKy1TRQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.0",
+        "esutils": "^2.0.2",
+        "js-tokens": "^4.0.0"
+      },
+      "dependencies": {
+        "js-tokens": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+          "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/parser": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.0.tgz",
+      "integrity": "sha512-+o2q111WEx4srBs7L9eJmcwi655eD8sXniLqMB93TBK9GrNzGrxDWSjiqz2hLU0Ha8MTXFIP0yd9fNdP+m43ZQ==",
+      "dev": true
+    },
+    "@babel/plugin-syntax-object-rest-spread": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.2.0.tgz",
+      "integrity": "sha512-t0JKGgqk2We+9may3t0xDdmneaXmyxq0xieYcKHxIsrJO64n1OiMWNUtc5gQK1PA0NpdCRrtZp4z+IUaKugrSA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/template": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.6.0.tgz",
+      "integrity": "sha512-5AEH2EXD8euCk446b7edmgFdub/qfH1SN6Nii3+fyXP807QRx9Q73A2N5hNwRRslC2H9sNzaFhsPubkS4L8oNQ==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/parser": "^7.6.0",
+        "@babel/types": "^7.6.0"
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.6.0.tgz",
+      "integrity": "sha512-93t52SaOBgml/xY74lsmt7xOR4ufYvhb5c5qiM6lu4J/dWGMAfAh6eKw4PjLes6DI6nQgearoxnFJk60YchpvQ==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.5.5",
+        "@babel/generator": "^7.6.0",
+        "@babel/helper-function-name": "^7.1.0",
+        "@babel/helper-split-export-declaration": "^7.4.4",
+        "@babel/parser": "^7.6.0",
+        "@babel/types": "^7.6.0",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0",
+        "lodash": "^4.17.13"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
+      }
+    },
+    "@babel/types": {
+      "version": "7.6.1",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.1.tgz",
+      "integrity": "sha512-X7gdiuaCmA0uRjCmRtYJNAVCc/q+5xSgsfKJHqMN4iNLILX39677fJE1O40arPMh0TTtS9ItH67yre6c7k6t0g==",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.13",
+        "to-fast-properties": "^2.0.0"
+      }
+    },
+    "@cnakazawa/watch": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.3.tgz",
+      "integrity": "sha512-r5160ogAvGyHsal38Kux7YYtodEKOj89RGb28ht1jh3SJb08VwRwAKKJL0bGb04Zd/3r9FL3BFIc3bBidYffCA==",
+      "dev": true,
+      "requires": {
+        "exec-sh": "^0.3.2",
+        "minimist": "^1.2.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
+    "@jest/console": {
+      "version": "24.9.0",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-24.9.0.tgz",
+      "integrity": "sha512-Zuj6b8TnKXi3q4ymac8EQfc3ea/uhLeCGThFqXeC8H9/raaH8ARPUTdId+XyGd03Z4In0/VjD2OYFcBF09fNLQ==",
+      "dev": true,
+      "requires": {
+        "@jest/source-map": "^24.9.0",
+        "chalk": "^2.0.1",
+        "slash": "^2.0.0"
+      }
+    },
+    "@jest/core": {
+      "version": "24.9.0",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-24.9.0.tgz",
+      "integrity": "sha512-Fogg3s4wlAr1VX7q+rhV9RVnUv5tD7VuWfYy1+whMiWUrvl7U3QJSJyWcDio9Lq2prqYsZaeTv2Rz24pWGkJ2A==",
+      "dev": true,
+      "requires": {
+        "@jest/console": "^24.7.1",
+        "@jest/reporters": "^24.9.0",
+        "@jest/test-result": "^24.9.0",
+        "@jest/transform": "^24.9.0",
+        "@jest/types": "^24.9.0",
+        "ansi-escapes": "^3.0.0",
+        "chalk": "^2.0.1",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.1.15",
+        "jest-changed-files": "^24.9.0",
+        "jest-config": "^24.9.0",
+        "jest-haste-map": "^24.9.0",
+        "jest-message-util": "^24.9.0",
+        "jest-regex-util": "^24.3.0",
+        "jest-resolve": "^24.9.0",
+        "jest-resolve-dependencies": "^24.9.0",
+        "jest-runner": "^24.9.0",
+        "jest-runtime": "^24.9.0",
+        "jest-snapshot": "^24.9.0",
+        "jest-util": "^24.9.0",
+        "jest-validate": "^24.9.0",
+        "jest-watcher": "^24.9.0",
+        "micromatch": "^3.1.10",
+        "p-each-series": "^1.0.0",
+        "realpath-native": "^1.1.0",
+        "rimraf": "^2.5.4",
+        "slash": "^2.0.0",
+        "strip-ansi": "^5.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
+      }
+    },
+    "@jest/environment": {
+      "version": "24.9.0",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-24.9.0.tgz",
+      "integrity": "sha512-5A1QluTPhvdIPFYnO3sZC3smkNeXPVELz7ikPbhUj0bQjB07EoE9qtLrem14ZUYWdVayYbsjVwIiL4WBIMV4aQ==",
+      "dev": true,
+      "requires": {
+        "@jest/fake-timers": "^24.9.0",
+        "@jest/transform": "^24.9.0",
+        "@jest/types": "^24.9.0",
+        "jest-mock": "^24.9.0"
+      }
+    },
+    "@jest/fake-timers": {
+      "version": "24.9.0",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-24.9.0.tgz",
+      "integrity": "sha512-eWQcNa2YSwzXWIMC5KufBh3oWRIijrQFROsIqt6v/NS9Io/gknw1jsAC9c+ih/RQX4A3O7SeWAhQeN0goKhT9A==",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^24.9.0",
+        "jest-message-util": "^24.9.0",
+        "jest-mock": "^24.9.0"
+      }
+    },
+    "@jest/reporters": {
+      "version": "24.9.0",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-24.9.0.tgz",
+      "integrity": "sha512-mu4X0yjaHrffOsWmVLzitKmmmWSQ3GGuefgNscUSWNiUNcEOSEQk9k3pERKEQVBb0Cnn88+UESIsZEMH3o88Gw==",
+      "dev": true,
+      "requires": {
+        "@jest/environment": "^24.9.0",
+        "@jest/test-result": "^24.9.0",
+        "@jest/transform": "^24.9.0",
+        "@jest/types": "^24.9.0",
+        "chalk": "^2.0.1",
+        "exit": "^0.1.2",
+        "glob": "^7.1.2",
+        "istanbul-lib-coverage": "^2.0.2",
+        "istanbul-lib-instrument": "^3.0.1",
+        "istanbul-lib-report": "^2.0.4",
+        "istanbul-lib-source-maps": "^3.0.1",
+        "istanbul-reports": "^2.2.6",
+        "jest-haste-map": "^24.9.0",
+        "jest-resolve": "^24.9.0",
+        "jest-runtime": "^24.9.0",
+        "jest-util": "^24.9.0",
+        "jest-worker": "^24.6.0",
+        "node-notifier": "^5.4.2",
+        "slash": "^2.0.0",
+        "source-map": "^0.6.0",
+        "string-length": "^2.0.0"
+      }
+    },
+    "@jest/source-map": {
+      "version": "24.9.0",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-24.9.0.tgz",
+      "integrity": "sha512-/Xw7xGlsZb4MJzNDgB7PW5crou5JqWiBQaz6xyPd3ArOg2nfn/PunV8+olXbbEZzNl591o5rWKE9BRDaFAuIBg==",
+      "dev": true,
+      "requires": {
+        "callsites": "^3.0.0",
+        "graceful-fs": "^4.1.15",
+        "source-map": "^0.6.0"
+      },
+      "dependencies": {
+        "callsites": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+          "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+          "dev": true
+        }
+      }
+    },
+    "@jest/test-result": {
+      "version": "24.9.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-24.9.0.tgz",
+      "integrity": "sha512-XEFrHbBonBJ8dGp2JmF8kP/nQI/ImPpygKHwQ/SY+es59Z3L5PI4Qb9TQQMAEeYsThG1xF0k6tmG0tIKATNiiA==",
+      "dev": true,
+      "requires": {
+        "@jest/console": "^24.9.0",
+        "@jest/types": "^24.9.0",
+        "@types/istanbul-lib-coverage": "^2.0.0"
+      }
+    },
+    "@jest/test-sequencer": {
+      "version": "24.9.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-24.9.0.tgz",
+      "integrity": "sha512-6qqsU4o0kW1dvA95qfNog8v8gkRN9ph6Lz7r96IvZpHdNipP2cBcb07J1Z45mz/VIS01OHJ3pY8T5fUY38tg4A==",
+      "dev": true,
+      "requires": {
+        "@jest/test-result": "^24.9.0",
+        "jest-haste-map": "^24.9.0",
+        "jest-runner": "^24.9.0",
+        "jest-runtime": "^24.9.0"
+      }
+    },
+    "@jest/transform": {
+      "version": "24.9.0",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-24.9.0.tgz",
+      "integrity": "sha512-TcQUmyNRxV94S0QpMOnZl0++6RMiqpbH/ZMccFB/amku6Uwvyb1cjYX7xkp5nGNkbX4QPH/FcB6q1HBTHynLmQ==",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.1.0",
+        "@jest/types": "^24.9.0",
+        "babel-plugin-istanbul": "^5.1.0",
+        "chalk": "^2.0.1",
+        "convert-source-map": "^1.4.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "graceful-fs": "^4.1.15",
+        "jest-haste-map": "^24.9.0",
+        "jest-regex-util": "^24.9.0",
+        "jest-util": "^24.9.0",
+        "micromatch": "^3.1.10",
+        "pirates": "^4.0.1",
+        "realpath-native": "^1.1.0",
+        "slash": "^2.0.0",
+        "source-map": "^0.6.1",
+        "write-file-atomic": "2.4.1"
+      }
+    },
+    "@jest/types": {
+      "version": "24.9.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-24.9.0.tgz",
+      "integrity": "sha512-XKK7ze1apu5JWQ5eZjHITP66AX+QsLlbaJRBGYr8pNzwcAE2JVkwnf0yqjHTsDRcjR0mujy/NmZMXw5kl+kGBw==",
+      "dev": true,
+      "requires": {
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^1.1.1",
+        "@types/yargs": "^13.0.0"
+      }
+    },
+    "@types/babel__core": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.3.tgz",
+      "integrity": "sha512-8fBo0UR2CcwWxeX7WIIgJ7lXjasFxoYgRnFHUj+hRvKkpiBJbxhdAPTCY6/ZKM0uxANFVzt4yObSLuTiTnazDA==",
+      "dev": true,
+      "requires": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "@types/babel__generator": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.0.2.tgz",
+      "integrity": "sha512-NHcOfab3Zw4q5sEE2COkpfXjoE7o+PmqD9DQW4koUT3roNxwziUdXGnRndMat/LJNUtePwn1TlP4do3uoe3KZQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@types/babel__template": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.0.2.tgz",
+      "integrity": "sha512-/K6zCpeW7Imzgab2bLkLEbz0+1JlFSrUMdw7KoIIu+IUdu51GWaBZpd3y1VXGVXzynvGa4DaIaxNZHiON3GXUg==",
+      "dev": true,
+      "requires": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@types/babel__traverse": {
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.7.tgz",
+      "integrity": "sha512-CeBpmX1J8kWLcDEnI3Cl2Eo6RfbGvzUctA+CjZUhOKDFbLfcr7fc4usEqLNWetrlJd7RhAkyYe2czXop4fICpw==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.3.0"
+      }
+    },
+    "@types/istanbul-lib-coverage": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
+      "integrity": "sha512-hRJD2ahnnpLgsj6KWMYSrmXkM3rm2Dl1qkx6IOFD5FnuNPXJIG5L0dhgKXCYTRMGzU4n0wImQ/xfmRc4POUFlg==",
+      "dev": true
+    },
+    "@types/istanbul-lib-report": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-1.1.1.tgz",
+      "integrity": "sha512-3BUTyMzbZa2DtDI2BkERNC6jJw2Mr2Y0oGI7mRxYNBPxppbtEK1F66u3bKwU2g+wxwWI7PAoRpJnOY1grJqzHg==",
+      "dev": true,
+      "requires": {
+        "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "@types/istanbul-reports": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.1.tgz",
+      "integrity": "sha512-UpYjBi8xefVChsCoBpKShdxTllC9pwISirfoZsUa2AAdQg/Jd2KQGtSbw+ya7GPo7x/wAPlH6JBhKhAsXUEZNA==",
+      "dev": true,
+      "requires": {
+        "@types/istanbul-lib-coverage": "*",
+        "@types/istanbul-lib-report": "*"
+      }
+    },
+    "@types/json-schema": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.3.tgz",
+      "integrity": "sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A==",
+      "dev": true
+    },
+    "@types/stack-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
+      "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
+      "dev": true
+    },
+    "@types/yargs": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.2.tgz",
+      "integrity": "sha512-lwwgizwk/bIIU+3ELORkyuOgDjCh7zuWDFqRtPPhhVgq9N1F7CvLNKg1TX4f2duwtKQ0p044Au9r1PLIXHrIzQ==",
+      "dev": true,
+      "requires": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "@types/yargs-parser": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-13.1.0.tgz",
+      "integrity": "sha512-gCubfBUZ6KxzoibJ+SCUc/57Ms1jz5NjHe4+dI2krNmU5zCPAphyLJYyTOg06ueIyfj+SaCUqmzun7ImlxDcKg==",
+      "dev": true
+    },
+    "@typescript-eslint/experimental-utils": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-1.13.0.tgz",
+      "integrity": "sha512-zmpS6SyqG4ZF64ffaJ6uah6tWWWgZ8m+c54XXgwFtUv0jNz8aJAVx8chMCvnk7yl6xwn8d+d96+tWp7fXzTuDg==",
+      "dev": true,
+      "requires": {
+        "@types/json-schema": "^7.0.3",
+        "@typescript-eslint/typescript-estree": "1.13.0",
+        "eslint-scope": "^4.0.0"
+      },
+      "dependencies": {
+        "eslint-scope": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
+          "integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
+          "dev": true,
+          "requires": {
+            "esrecurse": "^4.1.0",
+            "estraverse": "^4.1.1"
+          }
+        }
+      }
+    },
+    "@typescript-eslint/typescript-estree": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-1.13.0.tgz",
+      "integrity": "sha512-b5rCmd2e6DCC6tCTN9GSUAuxdYwCM/k/2wdjHGrIRGPSJotWMCe/dGpi66u42bhuh8q3QBzqM4TMA1GUUCJvdw==",
+      "dev": true,
+      "requires": {
+        "lodash.unescape": "4.0.1",
+        "semver": "5.5.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+          "dev": true
+        }
+      }
+    },
+    "abab": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.1.tgz",
+      "integrity": "sha512-1zSbbCuoIjafKZ3mblY5ikvAb0ODUbqBnFuUb7f6uLeQhhGJ0vEV4ntmtxKLT2WgXCO94E07BjunsIw1jOMPZw==",
       "dev": true
     },
     "acorn": {
@@ -15,6 +559,24 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
       "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
       "dev": true
+    },
+    "acorn-globals": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.4.tgz",
+      "integrity": "sha512-clfQEh21R+D0leSbUdWf3OcfqyaCSAQ8Ryq00bofSekfr9W8u1jyYZo6ir0xu9Gtcf7BjcHJpnbZH7JOCpP60A==",
+      "dev": true,
+      "requires": {
+        "acorn": "^6.0.1",
+        "acorn-walk": "^6.0.1"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.3.0.tgz",
+          "integrity": "sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA==",
+          "dev": true
+        }
+      }
     },
     "acorn-jsx": {
       "version": "3.0.1",
@@ -32,6 +594,12 @@
           "dev": true
         }
       }
+    },
+    "acorn-walk": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.2.0.tgz",
+      "integrity": "sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA==",
+      "dev": true
     },
     "ajv": {
       "version": "5.5.2",
@@ -51,13 +619,6 @@
       "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
       "dev": true
     },
-    "amdefine": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
-      "dev": true,
-      "optional": true
-    },
     "ansi-escapes": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
@@ -75,6 +636,16 @@
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
       "dev": true
     },
+    "anymatch": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+      "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+      "dev": true,
+      "requires": {
+        "micromatch": "^3.1.4",
+        "normalize-path": "^2.1.1"
+      }
+    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -83,6 +654,36 @@
       "requires": {
         "sprintf-js": "~1.0.2"
       }
+    },
+    "arr-diff": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+      "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+      "dev": true
+    },
+    "arr-flatten": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+      "dev": true
+    },
+    "arr-union": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+      "dev": true
+    },
+    "array-equal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+      "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
+      "dev": true
+    },
+    "array-unique": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+      "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+      "dev": true
     },
     "ascli": {
       "version": "1.0.1",
@@ -101,22 +702,58 @@
         "safer-buffer": "~2.1.0"
       }
     },
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "dev": true
+    },
     "assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true
     },
-    "async": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+    "assign-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+      "dev": true
+    },
+    "astral-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+      "dev": true
+    },
+    "async-limiter": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
+      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
       "dev": true
     },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
+    "atob": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+      "dev": true
+    },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+      "dev": true
+    },
+    "aws4": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
+      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
+      "dev": true
     },
     "babel-code-frame": {
       "version": "6.26.0",
@@ -144,15 +781,170 @@
         }
       }
     },
+    "babel-jest": {
+      "version": "24.9.0",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-24.9.0.tgz",
+      "integrity": "sha512-ntuddfyiN+EhMw58PTNL1ph4C9rECiQXjI4nMMBKBaNjXvqLdkXpPRcMSr4iyBrJg/+wz9brFUD6RhOAT6r4Iw==",
+      "dev": true,
+      "requires": {
+        "@jest/transform": "^24.9.0",
+        "@jest/types": "^24.9.0",
+        "@types/babel__core": "^7.1.0",
+        "babel-plugin-istanbul": "^5.1.0",
+        "babel-preset-jest": "^24.9.0",
+        "chalk": "^2.4.2",
+        "slash": "^2.0.0"
+      }
+    },
+    "babel-plugin-istanbul": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-5.2.0.tgz",
+      "integrity": "sha512-5LphC0USA8t4i1zCtjbbNb6jJj/9+X6P37Qfirc/70EQ34xKlMW+a1RHGwxGI+SwWpNwZ27HqvzAobeqaXwiZw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "find-up": "^3.0.0",
+        "istanbul-lib-instrument": "^3.3.0",
+        "test-exclude": "^5.2.3"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
+          "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
+        }
+      }
+    },
+    "babel-plugin-jest-hoist": {
+      "version": "24.9.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-24.9.0.tgz",
+      "integrity": "sha512-2EMA2P8Vp7lG0RAzr4HXqtYwacfMErOuv1U3wrvxHX6rD1sV6xS3WXG3r8TRQ2r6w8OhvSdWt+z41hQNwNm3Xw==",
+      "dev": true,
+      "requires": {
+        "@types/babel__traverse": "^7.0.6"
+      }
+    },
+    "babel-preset-jest": {
+      "version": "24.9.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-24.9.0.tgz",
+      "integrity": "sha512-izTUuhE4TMfTRPF92fFwD2QfdXaZW08qvWTFCI51V8rW5x00UuPgc3ajRoWofXOuxjfcOM5zzSYsQS3H8KGCAg==",
+      "dev": true,
+      "requires": {
+        "@babel/plugin-syntax-object-rest-spread": "^7.0.0",
+        "babel-plugin-jest-hoist": "^24.9.0"
+      }
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
+    "base": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+      "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+      "dev": true,
+      "requires": {
+        "cache-base": "^1.0.1",
+        "class-utils": "^0.3.5",
+        "component-emitter": "^1.2.1",
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.1",
+        "mixin-deep": "^1.2.0",
+        "pascalcase": "^0.1.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
     "base64-url": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-2.2.2.tgz",
-      "integrity": "sha512-JMAkNo3MJ7GG2CHPVMiGPrzGQizUcVE9qvCU6pxQln4aYZZgYM6BJHXbawDegSoryvsKGrK3FuBO9IuGWErRLQ=="
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-2.3.2.tgz",
+      "integrity": "sha512-2QpXjtjndKqPn9JKBpMTCbDGpgicfLUu+N5Y1vEfbuyqb1MN1D68C9YKCth4SjTHRvJleF3tPuxhLbH79MM0iQ=="
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "dev": true,
+      "requires": {
+        "tweetnacl": "^0.14.3"
+      }
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -163,11 +955,66 @@
         "concat-map": "0.0.1"
       }
     },
-    "browser-stdout": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
-      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+    "braces": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+      "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+      "dev": true,
+      "requires": {
+        "arr-flatten": "^1.1.0",
+        "array-unique": "^0.3.2",
+        "extend-shallow": "^2.0.1",
+        "fill-range": "^4.0.0",
+        "isobject": "^3.0.1",
+        "repeat-element": "^1.1.2",
+        "snapdragon": "^0.8.1",
+        "snapdragon-node": "^2.0.1",
+        "split-string": "^3.0.2",
+        "to-regex": "^3.0.1"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
+      }
+    },
+    "browser-process-hrtime": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.3.tgz",
+      "integrity": "sha512-bRFnI4NnjO6cnyLmOV/7PVoDEMJChlcfN0z4s1YMBY989/SvlfMI1lgCnkFUs53e9gQF+w7qu7XdllSTiSl8Aw==",
       "dev": true
+    },
+    "browser-resolve": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.3.tgz",
+      "integrity": "sha512-exDi1BYWB/6raKHmDTCicQfTkqwN5fioMFV4j8BsfMU4R2DK/QfZfK7kOVkmWCNANf0snkBzqGqAJBao9gZMdQ==",
+      "dev": true,
+      "requires": {
+        "resolve": "1.1.7"
+      },
+      "dependencies": {
+        "resolve": {
+          "version": "1.1.7",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+          "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+          "dev": true
+        }
+      }
+    },
+    "bser": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.0.tgz",
+      "integrity": "sha512-8zsjWrQkkBoLK6uxASk1nJ2SKv97ltiGDo6A3wA0/yRPz+CwmEyDo0hUrhIuukG2JHpAl3bvFIixw2/3Hi0DOg==",
+      "dev": true,
+      "requires": {
+        "node-int64": "^0.4.0"
+      }
     },
     "buffer-from": {
       "version": "1.1.1",
@@ -187,6 +1034,23 @@
       "integrity": "sha1-WC7qSxqHO20CCkjVjfhfC7ps/d0=",
       "requires": {
         "long": "~3"
+      }
+    },
+    "cache-base": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+      "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+      "dev": true,
+      "requires": {
+        "collection-visit": "^1.0.0",
+        "component-emitter": "^1.2.1",
+        "get-value": "^2.0.6",
+        "has-value": "^1.0.0",
+        "isobject": "^3.0.1",
+        "set-value": "^2.0.0",
+        "to-object-path": "^0.3.0",
+        "union-value": "^1.0.0",
+        "unset-value": "^1.0.0"
       }
     },
     "caller-callsite": {
@@ -226,15 +1090,33 @@
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
       "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
     },
-    "chai": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
-      "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
+    "capture-exit": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-2.0.0.tgz",
+      "integrity": "sha512-PiT/hQmTonHhl/HFGN+Lx3JJUznrVYJ3+AQsnthneZbvW7x+f08Tk7yLJTLEOUvBTbduLeeBkxEaYXUOUrRq6g==",
       "dev": true,
       "requires": {
-        "assertion-error": "^1.0.1",
-        "deep-eql": "^0.1.3",
-        "type-detect": "^1.0.0"
+        "rsvp": "^4.8.4"
+      }
+    },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+      "dev": true
+    },
+    "chai": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
+      "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
+      "dev": true,
+      "requires": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^3.0.1",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.1.0",
+        "type-detect": "^4.0.5"
       }
     },
     "chalk": {
@@ -292,6 +1174,29 @@
       "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
       "dev": true
     },
+    "class-utils": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+      "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+      "dev": true,
+      "requires": {
+        "arr-union": "^3.1.0",
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0",
+        "static-extend": "^0.1.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        }
+      }
+    },
     "cli-cursor": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
@@ -327,6 +1232,16 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+    },
+    "collection-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+      "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+      "dev": true,
+      "requires": {
+        "map-visit": "^1.0.0",
+        "object-visit": "^1.0.0"
+      }
     },
     "color-convert": {
       "version": "1.9.3",
@@ -391,10 +1306,33 @@
       "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
       "dev": true
     },
+    "convert-source-map": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
+      "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.1"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        }
+      }
+    },
     "cookiejar": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
       "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA=="
+    },
+    "copy-descriptor": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+      "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+      "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -436,6 +1374,54 @@
         "which": "^1.2.9"
       }
     },
+    "cssom": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+      "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
+      "dev": true
+    },
+    "cssstyle": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.4.0.tgz",
+      "integrity": "sha512-GBrLZYZ4X4x6/QEoBnIrqb8B/f5l4+8me2dkom/j1Gtbxy0kBv6OGzKuAsGM75bkGwGAFkt56Iwg28S3XTZgSA==",
+      "dev": true,
+      "requires": {
+        "cssom": "0.3.x"
+      }
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
+    "data-urls": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.1.0.tgz",
+      "integrity": "sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==",
+      "dev": true,
+      "requires": {
+        "abab": "^2.0.0",
+        "whatwg-mimetype": "^2.2.0",
+        "whatwg-url": "^7.0.0"
+      },
+      "dependencies": {
+        "whatwg-url": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.0.0.tgz",
+          "integrity": "sha512-37GeVSIJ3kn1JgKyjiYNmSLP1yzbpb29jdmwBSgkD9h40/hyrR/OifpVUndji3tmwGgD8qpw7iQu3RSbCrBpsQ==",
+          "dev": true,
+          "requires": {
+            "lodash.sortby": "^4.7.0",
+            "tr46": "^1.0.1",
+            "webidl-conversions": "^4.0.2"
+          }
+        }
+      }
+    },
     "debug": {
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
@@ -449,28 +1435,34 @@
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
+    "decode-uri-component": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "dev": true
+    },
     "deep-eql": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
-      "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
       "dev": true,
       "requires": {
-        "type-detect": "0.1.1"
-      },
-      "dependencies": {
-        "type-detect": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
-          "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
-          "dev": true
-        }
+        "type-detect": "^4.0.0"
       }
     },
     "deep-equal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
-      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
-      "dev": true
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.0.tgz",
+      "integrity": "sha512-ZbfWJq/wN1Z273o7mUSjILYqehAktR2NVoSrOukDkU9kg2v/Uv89yU4Cvz8seJeAmtN5oqiefKq8FPuXOboqLw==",
+      "dev": true,
+      "requires": {
+        "is-arguments": "^1.0.4",
+        "is-date-object": "^1.0.1",
+        "is-regex": "^1.0.4",
+        "object-is": "^1.0.1",
+        "object-keys": "^1.1.1",
+        "regexp.prototype.flags": "^1.2.0"
+      }
     },
     "deep-is": {
       "version": "0.1.3",
@@ -478,15 +1470,71 @@
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
+    "define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "dev": true,
+      "requires": {
+        "object-keys": "^1.0.12"
+      }
+    },
+    "define-property": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+      "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+      "dev": true,
+      "requires": {
+        "is-descriptor": "^1.0.2",
+        "isobject": "^3.0.1"
+      },
+      "dependencies": {
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
-    "diff": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+    "detect-newline": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
+      "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
+      "dev": true
+    },
+    "diff-sequences": {
+      "version": "24.9.0",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-24.9.0.tgz",
+      "integrity": "sha512-Dj6Wk3tWyTE+Fo1rW8v0Xhwk80um6yFYKbuAxc9c3EZxIHFDYwbi34Uk42u1CdnIiVorvt4RmlSDjIPyzGC2ew==",
       "dev": true
     },
     "doctrine": {
@@ -497,6 +1545,31 @@
       "requires": {
         "esutils": "^2.0.2"
       }
+    },
+    "domexception": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
+      "integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
+      "dev": true,
+      "requires": {
+        "webidl-conversions": "^4.0.2"
+      }
+    },
+    "ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "dev": true,
+      "requires": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
+    "emoji-regex": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+      "dev": true
     },
     "end-of-stream": {
       "version": "1.4.1",
@@ -516,6 +1589,35 @@
         "is-arrayish": "^0.2.1"
       }
     },
+    "es-abstract": {
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.14.2.tgz",
+      "integrity": "sha512-DgoQmbpFNOofkjJtKwr87Ma5EW4Dc8fWhD0R+ndq7Oc456ivUfGOOP6oAZTTKl5/CcNMP+EN+e3/iUzgE0veZg==",
+      "dev": true,
+      "requires": {
+        "es-to-primitive": "^1.2.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.0",
+        "is-callable": "^1.1.4",
+        "is-regex": "^1.0.4",
+        "object-inspect": "^1.6.0",
+        "object-keys": "^1.1.1",
+        "string.prototype.trimleft": "^2.0.0",
+        "string.prototype.trimright": "^2.0.0"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+      "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+      "dev": true,
+      "requires": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      }
+    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -523,28 +1625,22 @@
       "dev": true
     },
     "escodegen": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
-      "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.12.0.tgz",
+      "integrity": "sha512-TuA+EhsanGcme5T3R0L80u4t8CpbXQjegRmf7+FPTJrtCTErXFeelblRgHQa1FofEzqYYJmJ/OqjTwREp9qgmg==",
       "dev": true,
       "requires": {
-        "esprima": "^2.7.1",
-        "estraverse": "^1.9.1",
+        "esprima": "^3.1.3",
+        "estraverse": "^4.2.0",
         "esutils": "^2.0.2",
         "optionator": "^0.8.1",
-        "source-map": "~0.2.0"
+        "source-map": "~0.6.1"
       },
       "dependencies": {
         "esprima": {
-          "version": "2.7.3",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-          "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
-          "dev": true
-        },
-        "estraverse": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
-          "integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q=",
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
           "dev": true
         }
       }
@@ -649,9 +1745,9 @@
       }
     },
     "eslint-module-utils": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.4.0.tgz",
-      "integrity": "sha512-14tltLm38Eu3zS+mt0KvILC3q8jyIAH518MlG+HO0p+yK885Lb1UHTY/UgR91eOyGdmxAPb+OLoW4znqIT6Ndw==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.4.1.tgz",
+      "integrity": "sha512-H6DOj+ejw7Tesdgbfs4jeS4YMFrT8uI8xwd1gtQqXssaR0EQ26L+2O/w6wkYFy2MymON0fTwHmXBvvfLNZVZEw==",
       "dev": true,
       "requires": {
         "debug": "^2.6.8",
@@ -720,6 +1816,15 @@
         }
       }
     },
+    "eslint-plugin-jest": {
+      "version": "22.17.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-22.17.0.tgz",
+      "integrity": "sha512-WT4DP4RoGBhIQjv+5D0FM20fAdAUstfYAf/mkufLNTojsfgzc5/IYW22cIg/Q4QBavAZsROQlqppiWDpFZDS8Q==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/experimental-utils": "^1.13.0"
+      }
+    },
     "eslint-plugin-node": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-6.0.1.tgz",
@@ -749,9 +1854,9 @@
       }
     },
     "eslint-visitor-keys": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
-      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
+      "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
       "dev": true
     },
     "espree": {
@@ -789,15 +1894,21 @@
       }
     },
     "estraverse": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "dev": true
     },
     "esutils": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true
+    },
+    "exec-sh": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.3.2.tgz",
+      "integrity": "sha512-9sLAvzhI5nc8TpuQUh4ahMdCrWT00wPWz7j47/emR5+2qEfoZP5zzUXvx+vdx+H6ohhnsYC31iX04QLYJK8zTg==",
       "dev": true
     },
     "execa": {
@@ -830,10 +1941,112 @@
         }
       }
     },
+    "exit": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+      "dev": true
+    },
+    "expand-brackets": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+      "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+      "dev": true,
+      "requires": {
+        "debug": "^2.3.3",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "posix-character-classes": "^0.1.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
+    "expect": {
+      "version": "24.9.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-24.9.0.tgz",
+      "integrity": "sha512-wvVAx8XIol3Z5m9zvZXiyZOQ+sRJqNTIm6sGjdWlaZIeupQGO3WbYI+15D/AmEwZywL6wtJkbAbJtzkOfBuR0Q==",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^24.9.0",
+        "ansi-styles": "^3.2.0",
+        "jest-get-type": "^24.9.0",
+        "jest-matcher-utils": "^24.9.0",
+        "jest-message-util": "^24.9.0",
+        "jest-regex-util": "^24.9.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        }
+      }
+    },
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
+    "extend-shallow": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+      "dev": true,
+      "requires": {
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "^2.0.4"
+          }
+        }
+      }
     },
     "external-editor": {
       "version": "2.2.0",
@@ -845,6 +2058,77 @@
         "iconv-lite": "^0.4.17",
         "tmp": "^0.0.33"
       }
+    },
+    "extglob": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+      "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+      "dev": true,
+      "requires": {
+        "array-unique": "^0.3.2",
+        "define-property": "^1.0.0",
+        "expand-brackets": "^2.1.4",
+        "extend-shallow": "^2.0.1",
+        "fragment-cache": "^0.2.1",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true
     },
     "fast-deep-equal": {
       "version": "1.1.0",
@@ -864,6 +2148,15 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "fb-watchman": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
+      "integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
+      "dev": true,
+      "requires": {
+        "bser": "^2.0.0"
+      }
+    },
     "figures": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
@@ -881,6 +2174,29 @@
       "requires": {
         "flat-cache": "^1.2.1",
         "object-assign": "^4.0.1"
+      }
+    },
+    "fill-range": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+      "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^2.0.1",
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1",
+        "to-regex-range": "^2.1.0"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
       }
     },
     "find-up": {
@@ -904,10 +2220,22 @@
         "write": "^0.2.1"
       }
     },
+    "for-in": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+      "dev": true
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "dev": true
+    },
     "form-data": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.0.tgz",
-      "integrity": "sha512-WXieX3G/8side6VIqx44ablyULoGruSde5PNTxoUyo5CeyAMX6nVWUd0rgist/EuX655cjhUhTo1Fo3tRYqbcA==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+      "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.6",
@@ -919,10 +2247,567 @@
       "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.1.tgz",
       "integrity": "sha512-Fs9VRguL0gqGHkXS5GQiMCr1VhZBxz0JnJs4JmMp/2jL18Fmbzvv7vOFRU+U8TBkHEE/CX1qDXzJplVULgsLeg=="
     },
+    "fragment-cache": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+      "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+      "dev": true,
+      "requires": {
+        "map-cache": "^0.2.2"
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "fsevents": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
+      "integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "nan": "^2.12.1",
+        "node-pre-gyp": "^0.12.0"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "aproba": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "delegates": "^1.0.0",
+            "readable-stream": "^2.0.6"
+          }
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "chownr": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "debug": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "deep-extend": {
+          "version": "0.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "detect-libc": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "fs-minipass": {
+          "version": "1.2.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minipass": "^2.2.1"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "aproba": "^1.0.3",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.0",
+            "object-assign": "^4.1.0",
+            "signal-exit": "^3.0.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wide-align": "^1.1.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "iconv-lite": {
+          "version": "0.4.24",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        },
+        "ignore-walk": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minimatch": "^3.0.4"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "once": "^1.3.0",
+            "wrappy": "1"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "ini": {
+          "version": "1.3.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "minipass": {
+          "version": "2.3.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.0"
+          }
+        },
+        "minizlib": {
+          "version": "1.2.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minipass": "^2.2.1"
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "needle": {
+          "version": "2.3.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "debug": "^4.1.0",
+            "iconv-lite": "^0.4.4",
+            "sax": "^1.2.4"
+          }
+        },
+        "node-pre-gyp": {
+          "version": "0.12.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "detect-libc": "^1.0.2",
+            "mkdirp": "^0.5.1",
+            "needle": "^2.2.1",
+            "nopt": "^4.0.1",
+            "npm-packlist": "^1.1.6",
+            "npmlog": "^4.0.2",
+            "rc": "^1.2.7",
+            "rimraf": "^2.6.1",
+            "semver": "^5.3.0",
+            "tar": "^4"
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "abbrev": "1",
+            "osenv": "^0.1.4"
+          }
+        },
+        "npm-bundled": {
+          "version": "1.0.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "npm-packlist": {
+          "version": "1.4.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ignore-walk": "^3.0.1",
+            "npm-bundled": "^1.0.1"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "wrappy": "1"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "osenv": {
+          "version": "0.1.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "rc": {
+          "version": "1.2.8",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "deep-extend": "^0.6.0",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "safer-buffer": {
+          "version": "2.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "sax": {
+          "version": "1.2.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "semver": {
+          "version": "5.7.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "tar": {
+          "version": "4.4.8",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "chownr": "^1.1.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.3.4",
+            "minizlib": "^1.1.1",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.2"
+          }
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "wide-align": {
+          "version": "1.1.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "string-width": "^1.0.2 || 2"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "yallist": {
+          "version": "3.0.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        }
+      }
     },
     "function-bind": {
       "version": "1.1.1",
@@ -934,6 +2819,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
+    },
+    "get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
     },
     "get-func-name": {
@@ -957,6 +2848,21 @@
         "pump": "^3.0.0"
       }
     },
+    "get-value": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+      "dev": true
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
     "glob": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
@@ -977,33 +2883,67 @@
       "dev": true
     },
     "graceful-fs": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.0.tgz",
-      "integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
+      "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==",
       "dev": true
     },
-    "growl": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
-      "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
+    "growly": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
+      "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
       "dev": true
     },
     "handlebars": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
-      "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.2.0.tgz",
+      "integrity": "sha512-Kb4xn5Qh1cxAKvQnzNWZ512DhABzyFNmsaJf3OAkWNa4NkaqWcNI8Tao8Tasi0/F4JD9oyG0YxuFyvyR57d+Gw==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
         "optimist": "^0.6.1",
         "source-map": "^0.6.1",
         "uglify-js": "^3.1.4"
+      }
+    },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "dev": true
+    },
+    "har-validator": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+      "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.5.5",
+        "har-schema": "^2.0.0"
       },
       "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+        "ajv": {
+          "version": "6.10.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+          "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^2.0.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "fast-deep-equal": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+          "dev": true
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
           "dev": true
         }
       }
@@ -1032,17 +2972,69 @@
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
     },
-    "he": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+    "has-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
       "dev": true
     },
+    "has-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+      "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+      "dev": true,
+      "requires": {
+        "get-value": "^2.0.6",
+        "has-values": "^1.0.0",
+        "isobject": "^3.0.0"
+      }
+    },
+    "has-values": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+      "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+      "dev": true,
+      "requires": {
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
     "hosted-git-info": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
-      "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.4.tgz",
+      "integrity": "sha512-pzXIvANXEFrc5oFFXRMkbLPQ2rXRoDERwDLyrcUxGhaZhgP54BBSl9Oheh7Vv0T090cszWBxPjkQQ5Sq1PbBRQ==",
       "dev": true
+    },
+    "html-encoding-sniffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
+      "integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
+      "dev": true,
+      "requires": {
+        "whatwg-encoding": "^1.0.1"
+      }
+    },
+    "http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
+      }
     },
     "husky": {
       "version": "1.3.1",
@@ -1082,9 +3074,9 @@
           }
         },
         "p-limit": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
-          "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
+          "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
           "dev": true,
           "requires": {
             "p-try": "^2.0.0"
@@ -1185,6 +3177,70 @@
         }
       }
     },
+    "import-local": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-2.0.0.tgz",
+      "integrity": "sha512-b6s04m3O+s3CGSbqDIyP4R6aAwAeYlVq9+WUWep6iHa8ETRf9yei1U48C5MmfJmV9AiLYYBKPMq/W+/WRpQmCQ==",
+      "dev": true,
+      "requires": {
+        "pkg-dir": "^3.0.0",
+        "resolve-cwd": "^2.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
+          "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
+        },
+        "pkg-dir": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+          "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+          "dev": true,
+          "requires": {
+            "find-up": "^3.0.0"
+          }
+        }
+      }
+    },
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -1260,15 +3316,62 @@
         }
       }
     },
+    "invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.0.0"
+      }
+    },
     "invert-kv": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
       "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
     },
+    "is-accessor-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "is-arguments": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
+      "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA==",
+      "dev": true
+    },
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
+    },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true
+    },
+    "is-callable": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
       "dev": true
     },
     "is-ci": {
@@ -1280,10 +3383,61 @@
         "ci-info": "^2.0.0"
       }
     },
+    "is-data-descriptor": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "is-date-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+      "dev": true
+    },
+    "is-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+      "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+      "dev": true,
+      "requires": {
+        "is-accessor-descriptor": "^0.1.6",
+        "is-data-descriptor": "^0.1.4",
+        "kind-of": "^5.0.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "dev": true
+        }
+      }
+    },
     "is-directory": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
       "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
+      "dev": true
+    },
+    "is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
       "dev": true
     },
     "is-fullwidth-code-point": {
@@ -1294,11 +3448,55 @@
         "number-is-nan": "^1.0.0"
       }
     },
+    "is-generator-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
+      "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
+      "dev": true
+    },
+    "is-number": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+      "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "dev": true,
+      "requires": {
+        "isobject": "^3.0.1"
+      }
+    },
     "is-promise": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
       "dev": true
+    },
+    "is-regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.1"
+      }
     },
     "is-resolvable": {
       "version": "1.1.0",
@@ -1312,6 +3510,33 @@
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
       "dev": true
     },
+    "is-symbol": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+      "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.0"
+      }
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
+    },
+    "is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+      "dev": true
+    },
+    "is-wsl": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+      "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
+      "dev": true
+    },
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -1323,66 +3548,802 @@
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
-    "istanbul": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.4.5.tgz",
-      "integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
+    "isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "dev": true
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
+    },
+    "istanbul-lib-coverage": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
+      "integrity": "sha512-8aXznuEPCJvGnMSRft4udDRDtb1V3pkQkMMI5LI+6HuQz5oQ4J2UFn1H82raA3qJtyOLkkwVqICBQkjnGtn5mA==",
+      "dev": true
+    },
+    "istanbul-lib-instrument": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.3.0.tgz",
+      "integrity": "sha512-5nnIN4vo5xQZHdXno/YDXJ0G+I3dAm4XgzfSVTPLQpj/zAV2dV6Juy0yaf10/zrJOJeHoN3fraFe+XRq2bFVZA==",
       "dev": true,
       "requires": {
-        "abbrev": "1.0.x",
-        "async": "1.x",
-        "escodegen": "1.8.x",
-        "esprima": "2.7.x",
-        "glob": "^5.0.15",
-        "handlebars": "^4.0.1",
-        "js-yaml": "3.x",
-        "mkdirp": "0.5.x",
-        "nopt": "3.x",
-        "once": "1.x",
-        "resolve": "1.1.x",
-        "supports-color": "^3.1.0",
-        "which": "^1.1.1",
-        "wordwrap": "^1.0.0"
+        "@babel/generator": "^7.4.0",
+        "@babel/parser": "^7.4.3",
+        "@babel/template": "^7.4.0",
+        "@babel/traverse": "^7.4.3",
+        "@babel/types": "^7.4.0",
+        "istanbul-lib-coverage": "^2.0.5",
+        "semver": "^6.0.0"
       },
       "dependencies": {
-        "esprima": {
-          "version": "2.7.3",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-          "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
-        },
-        "glob": {
-          "version": "5.0.15",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+        }
+      }
+    },
+    "istanbul-lib-report": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-2.0.8.tgz",
+      "integrity": "sha512-fHBeG573EIihhAblwgxrSenp0Dby6tJMFR/HvlerBsrCTD5bkUuoNtn3gVh29ZCS824cGGBPn7Sg7cNk+2xUsQ==",
+      "dev": true,
+      "requires": {
+        "istanbul-lib-coverage": "^2.0.5",
+        "make-dir": "^2.1.0",
+        "supports-color": "^6.1.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "dev": true,
           "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "2 || 3",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "istanbul-lib-source-maps": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.6.tgz",
+      "integrity": "sha512-R47KzMtDJH6X4/YW9XTx+jrLnZnscW4VpNN+1PViSYTejLVPWv7oov+Duf8YQSPyVRUvueQqz1TcsC6mooZTXw==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^2.0.5",
+        "make-dir": "^2.1.0",
+        "rimraf": "^2.6.3",
+        "source-map": "^0.6.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
+      }
+    },
+    "istanbul-reports": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.6.tgz",
+      "integrity": "sha512-SKi4rnMyLBKe0Jy2uUdx28h8oG7ph2PPuQPvIAh31d+Ci+lSiEu4C+h3oBPuJ9+mPKhOyW0M8gY4U5NM1WLeXA==",
+      "dev": true,
+      "requires": {
+        "handlebars": "^4.1.2"
+      }
+    },
+    "jest": {
+      "version": "24.9.0",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-24.9.0.tgz",
+      "integrity": "sha512-YvkBL1Zm7d2B1+h5fHEOdyjCG+sGMz4f8D86/0HiqJ6MB4MnDc8FgP5vdWsGnemOQro7lnYo8UakZ3+5A0jxGw==",
+      "dev": true,
+      "requires": {
+        "import-local": "^2.0.0",
+        "jest-cli": "^24.9.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
           }
         },
-        "has-flag": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-          "dev": true
-        },
-        "resolve": {
-          "version": "1.1.7",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-          "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "3.2.3",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+        "cliui": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+          "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
           "dev": true,
           "requires": {
-            "has-flag": "^1.0.0"
+            "string-width": "^3.1.0",
+            "strip-ansi": "^5.2.0",
+            "wrap-ansi": "^5.1.0"
+          }
+        },
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "jest-cli": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-24.9.0.tgz",
+          "integrity": "sha512-+VLRKyitT3BWoMeSUIHRxV/2g8y9gw91Jh5z2UmXZzkZKpbC08CSehVxgHUwTpy+HwGcns/tqafQDJW7imYvGg==",
+          "dev": true,
+          "requires": {
+            "@jest/core": "^24.9.0",
+            "@jest/test-result": "^24.9.0",
+            "@jest/types": "^24.9.0",
+            "chalk": "^2.0.1",
+            "exit": "^0.1.2",
+            "import-local": "^2.0.0",
+            "is-ci": "^2.0.0",
+            "jest-config": "^24.9.0",
+            "jest-util": "^24.9.0",
+            "jest-validate": "^24.9.0",
+            "prompts": "^2.0.1",
+            "realpath-native": "^1.1.0",
+            "yargs": "^13.3.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
+          "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+          "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.0",
+            "string-width": "^3.0.0",
+            "strip-ansi": "^5.0.0"
+          }
+        },
+        "y18n": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+          "dev": true
+        },
+        "yargs": {
+          "version": "13.3.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.0.tgz",
+          "integrity": "sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==",
+          "dev": true,
+          "requires": {
+            "cliui": "^5.0.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^3.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^13.1.1"
+          }
+        }
+      }
+    },
+    "jest-changed-files": {
+      "version": "24.9.0",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-24.9.0.tgz",
+      "integrity": "sha512-6aTWpe2mHF0DhL28WjdkO8LyGjs3zItPET4bMSeXU6T3ub4FPMw+mcOcbdGXQOAfmLcxofD23/5Bl9Z4AkFwqg==",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^24.9.0",
+        "execa": "^1.0.0",
+        "throat": "^4.0.0"
+      }
+    },
+    "jest-config": {
+      "version": "24.9.0",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-24.9.0.tgz",
+      "integrity": "sha512-RATtQJtVYQrp7fvWg6f5y3pEFj9I+H8sWw4aKxnDZ96mob5i5SD6ZEGWgMLXQ4LE8UurrjbdlLWdUeo+28QpfQ==",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.1.0",
+        "@jest/test-sequencer": "^24.9.0",
+        "@jest/types": "^24.9.0",
+        "babel-jest": "^24.9.0",
+        "chalk": "^2.0.1",
+        "glob": "^7.1.1",
+        "jest-environment-jsdom": "^24.9.0",
+        "jest-environment-node": "^24.9.0",
+        "jest-get-type": "^24.9.0",
+        "jest-jasmine2": "^24.9.0",
+        "jest-regex-util": "^24.3.0",
+        "jest-resolve": "^24.9.0",
+        "jest-util": "^24.9.0",
+        "jest-validate": "^24.9.0",
+        "micromatch": "^3.1.10",
+        "pretty-format": "^24.9.0",
+        "realpath-native": "^1.1.0"
+      }
+    },
+    "jest-diff": {
+      "version": "24.9.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-24.9.0.tgz",
+      "integrity": "sha512-qMfrTs8AdJE2iqrTp0hzh7kTd2PQWrsFyj9tORoKmu32xjPjeE4NyjVRDz8ybYwqS2ik8N4hsIpiVTyFeo2lBQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.1",
+        "diff-sequences": "^24.9.0",
+        "jest-get-type": "^24.9.0",
+        "pretty-format": "^24.9.0"
+      }
+    },
+    "jest-docblock": {
+      "version": "24.9.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-24.9.0.tgz",
+      "integrity": "sha512-F1DjdpDMJMA1cN6He0FNYNZlo3yYmOtRUnktrT9Q37njYzC5WEaDdmbynIgy0L/IvXvvgsG8OsqhLPXTpfmZAA==",
+      "dev": true,
+      "requires": {
+        "detect-newline": "^2.1.0"
+      }
+    },
+    "jest-each": {
+      "version": "24.9.0",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-24.9.0.tgz",
+      "integrity": "sha512-ONi0R4BvW45cw8s2Lrx8YgbeXL1oCQ/wIDwmsM3CqM/nlblNCPmnC3IPQlMbRFZu3wKdQ2U8BqM6lh3LJ5Bsog==",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^24.9.0",
+        "chalk": "^2.0.1",
+        "jest-get-type": "^24.9.0",
+        "jest-util": "^24.9.0",
+        "pretty-format": "^24.9.0"
+      }
+    },
+    "jest-environment-jsdom": {
+      "version": "24.9.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-24.9.0.tgz",
+      "integrity": "sha512-Zv9FV9NBRzLuALXjvRijO2351DRQeLYXtpD4xNvfoVFw21IOKNhZAEUKcbiEtjTkm2GsJ3boMVgkaR7rN8qetA==",
+      "dev": true,
+      "requires": {
+        "@jest/environment": "^24.9.0",
+        "@jest/fake-timers": "^24.9.0",
+        "@jest/types": "^24.9.0",
+        "jest-mock": "^24.9.0",
+        "jest-util": "^24.9.0",
+        "jsdom": "^11.5.1"
+      }
+    },
+    "jest-environment-node": {
+      "version": "24.9.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-24.9.0.tgz",
+      "integrity": "sha512-6d4V2f4nxzIzwendo27Tr0aFm+IXWa0XEUnaH6nU0FMaozxovt+sfRvh4J47wL1OvF83I3SSTu0XK+i4Bqe7uA==",
+      "dev": true,
+      "requires": {
+        "@jest/environment": "^24.9.0",
+        "@jest/fake-timers": "^24.9.0",
+        "@jest/types": "^24.9.0",
+        "jest-mock": "^24.9.0",
+        "jest-util": "^24.9.0"
+      }
+    },
+    "jest-get-type": {
+      "version": "24.9.0",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.9.0.tgz",
+      "integrity": "sha512-lUseMzAley4LhIcpSP9Jf+fTrQ4a1yHQwLNeeVa2cEmbCGeoZAtYPOIv8JaxLD/sUpKxetKGP+gsHl8f8TSj8Q==",
+      "dev": true
+    },
+    "jest-haste-map": {
+      "version": "24.9.0",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-24.9.0.tgz",
+      "integrity": "sha512-kfVFmsuWui2Sj1Rp1AJ4D9HqJwE4uwTlS/vO+eRUaMmd54BFpli2XhMQnPC2k4cHFVbB2Q2C+jtI1AGLgEnCjQ==",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^24.9.0",
+        "anymatch": "^2.0.0",
+        "fb-watchman": "^2.0.0",
+        "fsevents": "^1.2.7",
+        "graceful-fs": "^4.1.15",
+        "invariant": "^2.2.4",
+        "jest-serializer": "^24.9.0",
+        "jest-util": "^24.9.0",
+        "jest-worker": "^24.9.0",
+        "micromatch": "^3.1.10",
+        "sane": "^4.0.3",
+        "walker": "^1.0.7"
+      }
+    },
+    "jest-jasmine2": {
+      "version": "24.9.0",
+      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-24.9.0.tgz",
+      "integrity": "sha512-Cq7vkAgaYKp+PsX+2/JbTarrk0DmNhsEtqBXNwUHkdlbrTBLtMJINADf2mf5FkowNsq8evbPc07/qFO0AdKTzw==",
+      "dev": true,
+      "requires": {
+        "@babel/traverse": "^7.1.0",
+        "@jest/environment": "^24.9.0",
+        "@jest/test-result": "^24.9.0",
+        "@jest/types": "^24.9.0",
+        "chalk": "^2.0.1",
+        "co": "^4.6.0",
+        "expect": "^24.9.0",
+        "is-generator-fn": "^2.0.0",
+        "jest-each": "^24.9.0",
+        "jest-matcher-utils": "^24.9.0",
+        "jest-message-util": "^24.9.0",
+        "jest-runtime": "^24.9.0",
+        "jest-snapshot": "^24.9.0",
+        "jest-util": "^24.9.0",
+        "pretty-format": "^24.9.0",
+        "throat": "^4.0.0"
+      }
+    },
+    "jest-leak-detector": {
+      "version": "24.9.0",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-24.9.0.tgz",
+      "integrity": "sha512-tYkFIDsiKTGwb2FG1w8hX9V0aUb2ot8zY/2nFg087dUageonw1zrLMP4W6zsRO59dPkTSKie+D4rhMuP9nRmrA==",
+      "dev": true,
+      "requires": {
+        "jest-get-type": "^24.9.0",
+        "pretty-format": "^24.9.0"
+      }
+    },
+    "jest-matcher-utils": {
+      "version": "24.9.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-24.9.0.tgz",
+      "integrity": "sha512-OZz2IXsu6eaiMAwe67c1T+5tUAtQyQx27/EMEkbFAGiw52tB9em+uGbzpcgYVpA8wl0hlxKPZxrly4CXU/GjHA==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.1",
+        "jest-diff": "^24.9.0",
+        "jest-get-type": "^24.9.0",
+        "pretty-format": "^24.9.0"
+      }
+    },
+    "jest-message-util": {
+      "version": "24.9.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-24.9.0.tgz",
+      "integrity": "sha512-oCj8FiZ3U0hTP4aSui87P4L4jC37BtQwUMqk+zk/b11FR19BJDeZsZAvIHutWnmtw7r85UmR3CEWZ0HWU2mAlw==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@jest/test-result": "^24.9.0",
+        "@jest/types": "^24.9.0",
+        "@types/stack-utils": "^1.0.1",
+        "chalk": "^2.0.1",
+        "micromatch": "^3.1.10",
+        "slash": "^2.0.0",
+        "stack-utils": "^1.0.1"
+      }
+    },
+    "jest-mock": {
+      "version": "24.9.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-24.9.0.tgz",
+      "integrity": "sha512-3BEYN5WbSq9wd+SyLDES7AHnjH9A/ROBwmz7l2y+ol+NtSFO8DYiEBzoO1CeFc9a8DYy10EO4dDFVv/wN3zl1w==",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^24.9.0"
+      }
+    },
+    "jest-pnp-resolver": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.1.tgz",
+      "integrity": "sha512-pgFw2tm54fzgYvc/OHrnysABEObZCUNFnhjoRjaVOCN8NYc032/gVjPaHD4Aq6ApkSieWtfKAFQtmDKAmhupnQ==",
+      "dev": true
+    },
+    "jest-regex-util": {
+      "version": "24.9.0",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-24.9.0.tgz",
+      "integrity": "sha512-05Cmb6CuxaA+Ys6fjr3PhvV3bGQmO+2p2La4hFbU+W5uOc479f7FdLXUWXw4pYMAhhSZIuKHwSXSu6CsSBAXQA==",
+      "dev": true
+    },
+    "jest-resolve": {
+      "version": "24.9.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-24.9.0.tgz",
+      "integrity": "sha512-TaLeLVL1l08YFZAt3zaPtjiVvyy4oSA6CRe+0AFPPVX3Q/VI0giIWWoAvoS5L96vj9Dqxj4fB5p2qrHCmTU/MQ==",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^24.9.0",
+        "browser-resolve": "^1.11.3",
+        "chalk": "^2.0.1",
+        "jest-pnp-resolver": "^1.2.1",
+        "realpath-native": "^1.1.0"
+      }
+    },
+    "jest-resolve-dependencies": {
+      "version": "24.9.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-24.9.0.tgz",
+      "integrity": "sha512-Fm7b6AlWnYhT0BXy4hXpactHIqER7erNgIsIozDXWl5dVm+k8XdGVe1oTg1JyaFnOxarMEbax3wyRJqGP2Pq+g==",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^24.9.0",
+        "jest-regex-util": "^24.3.0",
+        "jest-snapshot": "^24.9.0"
+      }
+    },
+    "jest-runner": {
+      "version": "24.9.0",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-24.9.0.tgz",
+      "integrity": "sha512-KksJQyI3/0mhcfspnxxEOBueGrd5E4vV7ADQLT9ESaCzz02WnbdbKWIf5Mkaucoaj7obQckYPVX6JJhgUcoWWg==",
+      "dev": true,
+      "requires": {
+        "@jest/console": "^24.7.1",
+        "@jest/environment": "^24.9.0",
+        "@jest/test-result": "^24.9.0",
+        "@jest/types": "^24.9.0",
+        "chalk": "^2.4.2",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.1.15",
+        "jest-config": "^24.9.0",
+        "jest-docblock": "^24.3.0",
+        "jest-haste-map": "^24.9.0",
+        "jest-jasmine2": "^24.9.0",
+        "jest-leak-detector": "^24.9.0",
+        "jest-message-util": "^24.9.0",
+        "jest-resolve": "^24.9.0",
+        "jest-runtime": "^24.9.0",
+        "jest-util": "^24.9.0",
+        "jest-worker": "^24.6.0",
+        "source-map-support": "^0.5.6",
+        "throat": "^4.0.0"
+      }
+    },
+    "jest-runtime": {
+      "version": "24.9.0",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-24.9.0.tgz",
+      "integrity": "sha512-8oNqgnmF3v2J6PVRM2Jfuj8oX3syKmaynlDMMKQ4iyzbQzIG6th5ub/lM2bCMTmoTKM3ykcUYI2Pw9xwNtjMnw==",
+      "dev": true,
+      "requires": {
+        "@jest/console": "^24.7.1",
+        "@jest/environment": "^24.9.0",
+        "@jest/source-map": "^24.3.0",
+        "@jest/transform": "^24.9.0",
+        "@jest/types": "^24.9.0",
+        "@types/yargs": "^13.0.0",
+        "chalk": "^2.0.1",
+        "exit": "^0.1.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.1.15",
+        "jest-config": "^24.9.0",
+        "jest-haste-map": "^24.9.0",
+        "jest-message-util": "^24.9.0",
+        "jest-mock": "^24.9.0",
+        "jest-regex-util": "^24.3.0",
+        "jest-resolve": "^24.9.0",
+        "jest-snapshot": "^24.9.0",
+        "jest-util": "^24.9.0",
+        "jest-validate": "^24.9.0",
+        "realpath-native": "^1.1.0",
+        "slash": "^2.0.0",
+        "strip-bom": "^3.0.0",
+        "yargs": "^13.3.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "cliui": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+          "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+          "dev": true,
+          "requires": {
+            "string-width": "^3.1.0",
+            "strip-ansi": "^5.2.0",
+            "wrap-ansi": "^5.1.0"
+          }
+        },
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
+          "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+          "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.0",
+            "string-width": "^3.0.0",
+            "strip-ansi": "^5.0.0"
+          }
+        },
+        "y18n": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+          "dev": true
+        },
+        "yargs": {
+          "version": "13.3.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.0.tgz",
+          "integrity": "sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==",
+          "dev": true,
+          "requires": {
+            "cliui": "^5.0.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^3.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^13.1.1"
+          }
+        }
+      }
+    },
+    "jest-serializer": {
+      "version": "24.9.0",
+      "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-24.9.0.tgz",
+      "integrity": "sha512-DxYipDr8OvfrKH3Kel6NdED3OXxjvxXZ1uIY2I9OFbGg+vUkkg7AGvi65qbhbWNPvDckXmzMPbK3u3HaDO49bQ==",
+      "dev": true
+    },
+    "jest-snapshot": {
+      "version": "24.9.0",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-24.9.0.tgz",
+      "integrity": "sha512-uI/rszGSs73xCM0l+up7O7a40o90cnrk429LOiK3aeTvfC0HHmldbd81/B7Ix81KSFe1lwkbl7GnBGG4UfuDew==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.0.0",
+        "@jest/types": "^24.9.0",
+        "chalk": "^2.0.1",
+        "expect": "^24.9.0",
+        "jest-diff": "^24.9.0",
+        "jest-get-type": "^24.9.0",
+        "jest-matcher-utils": "^24.9.0",
+        "jest-message-util": "^24.9.0",
+        "jest-resolve": "^24.9.0",
+        "mkdirp": "^0.5.1",
+        "natural-compare": "^1.4.0",
+        "pretty-format": "^24.9.0",
+        "semver": "^6.2.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
+    },
+    "jest-util": {
+      "version": "24.9.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-24.9.0.tgz",
+      "integrity": "sha512-x+cZU8VRmOJxbA1K5oDBdxQmdq0OIdADarLxk0Mq+3XS4jgvhG/oKGWcIDCtPG0HgjxOYvF+ilPJQsAyXfbNOg==",
+      "dev": true,
+      "requires": {
+        "@jest/console": "^24.9.0",
+        "@jest/fake-timers": "^24.9.0",
+        "@jest/source-map": "^24.9.0",
+        "@jest/test-result": "^24.9.0",
+        "@jest/types": "^24.9.0",
+        "callsites": "^3.0.0",
+        "chalk": "^2.0.1",
+        "graceful-fs": "^4.1.15",
+        "is-ci": "^2.0.0",
+        "mkdirp": "^0.5.1",
+        "slash": "^2.0.0",
+        "source-map": "^0.6.0"
+      },
+      "dependencies": {
+        "callsites": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+          "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+          "dev": true
+        }
+      }
+    },
+    "jest-validate": {
+      "version": "24.9.0",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-24.9.0.tgz",
+      "integrity": "sha512-HPIt6C5ACwiqSiwi+OfSSHbK8sG7akG8eATl+IPKaeIjtPOeBUd/g3J7DghugzxrGjI93qS/+RPKe1H6PqvhRQ==",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^24.9.0",
+        "camelcase": "^5.3.1",
+        "chalk": "^2.0.1",
+        "jest-get-type": "^24.9.0",
+        "leven": "^3.1.0",
+        "pretty-format": "^24.9.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+          "dev": true
+        }
+      }
+    },
+    "jest-watcher": {
+      "version": "24.9.0",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-24.9.0.tgz",
+      "integrity": "sha512-+/fLOfKPXXYJDYlks62/4R4GoT+GU1tYZed99JSCOsmzkkF7727RqKrjNAxtfO4YpGv11wybgRvCjR73lK2GZw==",
+      "dev": true,
+      "requires": {
+        "@jest/test-result": "^24.9.0",
+        "@jest/types": "^24.9.0",
+        "@types/yargs": "^13.0.0",
+        "ansi-escapes": "^3.0.0",
+        "chalk": "^2.0.1",
+        "jest-util": "^24.9.0",
+        "string-length": "^2.0.0"
+      }
+    },
+    "jest-worker": {
+      "version": "24.9.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-24.9.0.tgz",
+      "integrity": "sha512-51PE4haMSXcHohnSMdM42anbvZANYTqMrr52tVKPqqsPJMzoP6FYYDVqahX/HrAoKEKz3uUPzSvKs9A3qR4iVw==",
+      "dev": true,
+      "requires": {
+        "merge-stream": "^2.0.0",
+        "supports-color": "^6.1.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -1403,10 +4364,62 @@
         "esprima": "^4.0.0"
       }
     },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true
+    },
+    "jsdom": {
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.12.0.tgz",
+      "integrity": "sha512-y8Px43oyiBM13Zc1z780FrfNLJCXTL40EWlty/LXUtcjykRBNgLlCjWXpfSPBl2iv+N7koQN+dvqszHZgT/Fjw==",
+      "dev": true,
+      "requires": {
+        "abab": "^2.0.0",
+        "acorn": "^5.5.3",
+        "acorn-globals": "^4.1.0",
+        "array-equal": "^1.0.0",
+        "cssom": ">= 0.3.2 < 0.4.0",
+        "cssstyle": "^1.0.0",
+        "data-urls": "^1.0.0",
+        "domexception": "^1.0.1",
+        "escodegen": "^1.9.1",
+        "html-encoding-sniffer": "^1.0.2",
+        "left-pad": "^1.3.0",
+        "nwsapi": "^2.0.7",
+        "parse5": "4.0.0",
+        "pn": "^1.1.0",
+        "request": "^2.87.0",
+        "request-promise-native": "^1.0.5",
+        "sax": "^1.2.4",
+        "symbol-tree": "^3.2.2",
+        "tough-cookie": "^2.3.4",
+        "w3c-hr-time": "^1.0.1",
+        "webidl-conversions": "^4.0.2",
+        "whatwg-encoding": "^1.0.3",
+        "whatwg-mimetype": "^2.1.0",
+        "whatwg-url": "^6.4.1",
+        "ws": "^5.2.0",
+        "xml-name-validator": "^3.0.0"
+      }
+    },
+    "jsesc": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "dev": true
+    },
     "json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "dev": true
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
       "dev": true
     },
     "json-schema-traverse": {
@@ -1427,6 +4440,47 @@
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
+    "json5": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
+      "integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      }
+    },
+    "kind-of": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+      "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+      "dev": true
+    },
+    "kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "dev": true
+    },
     "lcid": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
@@ -1434,6 +4488,18 @@
       "requires": {
         "invert-kv": "^1.0.0"
       }
+    },
+    "left-pad": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
+      "integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==",
+      "dev": true
+    },
+    "leven": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+      "dev": true
     },
     "levn": {
       "version": "0.3.0",
@@ -1468,15 +4534,36 @@
       }
     },
     "lodash": {
-      "version": "4.17.14",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
-      "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==",
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "dev": true
+    },
+    "lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+      "dev": true
+    },
+    "lodash.unescape": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.1.tgz",
+      "integrity": "sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=",
       "dev": true
     },
     "long": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
       "integrity": "sha1-2CG3E4yhy1gcFymQ7xTbIAtcR0s="
+    },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "requires": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      }
     },
     "lru-cache": {
       "version": "4.1.5",
@@ -1488,10 +4575,79 @@
         "yallist": "^2.1.2"
       }
     },
+    "make-dir": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+      "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+      "dev": true,
+      "requires": {
+        "pify": "^4.0.1",
+        "semver": "^5.6.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+          "dev": true
+        }
+      }
+    },
+    "makeerror": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
+      "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
+      "dev": true,
+      "requires": {
+        "tmpl": "1.0.x"
+      }
+    },
+    "map-cache": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+      "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+      "dev": true
+    },
+    "map-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+      "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+      "dev": true,
+      "requires": {
+        "object-visit": "^1.0.0"
+      }
+    },
+    "merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true
+    },
     "methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
+    },
+    "micromatch": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+      "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+      "dev": true,
+      "requires": {
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "braces": "^2.3.1",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "extglob": "^2.0.4",
+        "fragment-cache": "^0.2.1",
+        "kind-of": "^6.0.2",
+        "nanomatch": "^1.2.9",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.2"
+      }
     },
     "mime": {
       "version": "1.6.0",
@@ -1531,6 +4687,27 @@
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true
     },
+    "mixin-deep": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+      "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
+      "dev": true,
+      "requires": {
+        "for-in": "^1.0.2",
+        "is-extendable": "^1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "^2.0.4"
+          }
+        }
+      }
+    },
     "mkdirp": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
@@ -1538,76 +4715,6 @@
       "dev": true,
       "requires": {
         "minimist": "0.0.8"
-      }
-    },
-    "mocha": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.0.5.tgz",
-      "integrity": "sha512-3MM3UjZ5p8EJrYpG7s+29HAI9G7sTzKEe4+w37Dg0QP7qL4XGsV+Q2xet2cE37AqdgN1OtYQB6Vl98YiPV3PgA==",
-      "dev": true,
-      "requires": {
-        "browser-stdout": "1.3.1",
-        "commander": "2.11.0",
-        "debug": "3.1.0",
-        "diff": "3.5.0",
-        "escape-string-regexp": "1.0.5",
-        "glob": "7.1.2",
-        "growl": "1.10.3",
-        "he": "1.1.1",
-        "mkdirp": "0.5.1",
-        "supports-color": "4.4.0"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.11.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-          "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
-          "dev": true
-        },
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "glob": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "has-flag": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
-          "dev": true
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "4.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^2.0.0"
-          }
-        }
       }
     },
     "ms": {
@@ -1620,6 +4727,32 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
+    },
+    "nan": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
+      "dev": true,
+      "optional": true
+    },
+    "nanomatch": {
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
+      "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
+      "dev": true,
+      "requires": {
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "fragment-cache": "^0.2.1",
+        "is-windows": "^1.0.2",
+        "kind-of": "^6.0.2",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      }
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -1654,37 +4787,6 @@
         "propagate": "^1.0.0",
         "qs": "^6.5.1",
         "semver": "^5.5.0"
-      },
-      "dependencies": {
-        "chai": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
-          "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
-          "dev": true,
-          "requires": {
-            "assertion-error": "^1.1.0",
-            "check-error": "^1.0.2",
-            "deep-eql": "^3.0.1",
-            "get-func-name": "^2.0.0",
-            "pathval": "^1.1.0",
-            "type-detect": "^4.0.5"
-          }
-        },
-        "deep-eql": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-          "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
-          "dev": true,
-          "requires": {
-            "type-detect": "^4.0.0"
-          }
-        },
-        "type-detect": {
-          "version": "4.0.8",
-          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-          "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-          "dev": true
-        }
       }
     },
     "node-forge": {
@@ -1692,21 +4794,37 @@
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.6.tgz",
       "integrity": "sha512-sol30LUpz1jQFBjOKwbjxijiE3b6pjd74YwfD0fJOKPjF+fONKb2Yg8rYgS6+bK6VDl+/wfr4IYpC7jDzLUIfw=="
     },
+    "node-int64": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+      "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
+      "dev": true
+    },
+    "node-modules-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
+      "integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=",
+      "dev": true
+    },
+    "node-notifier": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.3.tgz",
+      "integrity": "sha512-M4UBGcs4jeOK9CjTsYwkvH6/MzuUmGCyTW+kCY7uO+1ZVr0+FHGdPdIf5CCLqAaxnRrWidyoQlNkMIIVwbKB8Q==",
+      "dev": true,
+      "requires": {
+        "growly": "^1.3.0",
+        "is-wsl": "^1.1.0",
+        "semver": "^5.5.0",
+        "shellwords": "^0.1.1",
+        "which": "^1.3.0"
+      }
+    },
     "node-rsa": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/node-rsa/-/node-rsa-1.0.5.tgz",
       "integrity": "sha512-9o51yfV167CtQANnuAf+5owNs7aIMsAKVLhNaKuRxihsUUnfoBMN5OTVOK/2mHSOWaWq9zZBiRM3bHORbTZqrg==",
       "requires": {
         "asn1": "^0.2.4"
-      }
-    },
-    "nopt": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-      "dev": true,
-      "requires": {
-        "abbrev": "1"
       }
     },
     "normalize-package-data": {
@@ -1719,6 +4837,15 @@
         "resolve": "^1.10.0",
         "semver": "2 || 3 || 4 || 5",
         "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "normalize-path": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+      "dev": true,
+      "requires": {
+        "remove-trailing-separator": "^1.0.1"
       }
     },
     "npm-run-path": {
@@ -1735,11 +4862,100 @@
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
+    "nwsapi": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.1.4.tgz",
+      "integrity": "sha512-iGfd9Y6SFdTNldEy2L0GUhcarIutFmk+MPWIn9dmj8NMIup03G08uUF2KGbbmv/Ux4RT0VZJoP/sVbWA6d/VIw==",
+      "dev": true
+    },
+    "oauth-sign": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+      "dev": true
+    },
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "dev": true
+    },
+    "object-copy": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+      "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+      "dev": true,
+      "requires": {
+        "copy-descriptor": "^0.1.0",
+        "define-property": "^0.2.5",
+        "kind-of": "^3.0.3"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "object-inspect": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
+      "integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==",
+      "dev": true
+    },
+    "object-is": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.1.tgz",
+      "integrity": "sha1-CqYOyZiaCz7Xlc9NBvYs8a1lObY=",
+      "dev": true
+    },
+    "object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true
+    },
+    "object-visit": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+      "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+      "dev": true,
+      "requires": {
+        "isobject": "^3.0.0"
+      }
+    },
+    "object.getownpropertydescriptors": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
+      "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.5.1"
+      }
+    },
+    "object.pick": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+      "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+      "dev": true,
+      "requires": {
+        "isobject": "^3.0.1"
+      }
     },
     "once": {
       "version": "1.4.0",
@@ -1809,6 +5025,15 @@
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
+    "p-each-series": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-1.0.0.tgz",
+      "integrity": "sha1-kw89Et0fUOdDRFeiLNbwSsatf3E=",
+      "dev": true,
+      "requires": {
+        "p-reduce": "^1.0.0"
+      }
+    },
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
@@ -1833,6 +5058,12 @@
         "p-limit": "^1.1.0"
       }
     },
+    "p-reduce": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-1.0.0.tgz",
+      "integrity": "sha1-GMKw3ZNqRpClKfgjH1ig/bakffo=",
+      "dev": true
+    },
     "p-try": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
@@ -1847,6 +5078,18 @@
       "requires": {
         "error-ex": "^1.2.0"
       }
+    },
+    "parse5": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
+      "integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==",
+      "dev": true
+    },
+    "pascalcase": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+      "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+      "dev": true
     },
     "path-exists": {
       "version": "3.0.0",
@@ -1892,11 +5135,26 @@
       "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
       "dev": true
     },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "dev": true
+    },
     "pify": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
       "dev": true
+    },
+    "pirates": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.1.tgz",
+      "integrity": "sha512-WuNqLTbMI3tmfef2TKxlQmAiLHKtFhlsCZnPIpuv2Ow0RDVO8lfy1Opf4NUzlMXLjPl+Men7AuVdX6TA+s+uGA==",
+      "dev": true,
+      "requires": {
+        "node-modules-regexp": "^1.0.0"
+      }
     },
     "pkg-dir": {
       "version": "2.0.0",
@@ -1908,9 +5166,9 @@
       }
     },
     "please-upgrade-node": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.1.1.tgz",
-      "integrity": "sha512-KY1uHnQ2NlQHqIJQpnh/i54rKkuxCEBx+voJIS/Mvb+L2iYd2NMotwduhKTMjfC1uKoX3VXOxLjIYG66dfJTVQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz",
+      "integrity": "sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==",
       "dev": true,
       "requires": {
         "semver-compare": "^1.0.0"
@@ -1922,11 +5180,52 @@
       "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
       "dev": true
     },
+    "pn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
+      "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
+      "dev": true
+    },
+    "posix-character-classes": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+      "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+      "dev": true
+    },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
+    },
+    "pretty-format": {
+      "version": "24.9.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.9.0.tgz",
+      "integrity": "sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^24.9.0",
+        "ansi-regex": "^4.0.0",
+        "ansi-styles": "^3.2.0",
+        "react-is": "^16.8.4"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        }
+      }
     },
     "process-nextick-args": {
       "version": "2.0.1",
@@ -1938,6 +5237,16 @@
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
+    },
+    "prompts": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.2.1.tgz",
+      "integrity": "sha512-VObPvJiWPhpZI6C5m60XOzTfnYg/xc/an+r9VYymj9WJW3B/DIH+REzjpAACPf8brwPeP+7vz3bIim3S+AaMjw==",
+      "dev": true,
+      "requires": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.3"
+      }
     },
     "propagate": {
       "version": "1.0.0",
@@ -1962,6 +5271,12 @@
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
       "dev": true
     },
+    "psl": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.4.0.tgz",
+      "integrity": "sha512-HZzqCGPecFLyoRj5HLfuDSKYTJkAfB5thKBIkRHtGjWwY7p1dAyveIbXIq4tO0KYfDF2tHqPUgY9SDnGm00uFw==",
+      "dev": true
+    },
     "pump": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -1972,10 +5287,22 @@
         "once": "^1.3.1"
       }
     },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
+    },
     "qs": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
-      "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.8.0.tgz",
+      "integrity": "sha512-tPSkj8y92PfZVbinY1n84i1Qdx75lZjMQYx9WZhnkofyxzw2r7Ho39G3/aEvSUdebxpnnM4LZJCtvE/Aq3+s9w=="
+    },
+    "react-is": {
+      "version": "16.9.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.9.0.tgz",
+      "integrity": "sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw==",
+      "dev": true
     },
     "read-pkg": {
       "version": "2.0.0",
@@ -2019,10 +5346,151 @@
         }
       }
     },
+    "realpath-native": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.1.0.tgz",
+      "integrity": "sha512-wlgPA6cCIIg9gKz0fgAPjnzh4yR/LnXovwuo9hvyGvx3h8nX4+/iLZplfUWasXpqD8BdnGnP5njOFjkUwPzvjA==",
+      "dev": true,
+      "requires": {
+        "util.promisify": "^1.0.0"
+      }
+    },
+    "regex-not": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+      "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^3.0.2",
+        "safe-regex": "^1.1.0"
+      }
+    },
+    "regexp.prototype.flags": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.2.0.tgz",
+      "integrity": "sha512-ztaw4M1VqgMwl9HlPpOuiYgItcHlunW0He2fE6eNfT6E/CF2FtYi9ofOYe4mKntstYk0Fyh/rDRBdS3AnxjlrA==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2"
+      }
+    },
     "regexpp": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
       "integrity": "sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw==",
+      "dev": true
+    },
+    "remove-trailing-separator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+      "dev": true
+    },
+    "repeat-element": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
+      "integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==",
+      "dev": true
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true
+    },
+    "request": {
+      "version": "2.88.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+      "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+      "dev": true,
+      "requires": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.0",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.4.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+          "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+          "dev": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+          "dev": true
+        },
+        "qs": {
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+          "dev": true
+        },
+        "tough-cookie": {
+          "version": "2.4.3",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+          "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+          "dev": true,
+          "requires": {
+            "psl": "^1.1.24",
+            "punycode": "^1.4.1"
+          }
+        }
+      }
+    },
+    "request-promise-core": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.2.tgz",
+      "integrity": "sha512-UHYyq1MO8GsefGEt7EprS8UrXsm1TxEvFUX1IMTuSLU2Rh7fTIdFtl8xD7JiEYiWU2dl+NYAjCTksTehQUxPag==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.11"
+      }
+    },
+    "request-promise-native": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.7.tgz",
+      "integrity": "sha512-rIMnbBdgNViL37nZ1b3L/VfPOpSi0TqVDQPAvO6U14lMzOLrt5nilxCQqtDKhZeDiW0/hkCXGoQjhgJd/tCh6w==",
+      "dev": true,
+      "requires": {
+        "request-promise-core": "1.1.2",
+        "stealthy-require": "^1.1.1",
+        "tough-cookie": "^2.3.3"
+      }
+    },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true
+    },
+    "require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true
     },
     "require-uncached": {
@@ -2036,18 +5504,41 @@
       }
     },
     "resolve": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
-      "integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
+      "integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
       "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
+      }
+    },
+    "resolve-cwd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
+      "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
+      "dev": true,
+      "requires": {
+        "resolve-from": "^3.0.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+          "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+          "dev": true
+        }
       }
     },
     "resolve-from": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
       "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+      "dev": true
+    },
+    "resolve-url": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
       "dev": true
     },
     "restore-cursor": {
@@ -2060,6 +5551,12 @@
         "signal-exit": "^3.0.2"
       }
     },
+    "ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "dev": true
+    },
     "rimraf": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
@@ -2068,6 +5565,12 @@
       "requires": {
         "glob": "^7.1.3"
       }
+    },
+    "rsvp": {
+      "version": "4.8.5",
+      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
+      "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
+      "dev": true
     },
     "run-async": {
       "version": "2.3.0",
@@ -2104,15 +5607,55 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
       "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
     },
+    "safe-regex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+      "dev": true,
+      "requires": {
+        "ret": "~0.1.10"
+      }
+    },
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
+    "sane": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/sane/-/sane-4.1.0.tgz",
+      "integrity": "sha512-hhbzAgTIX8O7SHfp2c8/kREfEn4qO/9q8C9beyY6+tvZ87EpoZ3i1RIEvp27YBswnNbY9mWd6paKVmKbAgLfZA==",
+      "dev": true,
+      "requires": {
+        "@cnakazawa/watch": "^1.0.3",
+        "anymatch": "^2.0.0",
+        "capture-exit": "^2.0.0",
+        "exec-sh": "^0.3.2",
+        "execa": "^1.0.0",
+        "fb-watchman": "^2.0.0",
+        "micromatch": "^3.1.4",
+        "minimist": "^1.1.1",
+        "walker": "~1.0.5"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+      "dev": true
+    },
     "semver": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
       "dev": true
     },
     "semver-compare": {
@@ -2120,6 +5663,35 @@
       "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
       "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
       "dev": true
+    },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true
+    },
+    "set-value": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+      "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^2.0.1",
+        "is-extendable": "^0.1.1",
+        "is-plain-object": "^2.0.3",
+        "split-string": "^3.0.1"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
+      }
     },
     "shebang-command": {
       "version": "1.2.0",
@@ -2136,10 +5708,22 @@
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
     },
+    "shellwords": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
+      "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
+      "dev": true
+    },
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "dev": true
+    },
+    "sisteransi": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.3.tgz",
+      "integrity": "sha512-SbEG75TzH8G7eVXFSN5f9EExILKfly7SUvVY5DhhYLvfhKqhDFY0OzevWa/zwak0RLRfWS5AvfMWpd9gJvr5Yg==",
       "dev": true
     },
     "slash": {
@@ -2165,15 +5749,168 @@
         }
       }
     },
-    "source-map": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
-      "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
+    "snapdragon": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+      "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
       "dev": true,
-      "optional": true,
       "requires": {
-        "amdefine": ">=0.0.4"
+        "base": "^0.11.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "map-cache": "^0.2.2",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
       }
+    },
+    "snapdragon-node": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+      "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+      "dev": true,
+      "requires": {
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.0",
+        "snapdragon-util": "^3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
+    "snapdragon-util": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+      "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.2.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true
+    },
+    "source-map-resolve": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
+      "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
+      "dev": true,
+      "requires": {
+        "atob": "^2.1.1",
+        "decode-uri-component": "^0.2.0",
+        "resolve-url": "^0.2.1",
+        "source-map-url": "^0.4.0",
+        "urix": "^0.1.0"
+      }
+    },
+    "source-map-support": {
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "source-map-url": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+      "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+      "dev": true
     },
     "spdx-correct": {
       "version": "3.1.0",
@@ -2207,11 +5944,97 @@
       "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
       "dev": true
     },
+    "split-string": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^3.0.0"
+      }
+    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
+    },
+    "sshpk": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+      "dev": true,
+      "requires": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      }
+    },
+    "stack-utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.2.tgz",
+      "integrity": "sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==",
+      "dev": true
+    },
+    "static-extend": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+      "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+      "dev": true,
+      "requires": {
+        "define-property": "^0.2.5",
+        "object-copy": "^0.1.0"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        }
+      }
+    },
+    "stealthy-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
+      "dev": true
+    },
+    "string-length": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
+      "integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
+      "dev": true,
+      "requires": {
+        "astral-regex": "^1.0.0",
+        "strip-ansi": "^4.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
+      }
     },
     "string-width": {
       "version": "1.0.2",
@@ -2221,6 +6044,26 @@
         "code-point-at": "^1.0.0",
         "is-fullwidth-code-point": "^1.0.0",
         "strip-ansi": "^3.0.0"
+      }
+    },
+    "string.prototype.trimleft": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.0.tgz",
+      "integrity": "sha512-FJ6b7EgdKxxbDxc79cOlok6Afd++TTs5szo+zJTUyow3ycrRfJVE2pq3vcN53XexvKZu/DJMDfeI/qMiZTrjTw==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "function-bind": "^1.1.1"
+      }
+    },
+    "string.prototype.trimright": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.0.tgz",
+      "integrity": "sha512-fXZTSV55dNBwv16uw+hh5jkghxSnc5oHq+5K/gXgizHwAvMetdAJlHqqoFC1FSDVPYWLkAKl2cxpUT41sV7nSg==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "function-bind": "^1.1.1"
       }
     },
     "string_decoder": {
@@ -2287,6 +6130,12 @@
       "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
       "dev": true
     },
+    "symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true
+    },
     "table": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
@@ -2334,10 +6183,131 @@
         }
       }
     },
+    "test-exclude": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.2.3.tgz",
+      "integrity": "sha512-M+oxtseCFO3EDtAaGH7iiej3CBkzXqFMbzqYAACdzKui4eZA+pq3tZEwChvOdNfa7xxy8BfbmgJSIr43cC/+2g==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3",
+        "minimatch": "^3.0.4",
+        "read-pkg-up": "^4.0.0",
+        "require-main-filename": "^2.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "load-json-file": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+          "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^4.0.0",
+            "pify": "^3.0.0",
+            "strip-bom": "^3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
+          "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
+        },
+        "parse-json": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
+          }
+        },
+        "path-type": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+          "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+          "dev": true,
+          "requires": {
+            "pify": "^3.0.0"
+          }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        },
+        "read-pkg": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+          "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "^4.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^3.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
+          "integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
+          "dev": true,
+          "requires": {
+            "find-up": "^3.0.0",
+            "read-pkg": "^3.0.0"
+          }
+        }
+      }
+    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
+    "throat": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",
+      "integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=",
       "dev": true
     },
     "through": {
@@ -2355,6 +6325,100 @@
         "os-tmpdir": "~1.0.2"
       }
     },
+    "tmpl": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
+      "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
+      "dev": true
+    },
+    "to-fast-properties": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+      "dev": true
+    },
+    "to-object-path": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+      "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "to-regex": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+      "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+      "dev": true,
+      "requires": {
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "regex-not": "^1.0.2",
+        "safe-regex": "^1.1.0"
+      }
+    },
+    "to-regex-range": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+      "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+      "dev": true,
+      "requires": {
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1"
+      }
+    },
+    "tough-cookie": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+      "dev": true,
+      "requires": {
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
+      }
+    },
+    "tr46": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+      "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "trim-right": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+      "dev": true
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "dev": true
+    },
     "type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
@@ -2365,9 +6429,9 @@
       }
     },
     "type-detect": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
-      "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "dev": true
     },
     "typedarray": {
@@ -2385,26 +6449,100 @@
       "requires": {
         "commander": "~2.20.0",
         "source-map": "~0.6.1"
+      }
+    },
+    "union-value": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+      "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
+      "dev": true,
+      "requires": {
+        "arr-union": "^3.1.0",
+        "get-value": "^2.0.6",
+        "is-extendable": "^0.1.1",
+        "set-value": "^2.0.1"
+      }
+    },
+    "unset-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+      "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+      "dev": true,
+      "requires": {
+        "has-value": "^0.3.1",
+        "isobject": "^3.0.0"
       },
       "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+        "has-value": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+          "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
           "dev": true,
-          "optional": true
+          "requires": {
+            "get-value": "^2.0.3",
+            "has-values": "^0.1.4",
+            "isobject": "^2.0.0"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+              "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+              "dev": true,
+              "requires": {
+                "isarray": "1.0.0"
+              }
+            }
+          }
+        },
+        "has-values": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+          "dev": true
         }
       }
+    },
+    "uri-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "urix": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+      "dev": true
+    },
+    "use": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
+      "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
+      "dev": true
     },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
+    "util.promisify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
+      "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "object.getownpropertydescriptors": "^2.0.3"
+      }
+    },
     "uuid": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
+      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ=="
     },
     "validate-npm-package-license": {
       "version": "3.0.4",
@@ -2416,6 +6554,67 @@
         "spdx-expression-parse": "^3.0.0"
       }
     },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      }
+    },
+    "w3c-hr-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
+      "integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
+      "dev": true,
+      "requires": {
+        "browser-process-hrtime": "^0.1.2"
+      }
+    },
+    "walker": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
+      "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
+      "dev": true,
+      "requires": {
+        "makeerror": "1.0.x"
+      }
+    },
+    "webidl-conversions": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+      "dev": true
+    },
+    "whatwg-encoding": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
+      "integrity": "sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==",
+      "dev": true,
+      "requires": {
+        "iconv-lite": "0.4.24"
+      }
+    },
+    "whatwg-mimetype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
+      "integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==",
+      "dev": true
+    },
+    "whatwg-url": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
+      "integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
+      "dev": true,
+      "requires": {
+        "lodash.sortby": "^4.7.0",
+        "tr46": "^1.0.1",
+        "webidl-conversions": "^4.0.2"
+      }
+    },
     "which": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
@@ -2424,6 +6623,12 @@
       "requires": {
         "isexe": "^2.0.0"
       }
+    },
+    "which-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+      "dev": true
     },
     "window-size": {
       "version": "0.1.4",
@@ -2459,6 +6664,32 @@
         "mkdirp": "^0.5.1"
       }
     },
+    "write-file-atomic": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.1.tgz",
+      "integrity": "sha512-TGHFeZEZMnv+gBFRfjAcxL5bPHrsGKtnb4qsFAws7/vlh+QfwAaySIw4AXP9ZskTTh5GWu3FLuJhsWVdiJPGvg==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.11",
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "ws": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
+      "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
+      "dev": true,
+      "requires": {
+        "async-limiter": "~1.0.0"
+      }
+    },
+    "xml-name-validator": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
+      "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
+      "dev": true
+    },
     "y18n": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
@@ -2482,6 +6713,24 @@
         "string-width": "^1.0.1",
         "window-size": "^0.1.4",
         "y18n": "^3.2.0"
+      }
+    },
+    "yargs-parser": {
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
+      "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+          "dev": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -13,13 +13,24 @@
   },
   "scripts": {
     "lint": "node_modules/.bin/eslint *.js './src/**/*.js' './tests/**/*.spec.js' config/*.js",
-    "unit-test": "node_modules/.bin/jest --verbose",
+    "unit-test": "node_modules/.bin/jest",
     "test": "npm run lint && npm run unit-test"
   },
   "husky": {
     "hooks": {
       "pre-commit": "npm run test"
     }
+  },
+  "jest": {
+    "verbose": true,
+    "collectCoverage": true,
+    "collectCoverageFrom": [
+      "./*.js",
+      "./src/**/*.js",
+      "!**/node_modules/**",
+      "!**/vendor/**"
+    ],
+    "coverageDirectory": "./coverage"
   },
   "dependencies": {
     "base64-url": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -42,10 +42,10 @@
     "uuid": "^3.3.2"
   },
   "devDependencies": {
-    "eslint": "4.19.1",
-    "eslint-config-airbnb-base": "12.1.0",
-    "eslint-plugin-import": "2.9.0",
-    "eslint-plugin-jest": "^22.17.0",
+    "eslint": "^4.19.1",
+    "eslint-config-airbnb-base": "^12.1.0",
+    "eslint-plugin-import": "^2.18.2",
+    "eslint-plugin-jest": "^21.27.2",
     "eslint-plugin-node": "6.0.1",
     "husky": "^1.3.1",
     "jest": "^24.9.0",

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "node": ">=8.0.0"
   },
   "scripts": {
-    "lint": "node_modules/.bin/eslint *.js \"./src/**/*.js\" \"./tests/**/*.spec.js\" config/*.js",
-    "unit-test": "node_modules/.bin/istanbul cover node_modules/.bin/mocha \"./tests/**/*.spec.js\"",
+    "lint": "node_modules/.bin/eslint *.js './src/**/*.js' './tests/**/*.spec.js' config/*.js",
+    "unit-test": "node_modules/.bin/jest --verbose",
     "test": "npm run lint && npm run unit-test"
   },
   "husky": {
@@ -31,14 +31,13 @@
     "uuid": "^3.3.2"
   },
   "devDependencies": {
-    "chai": "3.5.0",
     "eslint": "4.19.1",
     "eslint-config-airbnb-base": "12.1.0",
     "eslint-plugin-import": "2.9.0",
+    "eslint-plugin-jest": "^22.17.0",
     "eslint-plugin-node": "6.0.1",
     "husky": "^1.3.1",
-    "istanbul": "0.4.5",
-    "mocha": "5.0.5",
+    "jest": "^24.9.0",
     "nock": "^9.6.1"
   }
 }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey = yoti-web-sdk:node
 sonar.projectName = node-sdk
 sonar.projectVersion = 3.6.0
-sonar.exclusions=tests/**,examples/**
+sonar.exclusions=tests/**,examples/**,node_modules/**
 sonar.javascript.lcov.reportPaths=coverage/lcov.info
 sonar.verbose = true

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey = yoti-web-sdk:node
 sonar.projectName = node-sdk
-sonar.projectVersion = 3.6.0
-sonar.exclusions=tests/**,examples/**,node_modules/**
+sonar.projectVersion = 3.7.0
+sonar.exclusions=tests/**,examples/**,node_modules/**,coverage/**
 sonar.javascript.lcov.reportPaths=coverage/lcov.info
 sonar.verbose = true

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,5 @@
+sonar.projectKey = yoti-web-sdk:node
+sonar.projectName = node-sdk
+sonar.exclusions=tests/**,examples/**
+sonar.python.pylint.reportPath=coverage/clover.xml
+sonar.verbose = true

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,6 @@
 sonar.projectKey = yoti-web-sdk:node
 sonar.projectName = node-sdk
+sonar.projectVersion = 3.6.0
 sonar.exclusions=tests/**,examples/**
-sonar.python.pylint.reportPath=coverage/clover.xml
+sonar.javascript.lcov.reportPaths=coverage/clover.xml
 sonar.verbose = true

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,5 +2,5 @@ sonar.projectKey = yoti-web-sdk:node
 sonar.projectName = node-sdk
 sonar.projectVersion = 3.6.0
 sonar.exclusions=tests/**,examples/**
-sonar.javascript.lcov.reportPaths=coverage/clover.xml
+sonar.javascript.lcov.reportPaths=coverage/lcov.info
 sonar.verbose = true

--- a/src/receipt.js
+++ b/src/receipt.js
@@ -1,8 +1,0 @@
-'use strict';
-
-const receipt = {};
-
-module.export.withWrappedReceiptKey = (wrappedReceiptKey) => {
-  receipt.wrapped_receipt_key = wrappedReceiptKey;
-  return receipt;
-};

--- a/tests/aml_service/index.spec.js
+++ b/tests/aml_service/index.spec.js
@@ -1,4 +1,3 @@
-const expect = require('chai').expect;
 const nock = require('nock');
 const fs = require('fs');
 
@@ -21,7 +20,7 @@ describe('amlService', () => {
       done();
     });
 
-    context('with a valid profile', () => {
+    describe('with a valid profile', () => {
       const amlCheckResult = fs.readFileSync('./tests/sample-data/responses/aml-check-result.json', 'utf8');
 
       beforeEach((done) => {
@@ -34,9 +33,9 @@ describe('amlService', () => {
       it('should return a successful result from performAmlCheck call', (done) => {
         amlService.performAmlCheck(amlProfile, privateKeyFile, 'stub-app-id')
           .then((amlResult) => {
-            expect(amlResult.isOnPepList).to.equal(true);
-            expect(amlResult.isOnFraudList).to.equal(false);
-            expect(amlResult.isOnWatchList).to.equal(false);
+            expect(amlResult.isOnPepList).toBe(true);
+            expect(amlResult.isOnFraudList).toBe(false);
+            expect(amlResult.isOnWatchList).toBe(false);
 
             done();
           })
@@ -44,7 +43,7 @@ describe('amlService', () => {
       });
     });
 
-    context('with an invalid profile response', () => {
+    describe('with an invalid profile response', () => {
       const amlCheckError = fs.readFileSync('./tests/sample-data/responses/aml-check-error.json', 'utf8');
       const expectedErrorMessage = 'PAYLOAD_VALIDATION - There were errors validating the payload: [{"property":"address.country","message":"country must be specified as an ISO-3166 3-letter code"}]';
 
@@ -59,7 +58,7 @@ describe('amlService', () => {
       it('should return PAYLOAD_VALIDATION error', (done) => {
         amlService.performAmlCheck(amlProfile, privateKeyFile, 'stub-app-id')
           .catch((err) => {
-            expect(err.message).to.equal(expectedErrorMessage);
+            expect(err.message).toBe(expectedErrorMessage);
             done();
           })
           .catch(done);

--- a/tests/client/index.spec.js
+++ b/tests/client/index.spec.js
@@ -1,4 +1,3 @@
-const expect = require('chai').expect;
 const nock = require('nock');
 const fs = require('fs');
 
@@ -28,7 +27,7 @@ describe('yotiClient', () => {
   });
 
   describe('#getActivityDetails', () => {
-    context('when the profile has attributes', () => {
+    describe('when the profile has attributes', () => {
       const responseContent = fs.readFileSync('./tests/sample-data/payloads/payload.json', 'utf8');
 
       beforeEach((done) => {
@@ -46,28 +45,28 @@ describe('yotiClient', () => {
             const applicationProfile = activityDetails.getApplicationProfile();
             const outcome = activityDetails.getOutcome();
 
-            expect(activityDetails.getUserId()).to.equal(rememberMeId);
-            expect(activityDetails.getRememberMeId()).to.equal(rememberMeId);
-            expect(activityDetails.getParentRememberMeId()).to.equal(parentRememberMeId);
-            expect(activityDetails.getBase64SelfieUri()).to.equal(selfie);
+            expect(activityDetails.getUserId()).toBe(rememberMeId);
+            expect(activityDetails.getRememberMeId()).toBe(rememberMeId);
+            expect(activityDetails.getParentRememberMeId()).toBe(parentRememberMeId);
+            expect(activityDetails.getBase64SelfieUri()).toBe(selfie);
 
-            expect(outcome).to.equal('SUCCESS');
+            expect(outcome).toBe('SUCCESS');
 
-            expect(profile).to.not.equal(undefined);
-            expect(profile.phoneNumber).to.equal(phoneNumber);
-            expect(`data:image/jpeg;base64,${profile.selfie.toBase64()}`).to.equal(selfie);
+            expect(profile).not.toBe(undefined);
+            expect(profile.phoneNumber).toBe(phoneNumber);
+            expect(`data:image/jpeg;base64,${profile.selfie.toBase64()}`).toBe(selfie);
 
-            expect(extendedProfile.getPhoneNumber().getValue()).to.equal(phoneNumber);
-            expect(extendedProfile.getSelfie().getValue().getBase64Content()).to.equal(selfie);
+            expect(extendedProfile.getPhoneNumber().getValue()).toBe(phoneNumber);
+            expect(extendedProfile.getSelfie().getValue().getBase64Content()).toBe(selfie);
 
             const phoneNumberAnchor = extendedProfile.getPhoneNumber().getAnchors()[0];
-            expect(phoneNumberAnchor.getType()).to.equal('UNKNOWN');
-            expect(phoneNumberAnchor.getValue()).to.equal('');
+            expect(phoneNumberAnchor.getType()).toBe('UNKNOWN');
+            expect(phoneNumberAnchor.getValue()).toBe('');
 
-            expect(applicationProfile.getName().getValue()).to.equal('Node SDK Test');
-            expect(applicationProfile.getUrl().getValue()).to.equal('https://example.com');
-            expect(applicationProfile.getLogo().getValue().getBase64Content()).to.equal('data:image/jpeg;base64,');
-            expect(applicationProfile.getReceiptBgColor().getValue()).to.equal('#ffffff');
+            expect(applicationProfile.getName().getValue()).toBe('Node SDK Test');
+            expect(applicationProfile.getUrl().getValue()).toBe('https://example.com');
+            expect(applicationProfile.getLogo().getValue().getBase64Content()).toBe('data:image/jpeg;base64,');
+            expect(applicationProfile.getReceiptBgColor().getValue()).toBe('#ffffff');
 
             done();
           })
@@ -75,7 +74,7 @@ describe('yotiClient', () => {
       });
     });
 
-    context('when the profile is empty', () => {
+    describe('when the profile is empty', () => {
       const responseContentNull = fs.readFileSync('./tests/sample-data/payloads/payload-other-party-null.json', 'utf8');
 
       beforeEach((done) => {
@@ -91,12 +90,12 @@ describe('yotiClient', () => {
             const profile = activityDetails.getUserProfile();
             const outcome = activityDetails.getOutcome();
 
-            expect(profile).to.not.equal(undefined);
-            expect(profile).to.deep.equal({});
-            expect(activityDetails.getUserId()).to.equal(rememberMeId);
-            expect(activityDetails.getRememberMeId()).to.equal(rememberMeId);
-            expect(activityDetails.getParentRememberMeId()).to.equal(parentRememberMeId);
-            expect(outcome).to.equal('SUCCESS');
+            expect(profile).not.toBe(undefined);
+            expect(profile).toEqual({});
+            expect(activityDetails.getUserId()).toBe(rememberMeId);
+            expect(activityDetails.getRememberMeId()).toBe(rememberMeId);
+            expect(activityDetails.getParentRememberMeId()).toBe(parentRememberMeId);
+            expect(outcome).toBe('SUCCESS');
 
             done();
           })
@@ -104,7 +103,7 @@ describe('yotiClient', () => {
       });
     });
 
-    context('when the profile contains an empty object', () => {
+    describe('when the profile contains an empty object', () => {
       const responseContentEmptyObj = fs.readFileSync('./tests/sample-data/payloads/payload-other-party-empty-object.json', 'utf8');
 
       beforeEach((done) => {
@@ -120,12 +119,12 @@ describe('yotiClient', () => {
             const profile = activityDetails.getUserProfile();
             const outcome = activityDetails.getOutcome();
 
-            expect(profile).to.not.equal(undefined);
-            expect(profile).to.deep.equal({});
-            expect(activityDetails.getUserId()).to.equal(rememberMeId);
-            expect(activityDetails.getRememberMeId()).to.equal(rememberMeId);
-            expect(activityDetails.getParentRememberMeId()).to.equal(parentRememberMeId);
-            expect(outcome).to.equal('SUCCESS');
+            expect(profile).not.toBe(undefined);
+            expect(profile).toEqual({});
+            expect(activityDetails.getUserId()).toBe(rememberMeId);
+            expect(activityDetails.getRememberMeId()).toBe(rememberMeId);
+            expect(activityDetails.getParentRememberMeId()).toBe(parentRememberMeId);
+            expect(outcome).toBe('SUCCESS');
 
             done();
           })
@@ -133,7 +132,7 @@ describe('yotiClient', () => {
       });
     });
 
-    context('when the response does not have profile attributes', () => {
+    describe('when the response does not have profile attributes', () => {
       const responseContentNonExistent = fs.readFileSync('./tests/sample-data/payloads/payload-other-party-non-existent.json', 'utf8');
 
       beforeEach((done) => {
@@ -149,12 +148,12 @@ describe('yotiClient', () => {
             const profile = activityDetails.getUserProfile();
             const outcome = activityDetails.getOutcome();
 
-            expect(profile).to.not.equal(undefined);
-            expect(profile).to.deep.equal({});
-            expect(activityDetails.getUserId()).to.equal(rememberMeId);
-            expect(activityDetails.getRememberMeId()).to.equal(rememberMeId);
-            expect(activityDetails.getParentRememberMeId()).to.equal(parentRememberMeId);
-            expect(outcome).to.equal('SUCCESS');
+            expect(profile).not.toBe(undefined);
+            expect(profile).toEqual({});
+            expect(activityDetails.getUserId()).toBe(rememberMeId);
+            expect(activityDetails.getRememberMeId()).toBe(rememberMeId);
+            expect(activityDetails.getParentRememberMeId()).toBe(parentRememberMeId);
+            expect(outcome).toBe('SUCCESS');
 
             done();
           })
@@ -180,9 +179,9 @@ describe('yotiClient', () => {
     it('should return a successful result', (done) => {
       yotiClient.performAmlCheck(amlProfile)
         .then((amlResult) => {
-          expect(amlResult.isOnPepList).to.equal(true);
-          expect(amlResult.isOnFraudList).to.equal(false);
-          expect(amlResult.isOnWatchList).to.equal(false);
+          expect(amlResult.isOnPepList).toBe(true);
+          expect(amlResult.isOnFraudList).toBe(false);
+          expect(amlResult.isOnWatchList).toBe(false);
 
           done();
         })
@@ -212,7 +211,7 @@ describe('yotiClient', () => {
     it('it should get a ShareUrlResult', (done) => {
       yotiClient.createShareUrl(dynamicScenario)
         .then((result) => {
-          expect(result).to.be.instanceOf(ShareUrlResult);
+          expect(result).toBeInstanceOf(ShareUrlResult);
           done();
         })
         .catch(done);

--- a/tests/data_type/age.verification.spec.js
+++ b/tests/data_type/age.verification.spec.js
@@ -1,12 +1,10 @@
-const expect = require('chai').expect;
-
 const { AgeVerification } = require('../../src/data_type/age.verification');
 const { Attribute } = require('../../src/data_type/attribute');
 
 const EXPECTED_PATTERN = /^[^:]+:(?!.*:)[0-9]+$/;
 
 describe('AgeVerification', () => {
-  context('when malformed age derivation is provided', () => {
+  describe('when malformed age derivation is provided', () => {
     it('should throw exception', () => {
       [
         '',
@@ -24,28 +22,28 @@ describe('AgeVerification', () => {
           value: 'true',
         });
         expect(() => new AgeVerification(attribute))
-          .to.throw(TypeError, `'attribute.name' value '${name}' does not match format '${EXPECTED_PATTERN}'`);
+          .toThrow(TypeError, `'attribute.name' value '${name}' does not match format '${EXPECTED_PATTERN}'`);
       });
     });
   });
 
-  context('when well formed age derivation is provided', () => {
+  describe('when well formed age derivation is provided', () => {
     const attribute = new Attribute({
       name: 'any_string_here:21',
       value: 'true',
     });
     const ageVerification = new AgeVerification(attribute);
     it('should parse check type', () => {
-      expect(ageVerification.getCheckType()).to.equal('any_string_here');
+      expect(ageVerification.getCheckType()).toBe('any_string_here');
     });
     it('should parse age', () => {
-      expect(ageVerification.getAge()).to.equal(21);
+      expect(ageVerification.getAge()).toBe(21);
     });
     it('should parse result', () => {
-      expect(ageVerification.getResult()).to.equal(true);
+      expect(ageVerification.getResult()).toBe(true);
     });
     it('should return provided attribute', () => {
-      expect(ageVerification.getAttribute()).to.equal(attribute);
+      expect(ageVerification.getAttribute()).toBe(attribute);
     });
   });
 });

--- a/tests/data_type/anchor.spec.js
+++ b/tests/data_type/anchor.spec.js
@@ -1,5 +1,3 @@
-const expect = require('chai').expect;
-
 const { YotiAnchor } = require('../../src/data_type/anchor');
 const { YotiDate } = require('../../src/data_type/date');
 const { YotiSignedTimeStamp } = require('../../src/data_type/signed.timestamp');
@@ -18,29 +16,29 @@ describe('YotiAnchor', () => {
     originServerCerts
   );
 
-  context('#getType()', () => {
+  describe('#getType()', () => {
     it('it should return test_type', () => {
-      expect(anchor.getType()).to.equal('test_type');
+      expect(anchor.getType()).toBe('test_type');
     });
   });
-  context('#getValue()', () => {
+  describe('#getValue()', () => {
     it('it should return test_value', () => {
-      expect(anchor.getValue()).to.equal('test_value');
+      expect(anchor.getValue()).toBe('test_value');
     });
   });
-  context('#getSubType()', () => {
+  describe('#getSubType()', () => {
     it('it should return test_sub_type', () => {
-      expect(anchor.getSubType()).to.equal('test_sub_type');
+      expect(anchor.getSubType()).toBe('test_sub_type');
     });
   });
-  context('#getSignedTimeStamp()', () => {
+  describe('#getSignedTimeStamp()', () => {
     it('it should return timestamp', () => {
-      expect(anchor.getSignedTimeStamp()).to.equal(signedTimestamp);
+      expect(anchor.getSignedTimeStamp()).toBe(signedTimestamp);
     });
   });
-  context('#getOriginServerCerts()', () => {
+  describe('#getOriginServerCerts()', () => {
     it('it should return origin server certs', () => {
-      expect(anchor.getOriginServerCerts()).to.equal(originServerCerts);
+      expect(anchor.getOriginServerCerts()).toBe(originServerCerts);
     });
   });
 });

--- a/tests/data_type/attribute.spec.js
+++ b/tests/data_type/attribute.spec.js
@@ -1,5 +1,4 @@
 const fs = require('fs');
-const expect = require('chai').expect;
 const protoRoot = require('../../src/proto-root').initializeProtoBufObjects();
 const AnchorProcessor = require('../../src/yoti_common/anchor.processor').AnchorProcessor;
 
@@ -31,63 +30,63 @@ describe('Attribute', () => {
     anchors,
   });
 
-  context('Attribute.getValue()', () => {
+  describe('Attribute.getValue()', () => {
     it('it should return DocumentDetails instance', () => {
-      expect(attributeObj.getValue()).to.be.an.instanceof(DocumentDetails);
+      expect(attributeObj.getValue()).toBeInstanceOf(DocumentDetails);
     });
   });
-  context('Attribute.getName()', () => {
+  describe('Attribute.getName()', () => {
     it('it should return document_details', () => {
-      expect(attributeObj.getName()).to.equal('document_details');
+      expect(attributeObj.getName()).toBe('document_details');
     });
   });
-  context('Attribute.getSources()[0]', () => {
+  describe('Attribute.getSources()[0]', () => {
     it('it should return an Anchor object', () => {
       const source = attributeObj.getSources()[0];
-      expect(source).to.be.an('object');
-      expect(source.getType()).to.equal('SOURCE');
-      expect(source.getValue()).to.equal('DRIVING_LICENCE');
-      expect(source.getSubType()).to.equal('');
+      expect(source).toBeInstanceOf(Object);
+      expect(source.getType()).toBe('SOURCE');
+      expect(source.getValue()).toBe('DRIVING_LICENCE');
+      expect(source.getSubType()).toBe('');
       expect(source.getSignedTimeStamp().getTimestamp()
-        .toUTCString()).to.equal('Wed, 11 Apr 2018 12:13:03 GMT');
-      expect(source.getOriginServerCerts()[0].signatureOid).to.equal('1.2.840.113549.1.1.11');
+        .toUTCString()).toBe('Wed, 11 Apr 2018 12:13:03 GMT');
+      expect(source.getOriginServerCerts()[0].signatureOid).toBe('1.2.840.113549.1.1.11');
     });
   });
-  context('Attribute.getVerifiers()[0]', () => {
+  describe('Attribute.getVerifiers()[0]', () => {
     it('it should return an Anchor object', () => {
       const verifier = attributeObj.getVerifiers()[0];
-      expect(verifier).to.be.an('object');
-      expect(verifier.getType()).to.equal('VERIFIER');
-      expect(verifier.getValue()).to.equal('YOTI_ADMIN');
-      expect(verifier.getSubType()).to.equal('');
+      expect(verifier).toBeInstanceOf(Object);
+      expect(verifier.getType()).toBe('VERIFIER');
+      expect(verifier.getValue()).toBe('YOTI_ADMIN');
+      expect(verifier.getSubType()).toBe('');
       expect(verifier.getSignedTimeStamp().getTimestamp()
-        .toUTCString()).to.equal('Wed, 11 Apr 2018 12:13:04 GMT');
-      expect(verifier.getOriginServerCerts()[0].signatureOid).to.equal('1.2.840.113549.1.1.11');
+        .toUTCString()).toBe('Wed, 11 Apr 2018 12:13:04 GMT');
+      expect(verifier.getOriginServerCerts()[0].signatureOid).toBe('1.2.840.113549.1.1.11');
     });
   });
-  context('Attribute.getAnchors()', () => {
+  describe('Attribute.getAnchors()', () => {
     it('it should return an array of Anchor objects', () => {
       const source = attributeObj.getAnchors()[0];
       const verifier = attributeObj.getAnchors()[1];
       const unknown = attributeObj.getAnchors()[2];
-      expect(attributeObj.getAnchors()).to.be.length(3);
-      expect(source.getType()).to.equal('SOURCE');
-      expect(verifier.getType()).to.equal('VERIFIER');
-      expect(unknown.getType()).to.equal('UNKNOWN');
+      expect(attributeObj.getAnchors()).toHaveLength(3);
+      expect(source.getType()).toBe('SOURCE');
+      expect(verifier.getType()).toBe('VERIFIER');
+      expect(unknown.getType()).toBe('UNKNOWN');
     });
   });
-  context('When Attribute value is a DocumentDetails', () => {
+  describe('When Attribute value is a DocumentDetails', () => {
     it('it should return PASSPORT as type', () => {
-      expect(attributeObj.getValue().getType()).to.equal('PASSPORT');
+      expect(attributeObj.getValue().getType()).toBe('PASSPORT');
     });
     it('it should return GBR as Issuing country', () => {
-      expect(attributeObj.getValue().getIssuingCountry()).to.equal('GBR');
+      expect(attributeObj.getValue().getIssuingCountry()).toBe('GBR');
     });
     it('it should return 01234567 as documentNumber', () => {
-      expect(attributeObj.getValue().getDocumentNumber()).to.equal('01234567');
+      expect(attributeObj.getValue().getDocumentNumber()).toBe('01234567');
     });
     it('it should return 2020-01-01 as expiration Date', () => {
-      expect(attributeObj.getValue().getExpirationDate().toISOString().slice(0, 10)).to.equal('2020-01-01');
+      expect(attributeObj.getValue().getExpirationDate().toISOString().slice(0, 10)).toBe('2020-01-01');
     });
   });
 });

--- a/tests/data_type/date.spec.js
+++ b/tests/data_type/date.spec.js
@@ -1,20 +1,19 @@
-const { expect } = require('chai');
 const { YotiDate } = require('../../src/data_type/date');
 
 describe('YotiDate', () => {
   const date = new YotiDate(1067950267923530);
 
-  context('#toUTCString()', () => {
+  describe('#toUTCString()', () => {
     it('should return Tue, 04 Nov 2003 12:51:07 GMT', () => {
-      expect(date.toUTCString()).to.equal('Tue, 04 Nov 2003 12:51:07 GMT');
+      expect(date.toUTCString()).toBe('Tue, 04 Nov 2003 12:51:07 GMT');
     });
   });
 
-  context('#getMicroseconds()', () => {
+  describe('#getMicroseconds()', () => {
     it('should return 923530', () => {
-      expect(date.getMicroseconds()).to.equal(923530);
-      expect(date.getMicrosecondTime()).to.equal('12:51:07.923530');
-      expect(date.getMicrosecondTimestamp()).to.equal('2003-11-04T12:51:07.923530Z');
+      expect(date.getMicroseconds()).toBe(923530);
+      expect(date.getMicrosecondTime()).toBe('12:51:07.923530');
+      expect(date.getMicrosecondTimestamp()).toBe('2003-11-04T12:51:07.923530Z');
     });
   });
 });

--- a/tests/data_type/document.details.spec.js
+++ b/tests/data_type/document.details.spec.js
@@ -1,4 +1,3 @@
-const expect = require('chai').expect;
 const { DocumentDetails } = require('../../src/data_type/document.details');
 
 /**
@@ -12,72 +11,72 @@ const assertInvalidDocumentDetails = (value, exceptionMessage) => {
   try {
     documentDetails = new DocumentDetails(value);
   } catch (err) {
-    expect(err.message).to.equal(exceptionMessage);
+    expect(err.message).toBe(exceptionMessage);
   }
-  expect(documentDetails).to.equal(null);
+  expect(documentDetails).toBe(null);
 };
 
 describe('documentDetails', () => {
-  context('when value is empty', () => {
+  describe('when value is empty', () => {
     it('it should throw an exception', () => {
       assertInvalidDocumentDetails('', 'Invalid value for DocumentDetails');
     });
   });
-  context('when value is less than 3 words', () => {
+  describe('when value is less than 3 words', () => {
     it('it should throw an exception', () => {
       assertInvalidDocumentDetails('PASS_CARD GBR', 'Invalid value for DocumentDetails');
     });
   });
-  context('when value is four words', () => {
+  describe('when value is four words', () => {
     it('it should parse one optional attribute', () => {
       const documentDetails = new DocumentDetails('PASSPORT GBR 01234567 2020-01-01');
-      expect(documentDetails.getType()).to.equal('PASSPORT');
-      expect(documentDetails.getIssuingCountry()).to.equal('GBR');
-      expect(documentDetails.getDocumentNumber()).to.equal('01234567');
-      expect(documentDetails.getExpirationDate().toISOString().slice(0, 10)).to.equal('2020-01-01');
+      expect(documentDetails.getType()).toBe('PASSPORT');
+      expect(documentDetails.getIssuingCountry()).toBe('GBR');
+      expect(documentDetails.getDocumentNumber()).toBe('01234567');
+      expect(documentDetails.getExpirationDate().toISOString().slice(0, 10)).toBe('2020-01-01');
     });
   });
-  context('when value is five words', () => {
+  describe('when value is five words', () => {
     it('it should parse two optional attributes', () => {
       const documentDetails = new DocumentDetails('DRIVING_LICENCE GBR 1234abc 2016-05-01 DVLA');
-      expect(documentDetails.getType()).to.equal('DRIVING_LICENCE');
-      expect(documentDetails.getIssuingCountry()).to.equal('GBR');
-      expect(documentDetails.getDocumentNumber()).to.equal('1234abc');
-      expect(documentDetails.getExpirationDate().toISOString().slice(0, 10)).to.equal('2016-05-01');
-      expect(documentDetails.getIssuingAuthority()).to.equal('DVLA');
+      expect(documentDetails.getType()).toBe('DRIVING_LICENCE');
+      expect(documentDetails.getIssuingCountry()).toBe('GBR');
+      expect(documentDetails.getDocumentNumber()).toBe('1234abc');
+      expect(documentDetails.getExpirationDate().toISOString().slice(0, 10)).toBe('2016-05-01');
+      expect(documentDetails.getIssuingAuthority()).toBe('DVLA');
     });
   });
-  context('when value is more than five words', () => {
+  describe('when value is more than five words', () => {
     it('it should parse only two optional attributes', () => {
       const documentDetails = new DocumentDetails('DRIVING_LICENCE GBR 1234abc 2016-05-01 DVLA someThirdAttribute');
-      expect(documentDetails.getType()).to.equal('DRIVING_LICENCE');
-      expect(documentDetails.getIssuingCountry()).to.equal('GBR');
-      expect(documentDetails.getDocumentNumber()).to.equal('1234abc');
-      expect(documentDetails.getExpirationDate().toISOString().slice(0, 10)).to.equal('2016-05-01');
-      expect(documentDetails.getIssuingAuthority()).to.equal('DVLA');
+      expect(documentDetails.getType()).toBe('DRIVING_LICENCE');
+      expect(documentDetails.getIssuingCountry()).toBe('GBR');
+      expect(documentDetails.getDocumentNumber()).toBe('1234abc');
+      expect(documentDetails.getExpirationDate().toISOString().slice(0, 10)).toBe('2016-05-01');
+      expect(documentDetails.getIssuingAuthority()).toBe('DVLA');
     });
   });
-  context('when value has invalid country 13', () => {
+  describe('when value has invalid country 13', () => {
     it('it should throw an exception', () => {
       assertInvalidDocumentDetails('PASSPORT 13 1234abc 2016-05-01', 'Invalid value for DocumentDetails');
     });
   });
-  context('when value has invalid document number', () => {
+  describe('when value has invalid document number', () => {
     it('it should throw an exception', () => {
       assertInvalidDocumentDetails('PASSPORT GBR $%^$%^£ 2016-05-01', 'Invalid value for DocumentDetails');
     });
   });
-  context('when expiration Date is set to dash (-)', () => {
+  describe('when expiration Date is set to dash (-)', () => {
     it('it should return NULL for date value', () => {
       const documentDetails = new DocumentDetails('PASS_CARD GBR 22719564893 - CITIZENCARD');
-      expect(documentDetails.getType()).to.equal('PASS_CARD');
-      expect(documentDetails.getIssuingCountry()).to.equal('GBR');
-      expect(documentDetails.getDocumentNumber()).to.equal('22719564893');
-      expect(documentDetails.getExpirationDate()).to.equal(null);
-      expect(documentDetails.getIssuingAuthority()).to.equal('CITIZENCARD');
+      expect(documentDetails.getType()).toBe('PASS_CARD');
+      expect(documentDetails.getIssuingCountry()).toBe('GBR');
+      expect(documentDetails.getDocumentNumber()).toBe('22719564893');
+      expect(documentDetails.getExpirationDate()).toBe(null);
+      expect(documentDetails.getIssuingAuthority()).toBe('CITIZENCARD');
     });
   });
-  context('when there is an invalid date', () => {
+  describe('when there is an invalid date', () => {
     it('it should throw an exception', () => {
       assertInvalidDocumentDetails('PASSPORT GBR 1234abc X016-05-01', 'Invalid Date');
     });

--- a/tests/data_type/image.spec.js
+++ b/tests/data_type/image.spec.js
@@ -1,4 +1,3 @@
-const expect = require('chai').expect;
 const Image = require('../../src/data_type/image');
 const ImageJpeg = require('../../src/data_type/image.jpeg');
 const ImagePng = require('../../src/data_type/image.png');
@@ -22,25 +21,25 @@ const imageTypes = [
 
 imageTypes.forEach((type) => {
   describe(`${type.imageObj.constructor.name}`, () => {
-    context('#getContent()', () => {
+    describe('#getContent()', () => {
       it('should return original image content', () => {
-        expect(type.imageObj.getContent()).to.equal(imageContent);
+        expect(type.imageObj.getContent()).toBe(imageContent);
       });
     });
-    context('#getBase64Content()', () => {
+    describe('#getBase64Content()', () => {
       it('should return base64 image content', () => {
         const base64String = `data:${type.mimeType};base64,${imageContent.toBase64()}`;
-        expect(type.imageObj.getBase64Content()).to.equal(base64String);
+        expect(type.imageObj.getBase64Content()).toBe(base64String);
       });
     });
-    context('#getMimeType()', () => {
+    describe('#getMimeType()', () => {
       it(`should return ${type.mimeType}`, () => {
-        expect(type.imageObj.getMimeType()).to.equal(type.mimeType);
+        expect(type.imageObj.getMimeType()).toBe(type.mimeType);
       });
     });
-    context('when instantiated', () => {
+    describe('when instantiated', () => {
       it('should be an instance of Image', () => {
-        expect(type.imageObj).to.be.an.instanceof(Image);
+        expect(type.imageObj).toBeInstanceOf(Image);
       });
     });
   });

--- a/tests/data_type/multi.value.spec.js
+++ b/tests/data_type/multi.value.spec.js
@@ -1,4 +1,3 @@
-const expect = require('chai').expect;
 const MultiValue = require('../../src/data_type/multi.value');
 const ImageJpeg = require('../../src/data_type/image.jpeg');
 const ImagePng = require('../../src/data_type/image.png');
@@ -26,16 +25,16 @@ const getTestValues = () => [
 ];
 
 describe('MultiValue', () => {
-  context('#getItems', () => {
+  describe('#getItems', () => {
     it('should return provided array of items', () => {
       const multiValue = new MultiValue(getTestValues());
-      expect(multiValue.getItems()).to.eql(getTestValues());
+      expect(multiValue.getItems()).toEqual(getTestValues());
     });
   });
-  context('#applyFilters', () => {
+  describe('#applyFilters', () => {
     it('should apply filters to all multi values', () => {
       const multiValue = new MultiValue(getTestValues());
-      expect(multiValue.getItems().length).to.equal(6);
+      expect(multiValue.getItems().length).toBe(6);
 
       // Apply filters.
       multiValue
@@ -43,69 +42,69 @@ describe('MultiValue', () => {
         .allowInstance(MultiValue);
 
       // First level.
-      expect(multiValue.getItems().length).to.equal(2);
+      expect(multiValue.getItems().length).toBe(2);
 
       // Second level.
       const secondLevelMultiValue = multiValue.getItems()[1];
-      expect(secondLevelMultiValue.getItems().length).to.equal(2);
-      expect(secondLevelMultiValue.getItems()[0]).to.be.instanceOf(ImageJpeg);
-      expect(secondLevelMultiValue.getItems()[1]).to.be.instanceOf(MultiValue);
+      expect(secondLevelMultiValue.getItems().length).toBe(2);
+      expect(secondLevelMultiValue.getItems()[0]).toBeInstanceOf(ImageJpeg);
+      expect(secondLevelMultiValue.getItems()[1]).toBeInstanceOf(MultiValue);
 
       // Third level.
       const thirdLevelMultiValue = secondLevelMultiValue.getItems()[1];
-      expect(thirdLevelMultiValue.getItems().length).to.equal(1);
-      expect(thirdLevelMultiValue.getItems()[0]).to.be.instanceOf(ImageJpeg);
+      expect(thirdLevelMultiValue.getItems().length).toBe(1);
+      expect(thirdLevelMultiValue.getItems()[0]).toBeInstanceOf(ImageJpeg);
     });
     it('should allow combination of instance and type filters', () => {
       const multiValue = new MultiValue(getTestValues());
-      expect(multiValue.getItems()).to.eql(getTestValues());
+      expect(multiValue.getItems()).toEqual(getTestValues());
 
       multiValue
         .allowInstance(ImageJpeg)
         .allowType('Array')
         .allowType('MultiValue');
-      expect(multiValue.getItems().length).to.equal(3);
-      expect(multiValue.getItems()[0]).to.be.instanceOf(ImageJpeg);
-      expect(multiValue.getItems()[1]).to.eql(['test', 'array']);
-      expect(multiValue.getItems()[2]).to.be.instanceOf(MultiValue);
+      expect(multiValue.getItems().length).toBe(3);
+      expect(multiValue.getItems()[0]).toBeInstanceOf(ImageJpeg);
+      expect(multiValue.getItems()[1]).toEqual(['test', 'array']);
+      expect(multiValue.getItems()[2]).toBeInstanceOf(MultiValue);
 
       // Check filters applied to second level.
       const secondLevelMultiValue = multiValue.getItems()[2];
-      expect(secondLevelMultiValue.getItems().length).to.equal(3);
-      expect(secondLevelMultiValue.getItems()[0]).to.be.instanceOf(ImageJpeg);
-      expect(secondLevelMultiValue.getItems()[1]).to.eql(['test', 'array 2']);
-      expect(secondLevelMultiValue.getItems()[2]).to.be.instanceOf(MultiValue);
+      expect(secondLevelMultiValue.getItems().length).toBe(3);
+      expect(secondLevelMultiValue.getItems()[0]).toBeInstanceOf(ImageJpeg);
+      expect(secondLevelMultiValue.getItems()[1]).toEqual(['test', 'array 2']);
+      expect(secondLevelMultiValue.getItems()[2]).toBeInstanceOf(MultiValue);
     });
   });
-  context('#allowInstance()', () => {
+  describe('#allowInstance()', () => {
     it('should filter values by instance', () => {
       const multiValue = new MultiValue(getTestValues());
-      expect(multiValue.getItems()).to.eql(getTestValues());
+      expect(multiValue.getItems()).toEqual(getTestValues());
 
       multiValue.allowInstance(ImageJpeg);
-      expect(multiValue.getItems().length).to.equal(1);
-      expect(multiValue.getItems()[0]).to.be.instanceOf(ImageJpeg);
+      expect(multiValue.getItems().length).toBe(1);
+      expect(multiValue.getItems()[0]).toBeInstanceOf(ImageJpeg);
 
       multiValue.allowInstance(ImagePng);
-      expect(multiValue.getItems().length).to.equal(2);
-      expect(multiValue.getItems()[0]).to.be.instanceOf(ImageJpeg);
-      expect(multiValue.getItems()[1]).to.be.instanceOf(ImagePng);
+      expect(multiValue.getItems().length).toBe(2);
+      expect(multiValue.getItems()[0]).toBeInstanceOf(ImageJpeg);
+      expect(multiValue.getItems()[1]).toBeInstanceOf(ImagePng);
     });
   });
-  context('#allowType()', () => {
+  describe('#allowType()', () => {
     it('should filter values by type', () => {
       const multiValue = new MultiValue(getTestValues());
-      expect(multiValue.getItems()).to.eql(getTestValues());
+      expect(multiValue.getItems()).toEqual(getTestValues());
 
       multiValue
         .allowType('String')
         .allowType('Object');
-      expect(multiValue.getItems().length).to.equal(2);
-      expect(multiValue.getItems()[0]).to.equal('test string');
-      expect(multiValue.getItems()[1]).to.eql({ name: 'test object' });
+      expect(multiValue.getItems().length).toBe(2);
+      expect(multiValue.getItems()[0]).toBe('test string');
+      expect(multiValue.getItems()[1]).toEqual({ name: 'test object' });
 
       multiValue.allowType('Array');
-      expect(multiValue.getItems().length).to.equal(3);
+      expect(multiValue.getItems().length).toBe(3);
     });
   });
 });

--- a/tests/data_type/signed.timestamp.spec.js
+++ b/tests/data_type/signed.timestamp.spec.js
@@ -1,29 +1,27 @@
-const { expect } = require('chai');
 const { YotiDate } = require('../../src/data_type/date');
 const { YotiSignedTimeStamp } = require('../../src/data_type/signed.timestamp');
 
 describe('YotiSignedTimeStamp', () => {
   const signedTimestamp = new YotiSignedTimeStamp(1, new YotiDate(1067950267923530));
 
-  context('#constructor()', () => {
+  describe('#constructor()', () => {
     it('should only accept YotiDate as timestamp', () => {
       expect(() => new YotiSignedTimeStamp(0, new Date()))
-        .to.throw(TypeError, 'timestamp must be instance of YotiDate');
+        .toThrow(TypeError, 'timestamp must be instance of YotiDate');
     });
   });
-  context('#getVersion()', () => {
+  describe('#getVersion()', () => {
     it('should return 1', () => {
-      expect(signedTimestamp.getVersion()).to.equal(1);
+      expect(signedTimestamp.getVersion()).toBe(1);
     });
   });
-  context('#getTimestamp()', () => {
+  describe('#getTimestamp()', () => {
     it('should return Date object', () => {
       const timestamp = signedTimestamp.getTimestamp();
-      expect(timestamp).to.be.a('Date');
-      expect(timestamp).to.be.instanceOf(YotiDate);
-      expect(timestamp).to.be.instanceOf(Date);
-      expect(timestamp.toUTCString()).to.equal('Tue, 04 Nov 2003 12:51:07 GMT');
-      expect(timestamp.getMicrosecondTimestamp()).to.equal('2003-11-04T12:51:07.923530Z');
+      expect(timestamp).toBeInstanceOf(YotiDate);
+      expect(timestamp).toBeInstanceOf(Date);
+      expect(timestamp.toUTCString()).toBe('Tue, 04 Nov 2003 12:51:07 GMT');
+      expect(timestamp.getMicrosecondTimestamp()).toBe('2003-11-04T12:51:07.923530Z');
     });
   });
 });

--- a/tests/dynamic_sharing_service/dynamic.scenario.builder.spec.js
+++ b/tests/dynamic_sharing_service/dynamic.scenario.builder.spec.js
@@ -1,5 +1,3 @@
-const { expect } = require('chai');
-
 const {
   DynamicScenarioBuilder,
   DynamicPolicyBuilder,
@@ -33,9 +31,9 @@ describe('DynamicScenarioBuilder', () => {
       .withExtension(extension2)
       .build();
 
-    expect(dynamicScenario.getCallbackEndpoint()).to.equal('/test-callback');
-    expect(dynamicScenario.getDynamicPolicy()).to.equal(dynamicPolicy);
-    expect(dynamicScenario.getExtensions()).to.deep.equal([extension1, extension2]);
+    expect(dynamicScenario.getCallbackEndpoint()).toBe('/test-callback');
+    expect(dynamicScenario.getDynamicPolicy()).toBe(dynamicPolicy);
+    expect(dynamicScenario.getExtensions()).toEqual([extension1, extension2]);
 
     const expectedJsonData = {
       callback_endpoint: '/test-callback',
@@ -73,7 +71,7 @@ describe('DynamicScenarioBuilder', () => {
     };
     const expectedJson = JSON.stringify(expectedJsonData);
 
-    expect(dynamicScenario).to.be.instanceOf(DynamicScenario);
-    expect(JSON.stringify(dynamicScenario)).to.equal(expectedJson);
+    expect(dynamicScenario).toBeInstanceOf(DynamicScenario);
+    expect(JSON.stringify(dynamicScenario)).toBe(expectedJson);
   });
 });

--- a/tests/dynamic_sharing_service/extension/extension.builder.spec.js
+++ b/tests/dynamic_sharing_service/extension/extension.builder.spec.js
@@ -1,7 +1,3 @@
-const {
-  expect,
-} = require('chai');
-
 const { ExtensionBuilder } = require('../../../');
 const Extension = require('../../../src/dynamic_sharing_service/extension/extension');
 
@@ -12,14 +8,14 @@ describe('ExtensionBuilder', () => {
       .withContent('test content')
       .build();
 
-    expect(extension).to.be.instanceOf(Extension);
-    expect(extension.getType()).to.equal('test type');
-    expect(extension.getContent()).to.equal('test content');
+    expect(extension).toBeInstanceOf(Extension);
+    expect(extension.getType()).toBe('test type');
+    expect(extension.getContent()).toBe('test content');
 
     const expectedJson = JSON.stringify({
       type: 'test type',
       content: 'test content',
     });
-    expect(JSON.stringify(extension)).to.equal(expectedJson);
+    expect(JSON.stringify(extension)).toBe(expectedJson);
   });
 });

--- a/tests/dynamic_sharing_service/extension/location.constraint.extension.builder.spec.js
+++ b/tests/dynamic_sharing_service/extension/location.constraint.extension.builder.spec.js
@@ -1,52 +1,48 @@
-const {
-  expect,
-} = require('chai');
-
 const { LocationConstraintExtensionBuilder } = require('../../../');
 const Extension = require('../../../src/dynamic_sharing_service/extension/extension');
 
 const LOCATION_CONSTRAINT = 'LOCATION_CONSTRAINT';
 
 const expectExtensionJson = (extension, expectedJsonData) => {
-  expect(extension).to.be.instanceOf(Extension);
-  expect(JSON.stringify(extension)).to.equal(JSON.stringify(expectedJsonData));
+  expect(extension).toBeInstanceOf(Extension);
+  expect(JSON.stringify(extension)).toBe(JSON.stringify(expectedJsonData));
 };
 
 describe('LocationConstraintExtensionBuilder', () => {
   it('should fail for latitude too low', () => {
     const builder = new LocationConstraintExtensionBuilder()
       .withLatitude(-91);
-    expect(() => builder.build()).to.throw(RangeError, "'latitude' value '-91' is less than '-90'");
+    expect(() => builder.build()).toThrow(RangeError, "'latitude' value '-91' is less than '-90'");
   });
 
   it('should fail for latitude too high', () => {
     const builder = new LocationConstraintExtensionBuilder()
       .withLatitude(91);
-    expect(() => builder.build()).to.throw(RangeError, "'latitude' value '91' is greater than '90'");
+    expect(() => builder.build()).toThrow(RangeError, "'latitude' value '91' is greater than '90'");
   });
 
   it('should fail for longitude too low', () => {
     const builder = new LocationConstraintExtensionBuilder()
       .withLongitude(-181);
-    expect(() => builder.build()).to.throw(RangeError, "'longitude' value '-181' is less than '-180'");
+    expect(() => builder.build()).toThrow(RangeError, "'longitude' value '-181' is less than '-180'");
   });
 
   it('should fail for longitude too high', () => {
     const builder = new LocationConstraintExtensionBuilder()
       .withLongitude(181);
-    expect(() => builder.build()).to.throw(RangeError, "'longitude' value '181' is greater than '180'");
+    expect(() => builder.build()).toThrow(RangeError, "'longitude' value '181' is greater than '180'");
   });
 
   it('should fail for radius less than zero', () => {
     const builder = new LocationConstraintExtensionBuilder()
       .withRadius(-1);
-    expect(() => builder.build()).to.throw(RangeError, "'radius' value '-1' is less than '0'");
+    expect(() => builder.build()).toThrow(RangeError, "'radius' value '-1' is less than '0'");
   });
 
   it('should fail for uncertainty less than zero', () => {
     const builder = new LocationConstraintExtensionBuilder()
       .withMaxUncertainty(-1);
-    expect(() => builder.build()).to.throw(RangeError, "'maxUncertainty' value '-1' is less than '0'");
+    expect(() => builder.build()).toThrow(RangeError, "'maxUncertainty' value '-1' is less than '0'");
   });
 
   it('should build constraint with given values', () => {

--- a/tests/dynamic_sharing_service/extension/transactional.flow.extension.builder.spec.js
+++ b/tests/dynamic_sharing_service/extension/transactional.flow.extension.builder.spec.js
@@ -1,7 +1,3 @@
-const {
-  expect,
-} = require('chai');
-
 const { TransactionalFlowExtensionBuilder } = require('../../../');
 const Extension = require('../../../src/dynamic_sharing_service/extension/extension');
 
@@ -10,7 +6,7 @@ const TRANSACTIONAL_FLOW = 'TRANSACTIONAL_FLOW';
 describe('TransactionalFlowExtensionBuilder', () => {
   it('should fail for null content', () => {
     const builder = new TransactionalFlowExtensionBuilder();
-    expect(() => builder.withContent(null)).to.throw(TypeError, 'content cannot be null');
+    expect(() => builder.withContent(null)).toThrow(TypeError, 'content cannot be null');
   });
 
   it('should build with content', () => {
@@ -19,14 +15,14 @@ describe('TransactionalFlowExtensionBuilder', () => {
       .withContent(content)
       .build();
 
-    expect(extension).to.be.instanceOf(Extension);
-    expect(extension.getType()).to.equal(TRANSACTIONAL_FLOW);
-    expect(extension.getContent()).to.eql(content);
+    expect(extension).toBeInstanceOf(Extension);
+    expect(extension.getType()).toBe(TRANSACTIONAL_FLOW);
+    expect(extension.getContent()).toBe(content);
 
     const expectedJson = JSON.stringify({
       type: TRANSACTIONAL_FLOW,
       content,
     });
-    expect(JSON.stringify(extension)).to.equal(expectedJson);
+    expect(JSON.stringify(extension)).toBe(expectedJson);
   });
 });

--- a/tests/dynamic_sharing_service/index.spec.js
+++ b/tests/dynamic_sharing_service/index.spec.js
@@ -1,6 +1,3 @@
-const {
-  expect,
-} = require('chai');
 const fs = require('fs');
 const nock = require('nock');
 const uuid = require('uuid');
@@ -23,7 +20,7 @@ describe('createShareUrl', () => {
   const REF_ID = '4c5473b1-3b79-4873-b2c8-8b141d602398';
   const SHARE_URL_RESULT = './tests/sample-data/responses/share-url-result.json';
 
-  context('when a valid response is returned', () => {
+  describe('when a valid response is returned', () => {
     it('should get the QR code and Ref ID', (done) => {
       nock(`${config.yoti.connectApi}`)
         .post(new RegExp(`^/api/v1/qrcodes/apps/${APP_ID}`))
@@ -41,22 +38,22 @@ describe('createShareUrl', () => {
 
       createShareUrl(dynamicScenario, privateKeyFile, APP_ID)
         .then((result) => {
-          expect(result.getShareUrl()).to.equal(QRCODE_LINK);
-          expect(result.getRefId()).to.equal(REF_ID);
+          expect(result.getShareUrl()).toBe(QRCODE_LINK);
+          expect(result.getRefId()).toBe(REF_ID);
           done();
         })
         .catch(done);
     });
   });
 
-  context('when a DynamicScenario is not provided', () => {
+  describe('when a DynamicScenario is not provided', () => {
     it('should throw error', () => {
       expect(() => createShareUrl('invalid scenario', privateKeyFile, APP_ID))
-        .to.throw(TypeError, 'dynamicScenario must be instance of DynamicScenario');
+        .toThrow(TypeError, 'dynamicScenario must be instance of DynamicScenario');
     });
   });
 
-  context('when an invalid response is returned', () => {
+  describe('when an invalid response is returned', () => {
     [
       {
         error: 'QR Code URL must be a string',
@@ -91,7 +88,7 @@ describe('createShareUrl', () => {
 
         createShareUrl(dynamicScenario, privateKeyFile, APP_ID)
           .catch((err) => {
-            expect(err.message).to.equal(invalidResponse.error);
+            expect(err.message).toBe(invalidResponse.error);
             done();
           })
           .catch(done);

--- a/tests/dynamic_sharing_service/policy/constraints.builder.spec.js
+++ b/tests/dynamic_sharing_service/policy/constraints.builder.spec.js
@@ -1,7 +1,3 @@
-const {
-  expect,
-} = require('chai');
-
 const { ConstraintsBuilder, SourceConstraintBuilder } = require('../../..');
 const Constraints = require('../../../src/dynamic_sharing_service/policy/constraints');
 
@@ -15,7 +11,7 @@ describe('ConstraintsBuilder', () => {
       .withSourceConstraint(sourceConstraint)
       .build();
 
-    expect(constraints).to.be.instanceOf(Constraints);
+    expect(constraints).toBeInstanceOf(Constraints);
 
     const expectedJson = JSON.stringify([
       {
@@ -32,6 +28,6 @@ describe('ConstraintsBuilder', () => {
       },
     ]);
 
-    expect(JSON.stringify(constraints)).to.equal(expectedJson);
+    expect(JSON.stringify(constraints)).toBe(expectedJson);
   });
 });

--- a/tests/dynamic_sharing_service/policy/dynamic.policy.builder.spec.js
+++ b/tests/dynamic_sharing_service/policy/dynamic.policy.builder.spec.js
@@ -1,8 +1,4 @@
 const {
-  expect,
-} = require('chai');
-
-const {
   DynamicPolicyBuilder,
   WantedAttributeBuilder,
 } = require('../../../');
@@ -17,8 +13,8 @@ const WantedAttribute = require('../../../src/dynamic_sharing_service/policy/wan
  * @param {object} expectedJsonData expected JSON data to serialize.
  */
 const expectDynamicPolicyJson = (dynamicPolicy, expectedJsonData) => {
-  expect(dynamicPolicy).to.be.instanceOf(DynamicPolicy);
-  expect(JSON.stringify(dynamicPolicy)).to.equal(JSON.stringify(expectedJsonData));
+  expect(dynamicPolicy).toBeInstanceOf(DynamicPolicy);
+  expect(JSON.stringify(dynamicPolicy)).toBe(JSON.stringify(expectedJsonData));
 };
 
 /**
@@ -30,7 +26,7 @@ const expectDynamicPolicyJson = (dynamicPolicy, expectedJsonData) => {
 const expectDynamicPolicyAttributes = (dynamicPolicy, expectedWantedAttributeData) => {
   // Assert that all items are instance of WantedAttribute.
   dynamicPolicy.getWantedAttributes().forEach((wantedAttribute) => {
-    expect(wantedAttribute).to.be.instanceOf(WantedAttribute);
+    expect(wantedAttribute).toBeInstanceOf(WantedAttribute);
   });
 
   // Build an array of WantedAttribute to check.
@@ -43,7 +39,7 @@ const expectDynamicPolicyAttributes = (dynamicPolicy, expectedWantedAttributeDat
   });
 
   // Assert that expected wanted attributes match dynamic policy wanted attributes.
-  expect(dynamicPolicy.getWantedAttributes()).to.deep.equal(expectedWantedAttributes);
+  expect(dynamicPolicy.getWantedAttributes()).toEqual(expectedWantedAttributes);
 };
 
 describe('DynamicPolicyBuilder', () => {
@@ -146,7 +142,7 @@ describe('DynamicPolicyBuilder', () => {
 
   it('should fail when invalid attribute objects are used', () => {
     const builder = new DynamicPolicyBuilder();
-    expect(() => builder.withWantedAttribute('invalid attribute')).to.throw(TypeError, 'wantedAttribute must be instance of WantedAttribute');
+    expect(() => builder.withWantedAttribute('invalid attribute')).toThrow(TypeError, 'wantedAttribute must be instance of WantedAttribute');
   });
 
   it('should build with age derived attributes', () => {
@@ -179,7 +175,7 @@ describe('DynamicPolicyBuilder', () => {
       new DynamicPolicyBuilder()
         .withDateOfBirth()
         .withAgeOver('18');
-    }).to.throw(TypeError, 'age must be an integer');
+    }).toThrow(TypeError, 'age must be an integer');
   });
 
   it('should only allow integers for age under', () => {
@@ -187,7 +183,7 @@ describe('DynamicPolicyBuilder', () => {
       new DynamicPolicyBuilder()
         .withDateOfBirth()
         .withAgeOver('30');
-    }).to.throw(TypeError, 'age must be an integer');
+    }).toThrow(TypeError, 'age must be an integer');
   });
 
   it('should overwrite identical age verification to ensure it only exists once', () => {
@@ -219,7 +215,7 @@ describe('DynamicPolicyBuilder', () => {
 
     const expectedAuthTypes = [EXPECTED_SELFIE_AUTH_TYPE, EXPECTED_PIN_AUTH_TYPE, 99];
 
-    expect(dynamicPolicy.getWantedAuthTypes()).to.deep.equal(expectedAuthTypes);
+    expect(dynamicPolicy.getWantedAuthTypes()).toEqual(expectedAuthTypes);
 
     expectDynamicPolicyJson(dynamicPolicy, {
       wanted: [],
@@ -238,7 +234,7 @@ describe('DynamicPolicyBuilder', () => {
 
     const expectedAuthTypes = [EXPECTED_SELFIE_AUTH_TYPE, EXPECTED_PIN_AUTH_TYPE, 99];
 
-    expect(dynamicPolicy.getWantedAuthTypes()).to.deep.equal(expectedAuthTypes);
+    expect(dynamicPolicy.getWantedAuthTypes()).toEqual(expectedAuthTypes);
 
     expectDynamicPolicyJson(dynamicPolicy, {
       wanted: [],
@@ -256,7 +252,7 @@ describe('DynamicPolicyBuilder', () => {
 
     const expectedAuthTypes = [];
 
-    expect(dynamicPolicy.getWantedAuthTypes()).to.deep.equal(expectedAuthTypes);
+    expect(dynamicPolicy.getWantedAuthTypes()).toEqual(expectedAuthTypes);
 
     expectDynamicPolicyJson(dynamicPolicy, {
       wanted: [],
@@ -271,7 +267,7 @@ describe('DynamicPolicyBuilder', () => {
       .withWantedRememberMe(true)
       .build();
 
-    expect(dynamicPolicy.getWantedRememberMe()).to.equal(true);
+    expect(dynamicPolicy.getWantedRememberMe()).toBe(true);
 
     expectDynamicPolicyJson(dynamicPolicy, {
       wanted: [],
@@ -290,8 +286,8 @@ describe('DynamicPolicyBuilder', () => {
       .build();
 
     const authTypes = dynamicPolicy.getWantedAuthTypes();
-    expect(authTypes).to.not.contain(EXPECTED_SELFIE_AUTH_TYPE);
-    expect(authTypes).to.not.contain(EXPECTED_PIN_AUTH_TYPE);
+    expect(authTypes).not.toContain(EXPECTED_SELFIE_AUTH_TYPE);
+    expect(authTypes).not.toContain(EXPECTED_PIN_AUTH_TYPE);
   });
 
   it('should build with no more than one auth type', () => {
@@ -302,7 +298,7 @@ describe('DynamicPolicyBuilder', () => {
       .build();
 
     const authTypesLength = dynamicPolicy.getWantedAuthTypes().length;
-    expect(authTypesLength).to.equal(1);
+    expect(authTypesLength).toBe(1);
   });
 
   it('should build with only two auth types', () => {
@@ -312,7 +308,7 @@ describe('DynamicPolicyBuilder', () => {
       .build();
 
     const authTypesLength = dynamicPolicy.getWantedAuthTypes().length;
-    expect(authTypesLength).to.equal(2);
+    expect(authTypesLength).toBe(2);
   });
 
   it('should build with no selfie authentication after having it added then removed', () => {
@@ -321,7 +317,7 @@ describe('DynamicPolicyBuilder', () => {
       .withSelfieAuthentication(false)
       .build();
 
-    expect(dynamicPolicy.wantedAuthTypes).to.not.contain(EXPECTED_SELFIE_AUTH_TYPE);
+    expect(dynamicPolicy.wantedAuthTypes).not.toContain(EXPECTED_SELFIE_AUTH_TYPE);
   });
 
   it('should build with no pin authentication after having it added then removed', () => {
@@ -330,6 +326,6 @@ describe('DynamicPolicyBuilder', () => {
       .withPinAuthentication(false)
       .build();
 
-    expect(dynamicPolicy.wantedAuthTypes).to.not.contain(EXPECTED_PIN_AUTH_TYPE);
+    expect(dynamicPolicy.wantedAuthTypes).not.toContain(EXPECTED_PIN_AUTH_TYPE);
   });
 });

--- a/tests/dynamic_sharing_service/policy/source.constraint.builder.spec.js
+++ b/tests/dynamic_sharing_service/policy/source.constraint.builder.spec.js
@@ -1,7 +1,3 @@
-const {
-  expect,
-} = require('chai');
-
 const { SourceConstraintBuilder, WantedAnchorBuilder } = require('../../..');
 const SourceConstraint = require('../../../src/dynamic_sharing_service/policy/source.constraint');
 
@@ -29,7 +25,7 @@ const expectSourceConstraintJson = (
   expectSubType,
   expectSoftPreference = false
 ) => {
-  expect(constraint).to.be.instanceOf(SourceConstraint);
+  expect(constraint).toBeInstanceOf(SourceConstraint);
 
   const expectedJson = JSON.stringify({
     type: CONSTRAINT_TYPE_SOURCE,
@@ -44,7 +40,7 @@ const expectSourceConstraintJson = (
     },
   });
 
-  expect(JSON.stringify(constraint)).to.equal(expectedJson);
+  expect(JSON.stringify(constraint)).toBe(expectedJson);
 };
 
 describe('SourceConstraintBuilder', () => {
@@ -161,7 +157,7 @@ describe('SourceConstraintBuilder', () => {
       .withPasscard(ANCHOR_SUB_TYPE_PASSCARD)
       .build();
 
-    expect(sourceConstraint).to.be.instanceOf(SourceConstraint);
+    expect(sourceConstraint).toBeInstanceOf(SourceConstraint);
 
     const expectedJson = JSON.stringify({
       type: 'SOURCE',
@@ -184,7 +180,7 @@ describe('SourceConstraintBuilder', () => {
       },
     });
 
-    expect(JSON.stringify(sourceConstraint)).to.equal(expectedJson);
+    expect(JSON.stringify(sourceConstraint)).toBe(expectedJson);
   });
 
   it('should build a constraint with soft preference', () => {

--- a/tests/dynamic_sharing_service/policy/wanted.anchor.builder.spec.js
+++ b/tests/dynamic_sharing_service/policy/wanted.anchor.builder.spec.js
@@ -1,7 +1,3 @@
-const {
-  expect,
-} = require('chai');
-
 const { WantedAnchorBuilder } = require('../../..');
 const WantedAnchor = require('../../../src/dynamic_sharing_service/policy/wanted.anchor');
 
@@ -15,12 +11,12 @@ describe('WantedAnchorBuilder', () => {
       .withSubType(TEST_SUB_TYPE)
       .build();
 
-    expect(wantedAnchor).to.be.instanceOf(WantedAnchor);
+    expect(wantedAnchor).toBeInstanceOf(WantedAnchor);
 
     const expectedJson = JSON.stringify({
       name: TEST_VALUE,
       sub_type: TEST_SUB_TYPE,
     });
-    expect(JSON.stringify(wantedAnchor)).to.equal(expectedJson);
+    expect(JSON.stringify(wantedAnchor)).toBe(expectedJson);
   });
 });

--- a/tests/dynamic_sharing_service/policy/wanted.attribute.builder.spec.js
+++ b/tests/dynamic_sharing_service/policy/wanted.attribute.builder.spec.js
@@ -1,7 +1,3 @@
-const {
-  expect,
-} = require('chai');
-
 const { WantedAttributeBuilder, SourceConstraintBuilder, ConstraintsBuilder } = require('../../../');
 const WantedAttribute = require('../../../src/dynamic_sharing_service/policy/wanted.attribute');
 
@@ -21,10 +17,10 @@ describe('WantedAttributeBuilder', () => {
       optional: false,
     });
 
-    expect(wantedAttribute).to.be.instanceOf(WantedAttribute);
-    expect(JSON.stringify(wantedAttribute)).to.equal(expectedJson);
-    expect(wantedAttribute.getName()).to.equal(TEST_NAME);
-    expect(wantedAttribute.getDerivation()).to.equal(TEST_DERIVATION);
+    expect(wantedAttribute).toBeInstanceOf(WantedAttribute);
+    expect(JSON.stringify(wantedAttribute)).toBe(expectedJson);
+    expect(wantedAttribute.getName()).toBe(TEST_NAME);
+    expect(wantedAttribute.getDerivation()).toBe(TEST_DERIVATION);
   });
 
   it('should build a wanted attribute with accept self asserted', () => {
@@ -45,10 +41,10 @@ describe('WantedAttributeBuilder', () => {
       accept_self_asserted: true,
     });
 
-    expect(wantedAttributeDefault).to.be.instanceOf(WantedAttribute);
-    expect(wantedAttribute).to.be.instanceOf(WantedAttribute);
-    expect(JSON.stringify(wantedAttributeDefault)).to.equal(expectedJson);
-    expect(JSON.stringify(wantedAttribute)).to.equal(expectedJson);
+    expect(wantedAttributeDefault).toBeInstanceOf(WantedAttribute);
+    expect(wantedAttribute).toBeInstanceOf(WantedAttribute);
+    expect(JSON.stringify(wantedAttributeDefault)).toBe(expectedJson);
+    expect(JSON.stringify(wantedAttribute)).toBe(expectedJson);
   });
 
   it('should build a wanted attribute without accept self asserted', () => {
@@ -64,8 +60,8 @@ describe('WantedAttributeBuilder', () => {
       accept_self_asserted: false,
     });
 
-    expect(wantedAttribute).to.be.instanceOf(WantedAttribute);
-    expect(JSON.stringify(wantedAttribute)).to.equal(expectedJson);
+    expect(wantedAttribute).toBeInstanceOf(WantedAttribute);
+    expect(JSON.stringify(wantedAttribute)).toBe(expectedJson);
   });
 
   it('should build a wanted attribute with constraints', () => {
@@ -102,7 +98,7 @@ describe('WantedAttributeBuilder', () => {
       ],
     });
 
-    expect(wantedAttribute).to.be.instanceOf(WantedAttribute);
-    expect(JSON.stringify(wantedAttribute)).to.equal(expectedJson);
+    expect(wantedAttribute).toBeInstanceOf(WantedAttribute);
+    expect(JSON.stringify(wantedAttribute)).toBe(expectedJson);
   });
 });

--- a/tests/profile_service/activity.details.spec.js
+++ b/tests/profile_service/activity.details.spec.js
@@ -1,4 +1,3 @@
-const expect = require('chai').expect;
 const { ActivityDetails } = require('../../src/profile_service/activity.details');
 const { Profile } = require('../../src/profile_service/profile');
 const { ApplicationProfile } = require('../../src/profile_service/application.profile');
@@ -6,32 +5,32 @@ const { Attribute } = require('../../src/data_type/attribute');
 
 describe('ActivityDetails', () => {
   describe('#getRememberMeId', () => {
-    context('when remember_me_id is available', () => {
+    describe('when remember_me_id is available', () => {
       const activityDetails = new ActivityDetails({
         receipt: {
           remember_me_id: 'test_remember_me_id',
         },
       });
       it('should return remember_me_id value', () => {
-        expect(activityDetails.getRememberMeId()).to.equal('test_remember_me_id');
+        expect(activityDetails.getRememberMeId()).toBe('test_remember_me_id');
       });
     });
-    context('when remember_me_id is undefined', () => {
+    describe('when remember_me_id is undefined', () => {
       const activityDetails = new ActivityDetails({
         receipt: {},
       });
       it('should return undefined', () => {
-        expect(activityDetails.getRememberMeId()).to.equal(undefined);
+        expect(activityDetails.getRememberMeId()).toBe(undefined);
       });
     });
-    context('when remember_me_id is empty string', () => {
+    describe('when remember_me_id is empty string', () => {
       const activityDetails = new ActivityDetails({
         receipt: {
           remember_me_id: '',
         },
       });
       it('should return empty string value', () => {
-        expect(activityDetails.getRememberMeId()).to.equal('');
+        expect(activityDetails.getRememberMeId()).toBe('');
       });
     });
   });
@@ -42,36 +41,36 @@ describe('ActivityDetails', () => {
       },
     });
     it('should return remember_me_id value', () => {
-      expect(activityDetails.getUserId()).to.equal('test_remember_me_id');
+      expect(activityDetails.getUserId()).toBe('test_remember_me_id');
     });
   });
   describe('#getParentRememberMeId', () => {
-    context('when parent_remember_me_id is available', () => {
+    describe('when parent_remember_me_id is available', () => {
       const activityDetails = new ActivityDetails({
         receipt: {
           parent_remember_me_id: 'test_parent_remember_me_id',
         },
       });
       it('should return parent_remember_me_id value', () => {
-        expect(activityDetails.getParentRememberMeId()).to.equal('test_parent_remember_me_id');
+        expect(activityDetails.getParentRememberMeId()).toBe('test_parent_remember_me_id');
       });
     });
-    context('when parent_remember_me_id is undefined', () => {
+    describe('when parent_remember_me_id is undefined', () => {
       const activityDetails = new ActivityDetails({
         receipt: {},
       });
       it('should return undefined', () => {
-        expect(activityDetails.getParentRememberMeId()).to.equal(undefined);
+        expect(activityDetails.getParentRememberMeId()).toBe(undefined);
       });
     });
-    context('when parent_remember_me_id is empty string', () => {
+    describe('when parent_remember_me_id is empty string', () => {
       const activityDetails = new ActivityDetails({
         receipt: {
           parent_remember_me_id: '',
         },
       });
       it('should return empty string value', () => {
-        expect(activityDetails.getParentRememberMeId()).to.equal('');
+        expect(activityDetails.getParentRememberMeId()).toBe('');
       });
     });
   });
@@ -88,8 +87,8 @@ describe('ActivityDetails', () => {
     ]);
     it('should return Profile object', () => {
       const profile = activityDetails.getProfile();
-      expect(profile).to.be.instanceOf(Profile);
-      expect(profile.getAttribute('attr_key').getValue()).to.equal('attr_value');
+      expect(profile).toBeInstanceOf(Profile);
+      expect(profile.getAttribute('attr_key').getValue()).toBe('attr_value');
     });
   });
   describe('#getUserProfile', () => {
@@ -99,7 +98,7 @@ describe('ActivityDetails', () => {
       },
     ]);
     it('should return user profile object', () => {
-      expect(activityDetails.getUserProfile()).to.eql({
+      expect(activityDetails.getUserProfile()).toEqual({
         attr_key: 'attr_value',
       });
     });
@@ -117,8 +116,8 @@ describe('ActivityDetails', () => {
     ]);
     it('should return ApplicationProfile object', () => {
       const applicationProfile = activityDetails.getApplicationProfile();
-      expect(applicationProfile).to.be.instanceOf(ApplicationProfile);
-      expect(applicationProfile.getAttribute('attr_key').getValue()).to.equal('attr_value');
+      expect(applicationProfile).toBeInstanceOf(ApplicationProfile);
+      expect(applicationProfile.getAttribute('attr_key').getValue()).toBe('attr_value');
     });
   });
   describe('#getOutcome', () => {
@@ -128,7 +127,7 @@ describe('ActivityDetails', () => {
       },
     });
     it('should return sharing_outcome value', () => {
-      expect(activityDetails.getOutcome()).to.equal('test_outcome');
+      expect(activityDetails.getOutcome()).toBe('test_outcome');
     });
   });
   describe('#getBase64SelfieUri', () => {
@@ -138,7 +137,7 @@ describe('ActivityDetails', () => {
           base64SelfieUri: 'test_base64_encoded_uri',
         },
       ]);
-      expect(activityDetails.getBase64SelfieUri()).to.equal('test_base64_encoded_uri');
+      expect(activityDetails.getBase64SelfieUri()).toBe('test_base64_encoded_uri');
     });
   });
   describe('#getTimestamp', () => {
@@ -148,7 +147,7 @@ describe('ActivityDetails', () => {
       },
     });
     it('should return timestamp value', () => {
-      expect(activityDetails.getTimestamp().toUTCString()).to.equal('Tue, 04 Nov 2003 12:51:07 GMT');
+      expect(activityDetails.getTimestamp().toUTCString()).toBe('Tue, 04 Nov 2003 12:51:07 GMT');
     });
   });
 });

--- a/tests/profile_service/application.profile.spec.js
+++ b/tests/profile_service/application.profile.spec.js
@@ -1,5 +1,4 @@
 const fs = require('fs');
-const expect = require('chai').expect;
 const { ApplicationProfile } = require('../../src/profile_service/application.profile');
 const { Attribute } = require('../../src/data_type/attribute');
 
@@ -12,40 +11,40 @@ describe('ApplicationProfile', () => {
   describe('#getName', () => {
     it('should return application_name value', () => {
       expect(profileObj.getName().getValue())
-        .to.equal(profileData.application_name.value);
+        .toBe(profileData.application_name.value);
     });
   });
 
   describe('#getUrl', () => {
     it('should return application_url value', () => {
       expect(profileObj.getUrl().getValue())
-        .to.equal(profileData.application_url.value);
+        .toBe(profileData.application_url.value);
     });
   });
 
   describe('#getReceiptBgColor', () => {
     it('should return application_receipt_bgcolor value', () => {
       expect(profileObj.getReceiptBgColor().getValue())
-        .to.equal(profileData.application_receipt_bgcolor.value);
+        .toBe(profileData.application_receipt_bgcolor.value);
     });
   });
 
   describe('#getLogo', () => {
     it('should return application_logo value', () => {
       expect(profileObj.getLogo().getValue())
-        .to.equal(profileData.application_logo.value);
+        .toBe(profileData.application_logo.value);
     });
   });
 
   describe('#getAttributes', () => {
     it('should return all attributes', () => {
       const attributes = profileObj.getAttributes();
-      expect(Object.keys(attributes).length).to.be.equal(4);
+      expect(Object.keys(attributes).length).toBe(4);
       Object.keys(attributes).forEach((attributeName) => {
-        expect(attributes[attributeName]).to.instanceOf(Attribute);
+        expect(attributes[attributeName]).toBeInstanceOf(Attribute);
       });
-      expect(attributes.application_name.getName()).to.equal('application_name');
-      expect(attributes.application_name.getValue()).to.equal('TEST APPLICATION');
+      expect(attributes.application_name.getName()).toBe('application_name');
+      expect(attributes.application_name.getValue()).toBe('TEST APPLICATION');
     });
   });
 });

--- a/tests/profile_service/index.spec.js
+++ b/tests/profile_service/index.spec.js
@@ -1,4 +1,3 @@
-const expect = require('chai').expect;
 const nock = require('nock');
 const fs = require('fs');
 
@@ -18,7 +17,7 @@ describe('profileService', () => {
     const parentRememberMeId = 'f5RjVQMyoKOvO/hkv43Ik+t6d6mGfP2tdrNijH4k4qafTG0FSNUgQIvd2Z3Nx1j8';
     const receiptId = '9HNJDX5bEIN5TqBm0OGzVIc1LaAmbzfx6eIrwNdwpHvKeQmgPujyogC+r7hJCVPl';
 
-    context('when the profile has attributes', () => {
+    describe('when the profile has attributes', () => {
       const response = fs.readFileSync('./tests/sample-data/payloads/payload.json', 'utf8');
 
       const selfie = fs.readFileSync('./tests/sample-data/fixtures/selfie.txt', 'utf8');
@@ -37,17 +36,17 @@ describe('profileService', () => {
             const profile = receipt.getUserProfile();
             const outcome = receipt.getOutcome();
 
-            expect(profile).to.not.equal(undefined);
-            expect(receipt.getReceiptId()).to.equal(receiptId);
-            expect(receipt.getUserId()).to.equal(rememberMeId);
-            expect(receipt.getRememberMeId()).to.equal(rememberMeId);
-            expect(receipt.getParentRememberMeId()).to.equal(parentRememberMeId);
-            expect(receipt.getTimestamp()).to.be.a('Date');
-            expect(receipt.getTimestamp().toUTCString()).to.equal('Tue, 19 Jul 2016 08:55:38 GMT');
-            expect(profile.phoneNumber).to.equal(phoneNumber);
-            expect(`data:image/jpeg;base64,${profile.selfie.toBase64()}`).to.equal(selfie);
-            expect(receipt.getBase64SelfieUri()).to.equal(selfie);
-            expect(outcome).to.equal('SUCCESS');
+            expect(profile).not.toBe(undefined);
+            expect(receipt.getReceiptId()).toBe(receiptId);
+            expect(receipt.getUserId()).toBe(rememberMeId);
+            expect(receipt.getRememberMeId()).toBe(rememberMeId);
+            expect(receipt.getParentRememberMeId()).toBe(parentRememberMeId);
+            expect(receipt.getTimestamp()).toBeInstanceOf(Date);
+            expect(receipt.getTimestamp().toUTCString()).toBe('Tue, 19 Jul 2016 08:55:38 GMT');
+            expect(profile.phoneNumber).toBe(phoneNumber);
+            expect(`data:image/jpeg;base64,${profile.selfie.toBase64()}`).toBe(selfie);
+            expect(receipt.getBase64SelfieUri()).toBe(selfie);
+            expect(outcome).toBe('SUCCESS');
 
             done();
           })
@@ -55,7 +54,7 @@ describe('profileService', () => {
       });
     });
 
-    context('when the profile is empty', () => {
+    describe('when the profile is empty', () => {
       const responseContentNull = fs.readFileSync('./tests/sample-data/payloads/payload-other-party-null.json', 'utf8');
 
       beforeEach((done) => {
@@ -71,13 +70,13 @@ describe('profileService', () => {
             const profile = receipt.getUserProfile();
             const outcome = receipt.getOutcome();
 
-            expect(profile).to.not.equal(undefined);
-            expect(profile).to.deep.equal({});
-            expect(receipt.getReceiptId()).to.equal(receiptId);
-            expect(receipt.getUserId()).to.equal(rememberMeId);
-            expect(receipt.getRememberMeId()).to.equal(rememberMeId);
-            expect(receipt.getParentRememberMeId()).to.equal(parentRememberMeId);
-            expect(outcome).to.equal('SUCCESS');
+            expect(profile).not.toBe(undefined);
+            expect(profile).toEqual({});
+            expect(receipt.getReceiptId()).toBe(receiptId);
+            expect(receipt.getUserId()).toBe(rememberMeId);
+            expect(receipt.getRememberMeId()).toBe(rememberMeId);
+            expect(receipt.getParentRememberMeId()).toBe(parentRememberMeId);
+            expect(outcome).toBe('SUCCESS');
 
             done();
           })
@@ -85,7 +84,7 @@ describe('profileService', () => {
       });
     });
 
-    context('when the profile contains an empty object', () => {
+    describe('when the profile contains an empty object', () => {
       const responseContentEmptyObj = fs.readFileSync('./tests/sample-data/payloads/payload-other-party-empty-object.json', 'utf8');
 
       beforeEach((done) => {
@@ -101,13 +100,13 @@ describe('profileService', () => {
             const profile = receipt.getUserProfile();
             const outcome = receipt.getOutcome();
 
-            expect(profile).to.not.equal(undefined);
-            expect(profile).to.deep.equal({});
-            expect(receipt.getReceiptId()).to.equal(receiptId);
-            expect(receipt.getUserId()).to.equal(rememberMeId);
-            expect(receipt.getRememberMeId()).to.equal(rememberMeId);
-            expect(receipt.getParentRememberMeId()).to.equal(parentRememberMeId);
-            expect(outcome).to.equal('SUCCESS');
+            expect(profile).not.toBe(undefined);
+            expect(profile).toEqual({});
+            expect(receipt.getReceiptId()).toBe(receiptId);
+            expect(receipt.getUserId()).toBe(rememberMeId);
+            expect(receipt.getRememberMeId()).toBe(rememberMeId);
+            expect(receipt.getParentRememberMeId()).toBe(parentRememberMeId);
+            expect(outcome).toBe('SUCCESS');
 
             done();
           })
@@ -115,7 +114,7 @@ describe('profileService', () => {
       });
     });
 
-    context('when the response does not have profile attributes', () => {
+    describe('when the response does not have profile attributes', () => {
       const responseContentNonExistent = fs.readFileSync('./tests/sample-data/payloads/payload-other-party-non-existent.json', 'utf8');
 
       beforeEach((done) => {
@@ -131,13 +130,13 @@ describe('profileService', () => {
             const profile = receipt.getUserProfile();
             const outcome = receipt.getOutcome();
 
-            expect(profile).to.not.equal(undefined);
-            expect(profile).to.deep.equal({});
-            expect(receipt.getReceiptId()).to.equal(receiptId);
-            expect(receipt.getUserId()).to.equal(rememberMeId);
-            expect(receipt.getRememberMeId()).to.equal(rememberMeId);
-            expect(receipt.getParentRememberMeId()).to.equal(parentRememberMeId);
-            expect(outcome).to.equal('SUCCESS');
+            expect(profile).not.toBe(undefined);
+            expect(profile).toEqual({});
+            expect(receipt.getReceiptId()).toBe(receiptId);
+            expect(receipt.getUserId()).toBe(rememberMeId);
+            expect(receipt.getRememberMeId()).toBe(rememberMeId);
+            expect(receipt.getParentRememberMeId()).toBe(parentRememberMeId);
+            expect(outcome).toBe('SUCCESS');
 
             done();
           })

--- a/tests/profile_service/profile.spec.js
+++ b/tests/profile_service/profile.spec.js
@@ -1,5 +1,4 @@
 const fs = require('fs');
-const { expect } = require('chai');
 const { Profile } = require('../../src/profile_service/profile');
 const { Attribute } = require('../../src/data_type/attribute');
 
@@ -58,42 +57,42 @@ describe('Profile', () => {
   describe('#getFullName', () => {
     const expectedValue = 'TEST FULL_NAME';
     it('should return full_name value', () => {
-      expect(profileObj.getFullName().getValue()).to.equal(expectedValue);
+      expect(profileObj.getFullName().getValue()).toBe(expectedValue);
     });
   });
 
   describe('#getGivenNames', () => {
     const expectedValue = 'TEST GIVEN_NAMES';
     it('should return given_names value', () => {
-      expect(profileObj.getGivenNames().getValue()).to.equal(expectedValue);
+      expect(profileObj.getGivenNames().getValue()).toBe(expectedValue);
     });
   });
 
   describe('#getFamilyName', () => {
     const expectedValue = 'TEST FAMILY_NAME';
     it('should return family_name value', () => {
-      expect(profileObj.getFamilyName().getValue()).to.equal(expectedValue);
+      expect(profileObj.getFamilyName().getValue()).toBe(expectedValue);
     });
   });
 
   describe('#getGender', () => {
     const expectedValue = 'TEST MALE';
     it('should return gender value', () => {
-      expect(profileObj.getGender().getValue()).to.equal(expectedValue);
+      expect(profileObj.getGender().getValue()).toBe(expectedValue);
     });
   });
 
   describe('#getEmailAddress', () => {
     const expectedValue = 'example@yoti.com';
     it('should return email_address value', () => {
-      expect(profileObj.getEmailAddress().getValue()).to.equal(expectedValue);
+      expect(profileObj.getEmailAddress().getValue()).toBe(expectedValue);
     });
   });
 
   describe('#getAgeVerified', () => {
     const expectedValue = 'true';
     it('should return age_verified value', () => {
-      expect(profileObj.getAgeVerified().getValue()).to.equal(expectedValue);
+      expect(profileObj.getAgeVerified().getValue()).toBe(expectedValue);
     });
   });
 
@@ -101,7 +100,7 @@ describe('Profile', () => {
     it('should return full_name first source value', () => {
       const expectedValue = 'PASSPORT';
       const sourceValue = profileObj.getFullName().getSources()[0].getValue();
-      expect(sourceValue).to.equal(expectedValue);
+      expect(sourceValue).toBe(expectedValue);
     });
   });
 
@@ -109,18 +108,18 @@ describe('Profile', () => {
     it('should return full_name first verifier value', () => {
       const expectedValue = 'YOTI_ADMIN';
       const verifierValue = profileObj.getFullName().getVerifiers()[0].getValue();
-      expect(verifierValue).to.equal(expectedValue);
+      expect(verifierValue).toBe(expectedValue);
     });
   });
 
   describe('#getPostalAddress', () => {
-    context('when postal address is available', () => {
+    describe('when postal address is available', () => {
       it('should return postal_address value', () => {
         const expectedValue = 'TEST ADDRESS';
-        expect(profileObj.getPostalAddress().getValue()).to.equal(expectedValue);
+        expect(profileObj.getPostalAddress().getValue()).toBe(expectedValue);
       });
     });
-    context('when postal address is null', () => {
+    describe('when postal address is null', () => {
       const expectedValue = 'SOME FORMATTED ADDRESS';
       const expectedName = 'postal_address';
       const expectedSources = [new YotiAnchor({
@@ -154,19 +153,19 @@ describe('Profile', () => {
 
       it('should return formatted address with structured address anchors', () => {
         const postalAddressAttr = profileNoAddress.getPostalAddress();
-        expect(postalAddressAttr.getName()).to.equal(expectedName);
-        expect(postalAddressAttr.getValue()).to.equal(expectedValue);
-        expect(postalAddressAttr.getSources()).to.equal(expectedSources);
-        expect(postalAddressAttr.getVerifiers()).to.equal(expectedVerifiers);
+        expect(postalAddressAttr.getName()).toBe(expectedName);
+        expect(postalAddressAttr.getValue()).toBe(expectedValue);
+        expect(postalAddressAttr.getSources()).toBe(expectedSources);
+        expect(postalAddressAttr.getVerifiers()).toBe(expectedVerifiers);
       });
     });
-    context('when both postal address and structured address are null', () => {
+    describe('when both postal address and structured address are null', () => {
       const profileDataNoAddress = loadProfileData();
       delete profileDataNoAddress.postal_address;
       delete profileDataNoAddress.structured_postal_address;
       const profileNoAddress = new Profile(profileDataNoAddress);
       it('should return null', () => {
-        expect(profileNoAddress.getPostalAddress()).to.equal(null);
+        expect(profileNoAddress.getPostalAddress()).toBe(null);
       });
     });
   });
@@ -174,25 +173,25 @@ describe('Profile', () => {
   describe('#getStructuredPostalAddress', () => {
     it('should return structured_postal_address value', () => {
       expect(profileObj.getStructuredPostalAddress().getValue())
-        .to.eql(profileData.structured_postal_address.value);
+        .toBe(profileData.structured_postal_address.value);
     });
   });
 
   describe('#getDocumentImages', () => {
     it('should return document_images value', () => {
-      expect(profileObj.getDocumentImages().getValue()).to.eql(profileData.document_images.value);
+      expect(profileObj.getDocumentImages().getValue()).toBe(profileData.document_images.value);
     });
   });
 
   describe('#getAttributes', () => {
     it('should return all attributes', () => {
       const attributes = profileObj.getAttributes();
-      expect(Object.keys(attributes).length).to.be.equal(16);
+      expect(Object.keys(attributes).length).toBe(16);
       Object.keys(attributes).forEach((attributeName) => {
-        expect(attributes[attributeName]).to.instanceOf(Attribute);
+        expect(attributes[attributeName]).toBeInstanceOf(Attribute);
       });
-      expect(attributes.gender.getName()).to.equal('gender');
-      expect(attributes.gender.getValue()).to.equal('TEST MALE');
+      expect(attributes.gender.getName()).toBe('gender');
+      expect(attributes.gender.getValue()).toBe('TEST MALE');
     });
   });
 
@@ -206,55 +205,55 @@ describe('Profile', () => {
       ];
       const ageVerifications = profileObj.getAgeVerifications();
 
-      expect(ageVerifications).to.be.instanceOf(Array);
-      expect(ageVerifications).to.be.length(4);
+      expect(ageVerifications).toBeInstanceOf(Array);
+      expect(ageVerifications).toHaveLength(4);
 
       ageVerifications.forEach((ageVerification) => {
-        expect(expectedAgeAttributes).to.include(ageVerification.getAttribute());
+        expect(expectedAgeAttributes).toContainEqual(ageVerification.getAttribute());
       });
     });
 
     it('should return an empty array when there are no age verifications', () => {
       const emptyProfile = new Profile();
       const ageVerifications = emptyProfile.getAgeVerifications();
-      expect(ageVerifications).to.be.instanceOf(Array);
-      expect(ageVerifications).to.be.length(0);
+      expect(ageVerifications).toBeInstanceOf(Array);
+      expect(ageVerifications).toHaveLength(0);
     });
   });
   describe('#findAgeUnderVerification', () => {
     it('should find unsuccessful age under verification', () => {
       const verification = profileObj.findAgeUnderVerification(18);
-      expect(verification.getAge()).to.equal(18);
-      expect(verification.getCheckType()).to.equal('age_under');
-      expect(verification.getResult()).to.equal(false);
+      expect(verification.getAge()).toBe(18);
+      expect(verification.getCheckType()).toBe('age_under');
+      expect(verification.getResult()).toBe(false);
     });
     it('should find successful age under verification', () => {
       const verification = profileObj.findAgeUnderVerification(21);
-      expect(verification.getAge()).to.equal(21);
-      expect(verification.getCheckType()).to.equal('age_under');
-      expect(verification.getResult()).to.equal(true);
+      expect(verification.getAge()).toBe(21);
+      expect(verification.getCheckType()).toBe('age_under');
+      expect(verification.getResult()).toBe(true);
     });
     it('should return NULL for no match', () => {
       const verification = profileObj.findAgeUnderVerification(100);
-      expect(verification).to.equal(null);
+      expect(verification).toBe(null);
     });
   });
   describe('#findAgeOverVerification', () => {
     it('should find successful age over verification', () => {
       const verification = profileObj.findAgeOverVerification(18);
-      expect(verification.getAge()).to.equal(18);
-      expect(verification.getCheckType()).to.equal('age_over');
-      expect(verification.getResult()).to.equal(true);
+      expect(verification.getAge()).toBe(18);
+      expect(verification.getCheckType()).toBe('age_over');
+      expect(verification.getResult()).toBe(true);
     });
     it('should find unsuccessful age over verification', () => {
       const verification = profileObj.findAgeOverVerification(21);
-      expect(verification.getAge()).to.equal(21);
-      expect(verification.getCheckType()).to.equal('age_over');
-      expect(verification.getResult()).to.equal(false);
+      expect(verification.getAge()).toBe(21);
+      expect(verification.getCheckType()).toBe('age_over');
+      expect(verification.getResult()).toBe(false);
     });
     it('should return NULL for no match', () => {
       const verification = profileObj.findAgeOverVerification(100);
-      expect(verification).to.equal(null);
+      expect(verification).toBe(null);
     });
   });
 });

--- a/tests/request/index.spec.js
+++ b/tests/request/index.spec.js
@@ -1,4 +1,3 @@
-const expect = require('chai').expect;
 const nock = require('nock');
 const fs = require('fs');
 
@@ -24,7 +23,7 @@ const mockConnectApi = () => {
 
 describe('request', () => {
   describe('#buildConnectApiRequest', () => {
-    context('when making a Connect API request', () => {
+    describe('when making a Connect API request', () => {
       mockConnectApi();
 
       it('should make a successful POST request to the endpoint', (done) => {
@@ -38,7 +37,7 @@ describe('request', () => {
 
         request.execute()
           .then((response) => {
-            expect(response.getParsedResponse()).to.be.a('object');
+            expect(response.getParsedResponse()).toBeInstanceOf(Object);
             done();
           })
           .catch(done);
@@ -47,13 +46,13 @@ describe('request', () => {
   });
 
   describe('#makeRequest', () => {
-    context('when making a Connect API request', () => {
+    describe('when making a Connect API request', () => {
       mockConnectApi();
 
       it('should make a successful POST request to the endpoint', (done) => {
         yotiRequest.makeRequest('POST', '/some-endpoint', PEM_STRING, 'stub-app-id', expectedPayload)
           .then((response) => {
-            expect(response.getParsedResponse()).to.be.a('object');
+            expect(response.getParsedResponse()).toBeInstanceOf(Object);
             done();
           })
           .catch(done);

--- a/tests/request/payload.spec.js
+++ b/tests/request/payload.spec.js
@@ -1,5 +1,3 @@
-const expect = require('chai').expect;
-
 const { AmlAddress, AmlProfile } = require('../../src/aml_type');
 const { Payload } = require('../../');
 
@@ -13,14 +11,14 @@ describe('amlPayload', () => {
   describe('#getPayloadJSON', () => {
     it('should return the payload JSON string', () => {
       const payloadJSON = amlPayload.getPayloadJSON();
-      expect(payloadJSON).to.equal(expectedPayloadJSON);
+      expect(payloadJSON).toBe(expectedPayloadJSON);
     });
   });
 
   describe('#getBase64Payload', () => {
     it('should return the base64Payload string', () => {
       const base64Payload = amlPayload.getBase64Payload();
-      expect(base64Payload).to.equal(expectedBase64Payload);
+      expect(base64Payload).toBe(expectedBase64Payload);
     });
   });
 });

--- a/tests/request/request.builder.spec.js
+++ b/tests/request/request.builder.spec.js
@@ -1,4 +1,3 @@
-const expect = require('chai').expect;
 const nock = require('nock');
 const fs = require('fs');
 
@@ -17,7 +16,7 @@ const API_ENDPOINT = '/some-endpoint';
  * @param {Request} request
  */
 const assertExpectedRequest = (request, done) => {
-  expect(request).to.be.instanceOf(YotiRequest);
+  expect(request).toBeInstanceOf(YotiRequest);
 
   // Check that auth headers are present.
   request.execute()
@@ -33,7 +32,7 @@ const assertExpectedRequest = (request, done) => {
 
       Object.keys(expectedHeaders).forEach((header) => {
         const sentHeader = sentHeaders[header.toLowerCase()];
-        expect(sentHeader).to.equal(expectedHeaders[header], header);
+        expect(sentHeader).toBe(expectedHeaders[header], header);
       });
 
       const expectedMatchHeaders = {
@@ -43,7 +42,7 @@ const assertExpectedRequest = (request, done) => {
 
       Object.keys(expectedMatchHeaders).forEach((header) => {
         const sentHeader = sentHeaders[header.toLowerCase()];
-        expect(sentHeader).to.match(expectedMatchHeaders[header], header);
+        expect(sentHeader).toMatch(expectedMatchHeaders[header], header);
       });
 
       done();
@@ -88,7 +87,7 @@ describe('RequestBuilder', () => {
         new RequestBuilder()
           .withBaseUrl(API_BASE_URL)
           .build();
-      }).to.throw(Error, 'PEM file path or string must be provided');
+      }).toThrow(Error, 'PEM file path or string must be provided');
     });
 
     it('should require a base url', () => {
@@ -96,7 +95,7 @@ describe('RequestBuilder', () => {
         new RequestBuilder()
           .withPemFilePath(PEM_FILE_PATH)
           .build();
-      }).to.throw(Error, 'Base URL must be specified');
+      }).toThrow(Error, 'Base URL must be specified');
     });
 
     it('should build with valid headers', (done) => {
@@ -113,8 +112,8 @@ describe('RequestBuilder', () => {
         .execute()
         .then((response) => {
           const headers = response.getParsedResponse().headers;
-          expect(headers['custom-1']).to.eql('value 1');
-          expect(headers['custom-2']).to.eql('value 2');
+          expect(headers['custom-1']).toBe('value 1');
+          expect(headers['custom-2']).toBe('value 2');
           done();
         })
         .catch(done);
@@ -159,7 +158,7 @@ describe('RequestBuilder', () => {
           .withHeader('Custom-1', 'valid header')
           .withHeader('Custom-2', ['invalid header'])
           .build();
-      }).to.throw(TypeError, "'Custom-2' header must be a string");
+      }).toThrow(TypeError, "'Custom-2' header must be a string");
     });
 
     it('should only accept string header name', () => {
@@ -171,7 +170,7 @@ describe('RequestBuilder', () => {
           .withHeader('Valid-Name', 'value')
           .withHeader(['Invalid-Name'], 'value')
           .build();
-      }).to.throw(TypeError, 'Header name must be a string');
+      }).toThrow(TypeError, 'Header name must be a string');
     });
   });
 });

--- a/tests/request/request.spec.js
+++ b/tests/request/request.spec.js
@@ -1,5 +1,3 @@
-const { expect } = require('chai');
-
 const { YotiRequest } = require('../../src/request/request');
 const { Payload } = require('../../src/request/payload');
 
@@ -14,44 +12,44 @@ const SOME_REQUEST = new YotiRequest(SOME_METHOD, SOME_URL, SOME_HEADERS, SOME_P
 describe('YotiRequest', () => {
   describe('#getUrl', () => {
     it('should return the URL', () => {
-      expect(SOME_REQUEST.getUrl()).equals(SOME_URL);
+      expect(SOME_REQUEST.getUrl()).toBe(SOME_URL);
     });
   });
   describe('#getMethod', () => {
     it('should return the method', () => {
-      expect(SOME_REQUEST.getMethod()).equals(SOME_METHOD);
+      expect(SOME_REQUEST.getMethod()).toBe(SOME_METHOD);
     });
   });
   describe('#getPayload', () => {
     it('should return the payload', () => {
-      expect(SOME_REQUEST.getPayload()).equals(SOME_PAYLOAD);
+      expect(SOME_REQUEST.getPayload()).toBe(SOME_PAYLOAD);
     });
   });
   describe('#getHeaders', () => {
     it('should return the header', () => {
-      expect(SOME_REQUEST.getHeaders()).equals(SOME_HEADERS);
+      expect(SOME_REQUEST.getHeaders()).toBe(SOME_HEADERS);
     });
   });
   describe('#constructor', () => {
-    context('When provided non-string URL', () => {
+    describe('When provided non-string URL', () => {
       it('should throw TypeError', () => {
         expect(() => new YotiRequest(SOME_METHOD, ['invalid'], SOME_HEADERS, SOME_PAYLOAD))
-          .to.throw(TypeError, 'url must be a string');
+          .toThrow(TypeError, 'url must be a string');
       });
     });
-    context('When provided invalid payload', () => {
+    describe('When provided invalid payload', () => {
       it('should throw TypeError', () => {
         expect(() => new YotiRequest(SOME_METHOD, SOME_URL, SOME_HEADERS, ['invalid']))
-          .to.throw(TypeError, 'payload must be instance of Payload');
+          .toThrow(TypeError, 'payload must be instance of Payload');
       });
     });
-    context('When provided invalid method', () => {
+    describe('When provided invalid method', () => {
       it('should throw Error', () => {
         expect(() => new YotiRequest('INVALID', SOME_URL, SOME_HEADERS, SOME_PAYLOAD))
-          .to.throw(Error, 'HTTP method INVALID is not supported');
+          .toThrow(Error, 'HTTP method INVALID is not supported');
       });
     });
-    context('When provided invalid headers', () => {
+    describe('When provided invalid headers', () => {
       it('should throw TypeError', () => {
         const invalidHeader = {
           some: {
@@ -59,7 +57,7 @@ describe('YotiRequest', () => {
           },
         };
         expect(() => new YotiRequest(SOME_METHOD, SOME_URL, invalidHeader, SOME_PAYLOAD))
-          .to.throw(TypeError, 'all values in headers must be a string');
+          .toThrow(TypeError, 'all values in headers must be a string');
       });
     });
   });

--- a/tests/yoti_common/anchor.processor.spec.js
+++ b/tests/yoti_common/anchor.processor.spec.js
@@ -1,7 +1,6 @@
 const fs = require('fs');
 const AnchorProcessor = require('../../src/yoti_common/anchor.processor').AnchorProcessor;
 const protoRoot = require('../../src/proto-root').initializeProtoBufObjects();
-const expect = require('chai').expect;
 
 function parseAnchorData(anchorString) {
   return protoRoot.builder.attrpubapi_v1.Anchor.decode(anchorString);
@@ -9,7 +8,7 @@ function parseAnchorData(anchorString) {
 
 describe('anchorProcessor', () => {
   describe('#process', () => {
-    context('when processing DL Source Anchor data', () => {
+    describe('when processing DL Source Anchor data', () => {
       const dlSourceAnchor = fs.readFileSync('./tests/sample-data/yoti-common/dl-source-anchor.txt', 'utf8');
 
       it('should return DRIVING_LICENCE as value', () => {
@@ -17,11 +16,11 @@ describe('anchorProcessor', () => {
         const dlAnchorObj = parseAnchorData(dlSourceAnchor);
         const anchorSources = AnchorProcessor.process([dlAnchorObj]);
         const anchorValue = anchorSources.sources[0].getValue();
-        expect(anchorValue).to.equal(expectedSourceValue);
+        expect(anchorValue).toBe(expectedSourceValue);
       });
     });
 
-    context('when processing Passport Source Anchor data', () => {
+    describe('when processing Passport Source Anchor data', () => {
       const ppSourceAnchor = fs.readFileSync('./tests/sample-data/yoti-common/pp-source-anchor.txt', 'utf8');
       const ppAnchorObj = parseAnchorData(ppSourceAnchor);
       const anchorSources = AnchorProcessor.process([ppAnchorObj]);
@@ -30,32 +29,31 @@ describe('anchorProcessor', () => {
       it('should return PASSPORT as value', () => {
         const expectedSourceValue = 'PASSPORT';
         const anchorValue = firstSource.getValue();
-        expect(anchorValue).to.equal(expectedSourceValue);
+        expect(anchorValue).toBe(expectedSourceValue);
       });
 
       it('should return OCR as subType', () => {
         const expectedSubType = 'OCR';
         const subType = firstSource.getSubType();
-        expect(subType).to.equal(expectedSubType);
+        expect(subType).toBe(expectedSubType);
       });
 
       it('should return Thu, 12 Apr 2018 13:14:32 GMT as timestamp', () => {
         const expectedTimestamp = 'Thu, 12 Apr 2018 13:14:32 GMT';
         const timestamp = firstSource.getSignedTimeStamp().getTimestamp();
-        expect(timestamp).to.be.a('Date');
-        expect(timestamp).to.be.instanceOf(Date);
-        expect(timestamp.toUTCString()).to.equal(expectedTimestamp);
-        expect(timestamp.getMicrosecondTimestamp()).to.equal('2018-04-12T13:14:32.835537Z');
+        expect(timestamp).toBeInstanceOf(Date);
+        expect(timestamp.toUTCString()).toBe(expectedTimestamp);
+        expect(timestamp.getMicrosecondTimestamp()).toBe('2018-04-12T13:14:32.835537Z');
       });
 
       it('should return 1.2.840.113549.1.1.11 as signature Oid', () => {
         const expectedCertificate = '1.2.840.113549.1.1.11';
         const certificates = firstSource.getOriginServerCerts();
-        expect(expectedCertificate).to.equal(certificates[0].signatureOid);
+        expect(expectedCertificate).toBe(certificates[0].signatureOid);
       });
     });
 
-    context('when processing Verifier Anchor data', () => {
+    describe('when processing Verifier Anchor data', () => {
       const verifierAnchor = fs.readFileSync('./tests/sample-data/yoti-common/verifier-anchor.txt', 'utf8');
       const AnchorObj = parseAnchorData(verifierAnchor);
       const anchorVerifiers = AnchorProcessor.process([AnchorObj]);
@@ -64,62 +62,61 @@ describe('anchorProcessor', () => {
       it('should return YOTI_ADMIN as value', () => {
         const expectedAnchorValue = 'YOTI_ADMIN';
         const anchorValue = firstVerifier.getValue();
-        expect(anchorValue).to.equal(expectedAnchorValue);
+        expect(anchorValue).toBe(expectedAnchorValue);
       });
 
       it('should return empty subType', () => {
         const expectedSubType = '';
         const subType = firstVerifier.getSubType();
-        expect(subType).to.equal(expectedSubType);
+        expect(subType).toBe(expectedSubType);
       });
 
       it('should return Wed, 11 Apr 2018 12:13:04 GMT as timestamp', () => {
         const expectedTimestamp = 'Wed, 11 Apr 2018 12:13:04 GMT';
         const timestamp = firstVerifier.getSignedTimeStamp().getTimestamp();
-        expect(timestamp).to.be.a('Date');
-        expect(timestamp).to.be.instanceOf(Date);
-        expect(timestamp.toUTCString()).to.equal(expectedTimestamp);
-        expect(timestamp.getMicrosecondTimestamp()).to.equal('2018-04-11T12:13:04.095238Z');
+        expect(timestamp).toBeInstanceOf(Date);
+        expect(timestamp.toUTCString()).toBe(expectedTimestamp);
+        expect(timestamp.getMicrosecondTimestamp()).toBe('2018-04-11T12:13:04.095238Z');
       });
 
       it('should return 1.2.840.113549.1.1.11 as signature Oid', () => {
         const expectedCertificate = '1.2.840.113549.1.1.11';
         const certificates = firstVerifier.getOriginServerCerts();
-        expect(expectedCertificate).to.equal(certificates[0].signatureOid);
+        expect(expectedCertificate).toBe(certificates[0].signatureOid);
       });
     });
 
-    context('when processing unknown anchor data', () => {
+    describe('when processing unknown anchor data', () => {
       const unknownAnchorData = fs.readFileSync('./tests/sample-data/yoti-common/unknown-anchor.txt', 'utf8');
       const unknownAnchorObj = parseAnchorData(unknownAnchorData);
       const anchors = AnchorProcessor.process([unknownAnchorObj]);
       const unknownAnchor = anchors.unknown[0];
 
       it('should return empty string as value', () => {
-        expect(unknownAnchor.getValue()).to.equal('');
+        expect(unknownAnchor.getValue()).toBe('');
       });
 
       it('should return UNKNOWN as type', () => {
-        expect(unknownAnchor.getType()).to.equal('UNKNOWN');
+        expect(unknownAnchor.getType()).toBe('UNKNOWN');
       });
 
       it('should return Wed, 11 Apr 2018 12:13:03 GMT as timestamp', () => {
         expect(unknownAnchor.getSignedTimeStamp().getTimestamp().toUTCString())
-          .to.equal('Tue, 05 Mar 2019 10:45:11 GMT');
+          .toBe('Tue, 05 Mar 2019 10:45:11 GMT');
       });
 
       it('should return empty subType', () => {
-        expect(unknownAnchor.getSubType()).to.equal('TEST UNKNOWN SUB TYPE');
+        expect(unknownAnchor.getSubType()).toBe('TEST UNKNOWN SUB TYPE');
       });
 
       it('should return 1.2.840.113549.1.1.11 as signature Oid', () => {
         const expectedCertificate = '1.2.840.113549.1.1.11';
         const certificates = unknownAnchor.getOriginServerCerts();
-        expect(expectedCertificate).to.equal(certificates[0].signatureOid);
+        expect(expectedCertificate).toBe(certificates[0].signatureOid);
       });
     });
 
-    context('when processing multiple anchors', () => {
+    describe('when processing multiple anchors', () => {
       const dlSourceAnchor = fs.readFileSync('./tests/sample-data/yoti-common/dl-source-anchor.txt', 'utf8');
       const verifierAnchor = fs.readFileSync('./tests/sample-data/yoti-common/verifier-anchor.txt', 'utf8');
       const unknownAnchor = fs.readFileSync('./tests/sample-data/yoti-common/unknown-anchor.txt', 'utf8');
@@ -131,23 +128,23 @@ describe('anchorProcessor', () => {
       ]);
 
       it('should return 1 source anchor', () => {
-        expect(anchors.sources).to.be.length(1);
-        expect(anchors.sources[0].getType()).to.equal('SOURCE');
+        expect(anchors.sources).toHaveLength(1);
+        expect(anchors.sources[0].getType()).toBe('SOURCE');
       });
 
       it('should return 1 verifier anchor', () => {
-        expect(anchors.verifiers).to.be.length(1);
-        expect(anchors.verifiers[0].getType()).to.equal('VERIFIER');
+        expect(anchors.verifiers).toHaveLength(1);
+        expect(anchors.verifiers[0].getType()).toBe('VERIFIER');
       });
 
       it('should return 1 unknown anchor', () => {
-        expect(anchors.unknown).to.be.length(1);
-        expect(anchors.unknown[0].getType()).to.equal('UNKNOWN');
+        expect(anchors.unknown).toHaveLength(1);
+        expect(anchors.unknown[0].getType()).toBe('UNKNOWN');
       });
     });
   });
   describe('#getAnchorByOid', () => {
-    context('when processing DL Source Anchor data', () => {
+    describe('when processing DL Source Anchor data', () => {
       const sourceAnchor = fs.readFileSync('./tests/sample-data/yoti-common/dl-source-anchor.txt', 'utf8');
 
       it('should return DRIVING_LICENCE as value', () => {
@@ -161,27 +158,27 @@ describe('anchorProcessor', () => {
           '1.3.6.1.4.1.47127.1.1.1'
         );
 
-        expect(anchor.getValue()).to.equal('DRIVING_LICENCE');
+        expect(anchor.getValue()).toBe('DRIVING_LICENCE');
       });
     });
   });
   describe('#processSingleAnchor', () => {
-    context('when processing a single anchor', () => {
+    describe('when processing a single anchor', () => {
       const sourceAnchor = fs.readFileSync('./tests/sample-data/yoti-common/dl-source-anchor.txt', 'utf8');
 
       it('should return a map of anchor types with 1 anchor', () => {
         const data = parseAnchorData(sourceAnchor);
         const anchors = AnchorProcessor.processSingleAnchor(data);
-        expect(anchors.sources).to.be.length(1);
-        expect(anchors.verifiers).to.be.length(0);
-        expect(anchors.unknown).to.be.length(0);
-        expect(anchors.sources[0].getType()).to.equal('SOURCE');
-        expect(anchors.sources[0].getValue()).to.equal('DRIVING_LICENCE');
+        expect(anchors.sources).toHaveLength(1);
+        expect(anchors.verifiers).toHaveLength(0);
+        expect(anchors.unknown).toHaveLength(0);
+        expect(anchors.sources[0].getType()).toBe('SOURCE');
+        expect(anchors.sources[0].getValue()).toBe('DRIVING_LICENCE');
       });
     });
   });
   describe('#getAnchorsByCertificate', () => {
-    context('when processing a single anchor', () => {
+    describe('when processing a single anchor', () => {
       const sourceAnchor = fs.readFileSync('./tests/sample-data/yoti-common/dl-source-anchor.txt', 'utf8');
 
       it('should return a map of anchor types with 1 anchor', () => {
@@ -192,11 +189,11 @@ describe('anchorProcessor', () => {
           AnchorProcessor.processSignedTimeStamp(anchorObj.getSignedTimeStamp()),
           AnchorProcessor.convertCertsListToX509(anchorObj.originServerCerts)
         );
-        expect(anchors.sources).to.be.length(1);
-        expect(anchors.verifiers).to.be.length(0);
-        expect(anchors.unknown).to.be.length(0);
-        expect(anchors.sources[0].getType()).to.equal('SOURCE');
-        expect(anchors.sources[0].getValue()).to.equal('DRIVING_LICENCE');
+        expect(anchors.sources).toHaveLength(1);
+        expect(anchors.verifiers).toHaveLength(0);
+        expect(anchors.unknown).toHaveLength(0);
+        expect(anchors.sources[0].getType()).toBe('SOURCE');
+        expect(anchors.sources[0].getValue()).toBe('DRIVING_LICENCE');
       });
     });
   });

--- a/tests/yoti_common/attribute.converter.spec.js
+++ b/tests/yoti_common/attribute.converter.spec.js
@@ -1,4 +1,3 @@
-const expect = require('chai').expect;
 const fs = require('fs');
 const { AttributeConverter } = require('../../src/yoti_common/attribute.converter');
 const protoRoot = require('../../src/proto-root');
@@ -126,18 +125,18 @@ const createTestAttribute = (contentType, value) => {
  * @param {String} base64Last10
  */
 const assertIsExpectedImage = (image, mimeType, base64Last10) => {
-  expect(image).to.be.instanceOf(ImageJpeg);
-  expect(image.getMimeType()).to.equal(mimeType);
+  expect(image).toBeInstanceOf(ImageJpeg);
+  expect(image.getMimeType()).toBe(mimeType);
   const base64String = image.getBase64Content();
-  expect(base64String.substr(base64String.length - 10)).to.equal(base64Last10);
+  expect(base64String.substr(base64String.length - 10)).toBe(base64Last10);
 };
 
 describe('AttributeConverter', () => {
   describe('#convertValueBasedOnContentType', () => {
     it('should return multi value object', () => {
       const multiValue = convertSampleMultiValue();
-      expect(multiValue.getItems().length).to.equal(2);
-      expect(multiValue).to.be.instanceOf(MultiValue);
+      expect(multiValue.getItems().length).toBe(2);
+      expect(multiValue).toBeInstanceOf(MultiValue);
       assertIsExpectedImage(multiValue.getItems()[0], 'image/jpeg', 'vWgD//2Q==');
       assertIsExpectedImage(multiValue.getItems()[1], 'image/jpeg', '38TVEH/9k=');
     });
@@ -154,16 +153,16 @@ describe('AttributeConverter', () => {
       );
       // Check top-level items.
       const items = multiValue.getItems();
-      expect(items[0]).to.be.instanceOf(ImageJpeg);
-      expect(items[1]).to.be.instanceOf(ImagePng);
-      expect(items[2]).to.equal('string 1');
-      expect(items[3]).to.be.instanceOf(MultiValue);
+      expect(items[0]).toBeInstanceOf(ImageJpeg);
+      expect(items[1]).toBeInstanceOf(ImagePng);
+      expect(items[2]).toBe('string 1');
+      expect(items[3]).toBeInstanceOf(MultiValue);
 
       // Check nested MultiValue.
       const nestedItems = items[3].getItems();
-      expect(nestedItems[0]).to.be.instanceOf(ImageJpeg);
-      expect(nestedItems[1]).to.be.instanceOf(ImagePng);
-      expect(nestedItems[2]).to.equal('string 1');
+      expect(nestedItems[0]).toBeInstanceOf(ImageJpeg);
+      expect(nestedItems[1]).toBeInstanceOf(ImagePng);
+      expect(nestedItems[2]).toBe('string 1');
     });
     it('should return empty string values', () => {
       const protoAttr = createTestAttribute(CONTENT_TYPE_STRING, '');
@@ -171,7 +170,7 @@ describe('AttributeConverter', () => {
         protoAttr.value,
         CONTENT_TYPE_STRING
       );
-      expect(value).to.equal('');
+      expect(value).toBe('');
     });
     it('should return UTF-8 encoded strings', () => {
       const protoAttr = createTestAttribute(CONTENT_TYPE_STRING, 'test string');
@@ -179,7 +178,7 @@ describe('AttributeConverter', () => {
         protoAttr.value,
         CONTENT_TYPE_STRING
       );
-      expect(value).to.equal('test string');
+      expect(value).toBe('test string');
     });
     it('should return UTF-8 encoded strings for undefined content type', () => {
       const protoAttr = createTestAttribute(CONTENT_TYPE_UNDEFINED, 'test undefined string');
@@ -187,7 +186,7 @@ describe('AttributeConverter', () => {
         protoAttr.value,
         CONTENT_TYPE_UNDEFINED
       );
-      expect(value).to.equal('test undefined string');
+      expect(value).toBe('test undefined string');
     });
     it('should return UTF-8 encoded strings for unknown content types', () => {
       const protoAttr = createTestAttribute(100, 'test unknown string');
@@ -195,7 +194,7 @@ describe('AttributeConverter', () => {
         protoAttr.value,
         100
       );
-      expect(value).to.equal('test unknown string');
+      expect(value).toBe('test unknown string');
     });
     it('should not allow empty non-string values', () => {
       nonStringContentTypes.forEach((contentType) => {
@@ -209,7 +208,7 @@ describe('AttributeConverter', () => {
         } catch (err) {
           errMessage = err.message;
         }
-        expect(errMessage).to.equal('Warning: value is NULL', `Content Type: ${contentType}`);
+        expect(errMessage).toBe('Warning: value is NULL', `Content Type: ${contentType}`);
       });
     });
     it('should return integer values', () => {
@@ -220,7 +219,7 @@ describe('AttributeConverter', () => {
           protoAttr.value,
           CONTENT_TYPE_INT
         );
-        expect(value).to.equal(integer);
+        expect(value).toBe(integer);
       });
     });
     it('should allow empty string MultiValue values', () => {
@@ -233,8 +232,8 @@ describe('AttributeConverter', () => {
         }),
         CONTENT_TYPE_MULTI_VALUE
       );
-      expect(multiValue.getItems()[0]).to.equal('');
-      expect(multiValue.getItems()[1]).to.be.instanceOf(ImagePng);
+      expect(multiValue.getItems()[0]).toBe('');
+      expect(multiValue.getItems()[1]).toBeInstanceOf(ImagePng);
     });
     it('should not allow empty non-string MultiValue values', () => {
       nonStringContentTypes.forEach((contentType) => {
@@ -252,7 +251,7 @@ describe('AttributeConverter', () => {
         } catch (err) {
           errMessage = err.message;
         }
-        expect(errMessage).to.equal('Warning: value is NULL', `Content Type: ${contentType}`);
+        expect(errMessage).toBe('Warning: value is NULL', `Content Type: ${contentType}`);
       });
     });
   });
@@ -264,10 +263,10 @@ describe('AttributeConverter', () => {
           constants.ATTR_DOCUMENT_IMAGES
         );
 
-      expect(documentImages.length).to.equal(2);
+      expect(documentImages.length).toBe(2);
       documentImages.forEach((item) => {
-        expect(item).to.be.instanceOf(ImageJpeg);
-        expect(item.getMimeType()).to.equal('image/jpeg');
+        expect(item).toBeInstanceOf(ImageJpeg);
+        expect(item.getMimeType()).toBe('image/jpeg');
       });
     });
   });
@@ -285,8 +284,8 @@ describe('AttributeConverter', () => {
         exceptionMessage = err.message;
       }
 
-      expect(exceptionMessage).to.equal('Document Images could not be decoded');
-      expect(documentImages).to.equal(null);
+      expect(exceptionMessage).toBe('Document Images could not be decoded');
+      expect(documentImages).toBe(null);
     });
   });
   describe('Document Images', () => {
@@ -300,9 +299,9 @@ describe('AttributeConverter', () => {
       // Attempt to change a document image.
       documentImages[0] = 'not allowed';
 
-      expect(documentImages.length).to.equal(2);
-      expect(documentImages[0]).to.be.instanceOf(ImageJpeg);
-      expect(documentImages[0].getMimeType()).to.equal('image/jpeg');
+      expect(documentImages.length).toBe(2);
+      expect(documentImages[0]).toBeInstanceOf(ImageJpeg);
+      expect(documentImages[0].getMimeType()).toBe('image/jpeg');
     });
   });
 });

--- a/tests/yoti_common/index.spec.js
+++ b/tests/yoti_common/index.spec.js
@@ -1,4 +1,3 @@
-const expect = require('chai').expect;
 const fs = require('fs');
 
 const yotiCommon = require('../../src/yoti_common');
@@ -10,7 +9,7 @@ describe('yotiCommon', () => {
     it('should return the signed message', () => {
       const signedMessage = yotiCommon.getRSASignatureForMessage('blah blah blah', privateKeyFile);
       const expectedSignedMessage = fs.readFileSync('./tests/sample-data/fixtures/aml-signed-message.txt', 'utf8');
-      expect(signedMessage).to.equal(expectedSignedMessage);
+      expect(signedMessage).toBe(expectedSignedMessage);
     });
   });
 });


### PR DESCRIPTION
### Added
- [Jest](https://jestjs.io/)
  - Coverage is collected in `./coverage`
  - Converted existing tests for Jest _(like for like)_
  - We could also consider replacing `nock` with Jest mocks as a separate task
- `sonar-project.properties` configuration

### Removed
- Chai/Mocha - replace by Jest
- `src/receipt.js` - this file is not used

### Fixed
- Reverted #91 - `npm --depth=9999 update` caused performance issues on Travis CI - _we are still updating top level dependencies_
- Moved Travis example linting into single `script:` command - _it was changing back to root folder so wasn't actually checking the examples_