### PR TITLE
SDK-604: Correct Document Details docs & npm audit fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "yoti",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -14,17 +14,17 @@
       }
     },
     "@babel/core": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.6.0.tgz",
-      "integrity": "sha512-FuRhDRtsd6IptKpHXAa+4WPZYY2ZzgowkbLBecEDDSje1X/apG7jQM33or3NdOmjXBKWGOg4JmSiRfUfuTtHXw==",
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.6.2.tgz",
+      "integrity": "sha512-l8zto/fuoZIbncm+01p8zPSDZu/VuuJhAfA7d/AbzM09WR7iVhavvfNDYCNpo1VvLk6E6xgAoP9P+/EMJHuRkQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.5.5",
-        "@babel/generator": "^7.6.0",
-        "@babel/helpers": "^7.6.0",
-        "@babel/parser": "^7.6.0",
+        "@babel/generator": "^7.6.2",
+        "@babel/helpers": "^7.6.2",
+        "@babel/parser": "^7.6.2",
         "@babel/template": "^7.6.0",
-        "@babel/traverse": "^7.6.0",
+        "@babel/traverse": "^7.6.2",
         "@babel/types": "^7.6.0",
         "convert-source-map": "^1.1.0",
         "debug": "^4.1.0",
@@ -53,16 +53,15 @@
       }
     },
     "@babel/generator": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.6.0.tgz",
-      "integrity": "sha512-Ms8Mo7YBdMMn1BYuNtKuP/z0TgEIhbcyB8HVR6PPNYp4P61lMsABiS4A3VG1qznjXVCf3r+fVHhm4efTYVsySA==",
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.6.2.tgz",
+      "integrity": "sha512-j8iHaIW4gGPnViaIHI7e9t/Hl8qLjERI6DcV9kEpAIDJsAOrcnXqRS7t+QbhL76pwbtqP+QCQLL0z1CyVmtjjQ==",
       "dev": true,
       "requires": {
         "@babel/types": "^7.6.0",
         "jsesc": "^2.5.1",
         "lodash": "^4.17.13",
-        "source-map": "^0.5.0",
-        "trim-right": "^1.0.1"
+        "source-map": "^0.5.0"
       },
       "dependencies": {
         "source-map": {
@@ -109,13 +108,13 @@
       }
     },
     "@babel/helpers": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.6.0.tgz",
-      "integrity": "sha512-W9kao7OBleOjfXtFGgArGRX6eCP0UEcA2ZWEWNkJdRZnHhW4eEbeswbG3EwaRsnQUAEGWYgMq1HsIXuNNNy2eQ==",
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.6.2.tgz",
+      "integrity": "sha512-3/bAUL8zZxYs1cdX2ilEE0WobqbCmKWr/889lf2SS0PpDcpEIY8pb1CCyz0pEcX3pEb+MCbks1jIokz2xLtGTA==",
       "dev": true,
       "requires": {
         "@babel/template": "^7.6.0",
-        "@babel/traverse": "^7.6.0",
+        "@babel/traverse": "^7.6.2",
         "@babel/types": "^7.6.0"
       }
     },
@@ -139,9 +138,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.0.tgz",
-      "integrity": "sha512-+o2q111WEx4srBs7L9eJmcwi655eD8sXniLqMB93TBK9GrNzGrxDWSjiqz2hLU0Ha8MTXFIP0yd9fNdP+m43ZQ==",
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.2.tgz",
+      "integrity": "sha512-mdFqWrSPCmikBoaBYMuBulzTIKuXVPtEISFbRRVNwMWpCms/hmE2kRq0bblUHaNRKrjRlmVbx1sDHmjmRgD2Xg==",
       "dev": true
     },
     "@babel/plugin-syntax-object-rest-spread": {
@@ -165,16 +164,16 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.6.0.tgz",
-      "integrity": "sha512-93t52SaOBgml/xY74lsmt7xOR4ufYvhb5c5qiM6lu4J/dWGMAfAh6eKw4PjLes6DI6nQgearoxnFJk60YchpvQ==",
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.6.2.tgz",
+      "integrity": "sha512-8fRE76xNwNttVEF2TwxJDGBLWthUkHWSldmfuBzVRmEDWOtu4XdINTgN7TDWzuLg4bbeIMLvfMFD9we5YcWkRQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.5.5",
-        "@babel/generator": "^7.6.0",
+        "@babel/generator": "^7.6.2",
         "@babel/helper-function-name": "^7.1.0",
         "@babel/helper-split-export-declaration": "^7.4.4",
-        "@babel/parser": "^7.6.0",
+        "@babel/parser": "^7.6.2",
         "@babel/types": "^7.6.0",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
@@ -428,9 +427,9 @@
       }
     },
     "@types/babel__generator": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.0.2.tgz",
-      "integrity": "sha512-NHcOfab3Zw4q5sEE2COkpfXjoE7o+PmqD9DQW4koUT3roNxwziUdXGnRndMat/LJNUtePwn1TlP4do3uoe3KZQ==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.0.tgz",
+      "integrity": "sha512-c1mZUu4up5cp9KROs/QAw0gTeHrw/x7m52LcnvMxxOZ03DmLwPV0MlGmlgzV3cnSdjhJOZsj7E7FHeioai+egw==",
       "dev": true,
       "requires": {
         "@babel/types": "^7.0.0"
@@ -502,9 +501,9 @@
       "dev": true
     },
     "abab": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.1.tgz",
-      "integrity": "sha512-1zSbbCuoIjafKZ3mblY5ikvAb0ODUbqBnFuUb7f6uLeQhhGJ0vEV4ntmtxKLT2WgXCO94E07BjunsIw1jOMPZw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.2.tgz",
+      "integrity": "sha512-2scffjvioEmNz0OyDSLGWDfKCVwaKc6l9Pm9kOIREU13ClXZvHpg/nRL5xyjSSSLhOnXqft2HpsAzNEEA8cFFg==",
       "dev": true
     },
     "acorn": {
@@ -1529,9 +1528,9 @@
       "dev": true
     },
     "end-of-stream": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.3.tgz",
+      "integrity": "sha512-cbNhPFS6MlYlWTGncSiDYbdqKhwWFy7kNeb1YSOG6K65i/wPTkLVCJQj0hXA4j0m5Da+hBWnqopEnu1FFelisQ==",
       "dev": true,
       "requires": {
         "once": "^1.4.0"
@@ -2850,9 +2849,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.2.0.tgz",
-      "integrity": "sha512-Kb4xn5Qh1cxAKvQnzNWZ512DhABzyFNmsaJf3OAkWNa4NkaqWcNI8Tao8Tasi0/F4JD9oyG0YxuFyvyR57d+Gw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.3.1.tgz",
+      "integrity": "sha512-c0HoNHzDiHpBt4Kqe99N8tdLPKAnGCQ73gYMPWtAYM4PwGnf7xl8PBUHJqh9ijlzt2uQKaSRxbXRt+rZ7M2/kA==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
@@ -4769,9 +4768,9 @@
       }
     },
     "node-rsa": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/node-rsa/-/node-rsa-1.0.5.tgz",
-      "integrity": "sha512-9o51yfV167CtQANnuAf+5owNs7aIMsAKVLhNaKuRxihsUUnfoBMN5OTVOK/2mHSOWaWq9zZBiRM3bHORbTZqrg==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/node-rsa/-/node-rsa-1.0.6.tgz",
+      "integrity": "sha512-v42495lozKpuQmrcIzld9ds/Tn7pwjuh0BHSHnhPrKkAVSyTAyrZodFLFafOfWiUKamLt4lgWdngP8W/LzCm2w==",
       "requires": {
         "asn1": "^0.2.4"
       }
@@ -5255,9 +5254,9 @@
       "dev": true
     },
     "qs": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.8.0.tgz",
-      "integrity": "sha512-tPSkj8y92PfZVbinY1n84i1Qdx75lZjMQYx9WZhnkofyxzw2r7Ho39G3/aEvSUdebxpnnM4LZJCtvE/Aq3+s9w=="
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.0.tgz",
+      "integrity": "sha512-27RP4UotQORTpmNQDX8BHPukOnBP3p1uUJY5UnDhaJB+rMt9iMsok724XL+UHU23bEFOHRMQ2ZhI99qOWUMGFA=="
     },
     "react-is": {
       "version": "16.9.0",
@@ -6358,12 +6357,6 @@
       "requires": {
         "punycode": "^2.1.0"
       }
-    },
-    "trim-right": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
-      "dev": true
     },
     "tunnel-agent": {
       "version": "0.6.0",

--- a/src/data_type/document.details.js
+++ b/src/data_type/document.details.js
@@ -9,7 +9,6 @@ const AUTHORITY_INDEX = 4;
 
 module.exports.DocumentDetails = class DocumentDetails {
   constructor(value) {
-    this.validateData(value);
     this.parseFromValue(value);
   }
 
@@ -21,6 +20,8 @@ module.exports.DocumentDetails = class DocumentDetails {
   }
 
   parseFromValue(value) {
+    this.validateData(value);
+
     const parsedValues = value.split(' ');
 
     this.type = parsedValues[TYPE_INDEX];

--- a/src/data_type/document.details.js
+++ b/src/data_type/document.details.js
@@ -73,7 +73,7 @@ module.exports.DocumentDetails = class DocumentDetails {
    * Expiration date of the document in Date format. If the document does not expire, this
    * field will not be present. The time part of this Date will default to 00:00:00.
    *
-   * @returns {Date|undefined}
+   * @returns {Date|null|undefined}
    */
   getExpirationDate() {
     return this.expirationDate;

--- a/src/data_type/document.details.js
+++ b/src/data_type/document.details.js
@@ -35,21 +35,17 @@ module.exports.DocumentDetails = class DocumentDetails {
         throw new Error('Invalid Date');
       }
       this.expirationDate = dateValue !== '-' ? dateObj : null;
-    } else {
-      this.expirationDate = null;
     }
 
     if (parsedValues.length > AUTHORITY_INDEX) {
       this.issuingAuthority = parsedValues[AUTHORITY_INDEX];
-    } else {
-      this.issuingAuthority = null;
     }
   }
 
   /**
    * Type of the document e.g. PASSPORT | DRIVING_LICENCE | NATIONAL_ID | PASS_CARD
    *
-   * @returns {null|string}
+   * @returns {string}
    */
   getType() {
     return this.type;
@@ -58,7 +54,7 @@ module.exports.DocumentDetails = class DocumentDetails {
   /**
    * ISO-3166-1 alpha-3 country code, e.g. “GBR“
    *
-   * @returns {null|string}
+   * @returns {string}
    */
   getIssuingCountry() {
     return this.issuingCountry;
@@ -67,7 +63,7 @@ module.exports.DocumentDetails = class DocumentDetails {
   /**
    * Document number (may include letters) from the document.
    *
-   * @returns {null|string}
+   * @returns {string}
    */
   getDocumentNumber() {
     return this.documentNumber;
@@ -77,7 +73,7 @@ module.exports.DocumentDetails = class DocumentDetails {
    * Expiration date of the document in Date format. If the document does not expire, this
    * field will not be present. The time part of this Date will default to 00:00:00.
    *
-   * @returns {null|Date}
+   * @returns {Date|undefined}
    */
   getExpirationDate() {
     return this.expirationDate;
@@ -86,7 +82,7 @@ module.exports.DocumentDetails = class DocumentDetails {
   /**
    * Can either be a country code (for a state), or the name of the issuing authority.
    *
-   * @returns {null|string}
+   * @returns {string|undefined}
    */
   getIssuingAuthority() {
     return this.issuingAuthority;

--- a/src/data_type/document.details.js
+++ b/src/data_type/document.details.js
@@ -21,7 +21,6 @@ module.exports.DocumentDetails = class DocumentDetails {
   }
 
   parseFromValue(value) {
-    this.validateData(value);
     const parsedValues = value.split(' ');
 
     this.type = parsedValues[TYPE_INDEX];
@@ -36,10 +35,14 @@ module.exports.DocumentDetails = class DocumentDetails {
         throw new Error('Invalid Date');
       }
       this.expirationDate = dateValue !== '-' ? dateObj : null;
+    } else {
+      this.expirationDate = null;
     }
 
     if (parsedValues.length > AUTHORITY_INDEX) {
       this.issuingAuthority = parsedValues[AUTHORITY_INDEX];
+    } else {
+      this.issuingAuthority = null;
     }
   }
 

--- a/tests/data_type/document.details.spec.js
+++ b/tests/data_type/document.details.spec.js
@@ -18,17 +18,24 @@ const assertInvalidDocumentDetails = (value, exceptionMessage) => {
 
 describe('documentDetails', () => {
   describe('when value is empty', () => {
-    it('it should throw an exception', () => {
+    it('should throw an exception', () => {
       assertInvalidDocumentDetails('', 'Invalid value for DocumentDetails');
     });
   });
   describe('when value is less than 3 words', () => {
-    it('it should throw an exception', () => {
+    it('should throw an exception', () => {
       assertInvalidDocumentDetails('PASS_CARD GBR', 'Invalid value for DocumentDetails');
     });
   });
+  describe('when value is three words', () => {
+    it('should return null for optional attributes', () => {
+      const documentDetails = new DocumentDetails('PASSPORT GBR 01234567');
+      expect(documentDetails.getExpirationDate()).toBe(null);
+      expect(documentDetails.getIssuingAuthority()).toBe(null);
+    });
+  });
   describe('when value is four words', () => {
-    it('it should parse one optional attribute', () => {
+    it('should parse one optional attribute', () => {
       const documentDetails = new DocumentDetails('PASSPORT GBR 01234567 2020-01-01');
       expect(documentDetails.getType()).toBe('PASSPORT');
       expect(documentDetails.getIssuingCountry()).toBe('GBR');
@@ -37,7 +44,7 @@ describe('documentDetails', () => {
     });
   });
   describe('when value is five words', () => {
-    it('it should parse two optional attributes', () => {
+    it('should parse two optional attributes', () => {
       const documentDetails = new DocumentDetails('DRIVING_LICENCE GBR 1234abc 2016-05-01 DVLA');
       expect(documentDetails.getType()).toBe('DRIVING_LICENCE');
       expect(documentDetails.getIssuingCountry()).toBe('GBR');
@@ -47,7 +54,7 @@ describe('documentDetails', () => {
     });
   });
   describe('when value is more than five words', () => {
-    it('it should parse only two optional attributes', () => {
+    it('should parse only two optional attributes', () => {
       const documentDetails = new DocumentDetails('DRIVING_LICENCE GBR 1234abc 2016-05-01 DVLA someThirdAttribute');
       expect(documentDetails.getType()).toBe('DRIVING_LICENCE');
       expect(documentDetails.getIssuingCountry()).toBe('GBR');
@@ -57,17 +64,17 @@ describe('documentDetails', () => {
     });
   });
   describe('when value has invalid country 13', () => {
-    it('it should throw an exception', () => {
+    it('should throw an exception', () => {
       assertInvalidDocumentDetails('PASSPORT 13 1234abc 2016-05-01', 'Invalid value for DocumentDetails');
     });
   });
   describe('when value has invalid document number', () => {
-    it('it should throw an exception', () => {
+    it('should throw an exception', () => {
       assertInvalidDocumentDetails('PASSPORT GBR $%^$%^£ 2016-05-01', 'Invalid value for DocumentDetails');
     });
   });
   describe('when expiration Date is set to dash (-)', () => {
-    it('it should return NULL for date value', () => {
+    it('should return NULL for date value', () => {
       const documentDetails = new DocumentDetails('PASS_CARD GBR 22719564893 - CITIZENCARD');
       expect(documentDetails.getType()).toBe('PASS_CARD');
       expect(documentDetails.getIssuingCountry()).toBe('GBR');
@@ -77,7 +84,7 @@ describe('documentDetails', () => {
     });
   });
   describe('when there is an invalid date', () => {
-    it('it should throw an exception', () => {
+    it('should throw an exception', () => {
       assertInvalidDocumentDetails('PASSPORT GBR 1234abc X016-05-01', 'Invalid Date');
     });
   });

--- a/tests/data_type/document.details.spec.js
+++ b/tests/data_type/document.details.spec.js
@@ -30,8 +30,8 @@ describe('documentDetails', () => {
   describe('when value is three words', () => {
     it('should return null for optional attributes', () => {
       const documentDetails = new DocumentDetails('PASSPORT GBR 01234567');
-      expect(documentDetails.getExpirationDate()).toBe(null);
-      expect(documentDetails.getIssuingAuthority()).toBe(null);
+      expect(documentDetails.getExpirationDate()).toBeUndefined();
+      expect(documentDetails.getIssuingAuthority()).toBeUndefined();
     });
   });
   describe('when value is four words', () => {

--- a/tests/data_type/document.details.spec.js
+++ b/tests/data_type/document.details.spec.js
@@ -28,7 +28,7 @@ describe('documentDetails', () => {
     });
   });
   describe('when value is three words', () => {
-    it('should return null for optional attributes', () => {
+    it('should return undefined for optional attributes', () => {
       const documentDetails = new DocumentDetails('PASSPORT GBR 01234567');
       expect(documentDetails.getExpirationDate()).toBeUndefined();
       expect(documentDetails.getIssuingAuthority()).toBeUndefined();


### PR DESCRIPTION
### Fixed
- JSDocs for optional document details
- Removed redundant `this.validateData(value);` _(already called in `parseFromValue`)_
- NPM audit fix _(updated package-lock.json)_