### PR TITLE
Release 3.7.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "yoti",
-  "version": "3.7.1",
+  "version": "3.7.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yoti",
-  "version": "3.7.1",
+  "version": "3.7.2",
   "description": "Yoti NodeJS SDK for back-end integration",
   "author": "Yoti LTD <tech@yoti.com> (https://www.yoti.com/developers)",
   "license": "MIT",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey = yoti-web-sdk:node
 sonar.projectName = node-sdk
-sonar.projectVersion = 3.7.1
+sonar.projectVersion = 3.7.2
 sonar.exclusions=tests/**,examples/**,node_modules/**,coverage/**
 sonar.javascript.lcov.reportPaths=coverage/lcov.info
 sonar.verbose = true

--- a/src/request/request.builder.js
+++ b/src/request/request.builder.js
@@ -162,7 +162,7 @@ class RequestBuilder {
 
     // Merge provided query params with nonce and timestamp.
     const queryString = buildQueryString(Object.assign(
-      this.queryParams || {},
+      this.queryParams,
       {
         nonce: uuid.v4(),
         timestamp: Date.now(),

--- a/src/request/request.handler.js
+++ b/src/request/request.handler.js
@@ -28,11 +28,14 @@ module.exports.execute = (yotiRequest, buffer = false) => new Promise((resolve, 
   request
     .then((response) => {
       let parsedResponse = null;
+      let body = null;
       let receipt = null;
 
       if (response.body instanceof Buffer) {
+        body = response.body;
         parsedResponse = response.body;
       } else if (response.text) {
+        body = response.text;
         parsedResponse = response.headers['content-type'] ? response.body : JSON.parse(response.text);
         receipt = parsedResponse.receipt || null;
       }
@@ -40,7 +43,8 @@ module.exports.execute = (yotiRequest, buffer = false) => new Promise((resolve, 
       return resolve(new YotiResponse(
         parsedResponse,
         response.statusCode,
-        receipt
+        receipt,
+        body
       ));
     })
     .catch((err) => {

--- a/src/request/request.handler.js
+++ b/src/request/request.handler.js
@@ -22,11 +22,25 @@ module.exports.execute = yotiRequest => new Promise((resolve, reject) => {
 
   request
     .then((response) => {
-      try {
-        const parsedResponse = response.text !== '' ? JSON.parse(response.text) : null;
-        const receipt = parsedResponse !== null ? parsedResponse.receipt : null;
+      let parsedResponse = null;
+      if (typeof response.text !== 'undefined') {
+        try {
+          parsedResponse = JSON.parse(response.text);
+        } catch (e) {
+          parsedResponse = response.text;
+        }
+      } else {
+        parsedResponse = response.body;
+      }
 
-        return resolve(new YotiResponse(parsedResponse, response.statusCode, receipt));
+      const receipt = parsedResponse !== null ? parsedResponse.receipt : null;
+
+      try {
+        return resolve(new YotiResponse(
+          parsedResponse,
+          response.statusCode,
+          receipt
+        ));
       } catch (err) {
         return reject(err);
       }

--- a/src/request/request.handler.js
+++ b/src/request/request.handler.js
@@ -23,8 +23,9 @@ module.exports.execute = yotiRequest => new Promise((resolve, reject) => {
   request
     .then((response) => {
       try {
-        const parsedResponse = JSON.parse(response.text);
-        const receipt = parsedResponse.receipt || null;
+        const parsedResponse = response.text !== '' ? JSON.parse(response.text) : null;
+        const receipt = parsedResponse !== null ? parsedResponse.receipt : null;
+
         return resolve(new YotiResponse(parsedResponse, response.statusCode, receipt));
       } catch (err) {
         return reject(err);

--- a/src/request/request.handler.js
+++ b/src/request/request.handler.js
@@ -37,15 +37,11 @@ module.exports.execute = (yotiRequest, buffer = false) => new Promise((resolve, 
         receipt = parsedResponse.receipt || null;
       }
 
-      try {
-        return resolve(new YotiResponse(
-          parsedResponse,
-          response.statusCode,
-          receipt
-        ));
-      } catch (err) {
-        return reject(err);
-      }
+      return resolve(new YotiResponse(
+        parsedResponse,
+        response.statusCode,
+        receipt
+      ));
     })
     .catch((err) => {
       console.log(`Error getting data from Connect API: ${err.message}`);

--- a/src/request/request.js
+++ b/src/request/request.js
@@ -62,10 +62,12 @@ class YotiRequest {
   /**
    * Executes the request.
    *
+   * @param {boolean} buffer Return the response as a Buffer.
+   *
    * @returns {Promise} Resolves {YotiResponse}
    */
-  execute() {
-    return requestHandler.execute(this);
+  execute(buffer = false) {
+    return requestHandler.execute(this, buffer);
   }
 }
 

--- a/src/request/response.js
+++ b/src/request/response.js
@@ -8,11 +8,13 @@ class YotiResponse {
    * @param {*} parsedResponse
    * @param {int} statusCode
    * @param {Object|null} receipt
+   * @param {Buffer|string|null} body
    */
-  constructor(parsedResponse, statusCode, receipt = null) {
+  constructor(parsedResponse, statusCode, receipt = null, body = null) {
     this.parsedResponse = parsedResponse;
     this.statusCode = statusCode;
     this.receipt = receipt;
+    this.body = body;
   }
 
   /**
@@ -27,6 +29,13 @@ class YotiResponse {
    */
   getParsedResponse() {
     return this.parsedResponse;
+  }
+
+  /**
+   * @returns {Buffer|string|null} The response body.
+   */
+  getBody() {
+    return this.body;
   }
 
   /**

--- a/tests/request/request.builder.spec.js
+++ b/tests/request/request.builder.spec.js
@@ -148,6 +148,30 @@ describe('RequestBuilder', () => {
       assertExpectedRequest(request, done);
     });
   });
+  describe('#withGet', () => {
+    it('should set method to GET', () => {
+      const request = new RequestBuilder()
+        .withBaseUrl(API_BASE_URL)
+        .withPemFilePath(PEM_FILE_PATH)
+        .withEndpoint(API_ENDPOINT)
+        .withGet()
+        .build();
+
+      expect(request.getMethod()).toBe('GET');
+    });
+  });
+  describe('#withPost', () => {
+    it('should set method to POST', () => {
+      const request = new RequestBuilder()
+        .withBaseUrl(API_BASE_URL)
+        .withPemFilePath(PEM_FILE_PATH)
+        .withEndpoint(API_ENDPOINT)
+        .withPost()
+        .build();
+
+      expect(request.getMethod()).toBe('POST');
+    });
+  });
   describe('#withHeader', () => {
     it('should only accept string header value', () => {
       expect(() => {

--- a/tests/request/request.handler.spec.js
+++ b/tests/request/request.handler.spec.js
@@ -1,0 +1,112 @@
+const nock = require('nock');
+const fs = require('fs');
+const yotiRequestHandler = require('../../src/request/request.handler');
+const { RequestBuilder } = require('../../src/request/request.builder');
+const { Payload } = require('../../src/request/payload');
+
+const SOME_BASE_URL = 'https://someapi.yoti.com';
+const SOME_ENDPOINT = '/some/endpoint';
+const SOME_ENDPOINT_REG_EXP = new RegExp(`^${SOME_ENDPOINT}`);
+const SOME_PEM_STRING = fs.readFileSync('./tests/sample-data/keys/node-sdk-test.pem', 'utf8');
+const ALLOWED_METHODS = ['POST', 'PUT', 'PATCH', 'GET', 'DELETE'];
+const SOME_JSON_DATA = { some: 'json' };
+const SOME_JSON_RECEIPT_DATA = { receipt: 'some receipt' };
+
+/**
+ * @param {string} method
+ * @param {string} uri
+ * @param {integer} responseCode
+ * @param {string} body
+ */
+const mockResponse = (method, uri, responseCode, body) => {
+  const scope = nock(SOME_BASE_URL);
+  const interceptor = scope[method.toLowerCase()](uri);
+  interceptor.reply(responseCode, body);
+};
+
+describe('yotiRequest', () => {
+  afterEach((done) => {
+    nock.cleanAll();
+    done();
+  });
+
+  ALLOWED_METHODS.forEach((ALLOWED_METHOD) => {
+    describe(`when empty response is returned for ${ALLOWED_METHOD} method`, () => {
+      beforeEach((done) => {
+        mockResponse(ALLOWED_METHOD, SOME_ENDPOINT_REG_EXP, 200, '');
+        done();
+      });
+
+      it('should return YotiResponse', (done) => {
+        const request = new RequestBuilder()
+          .withBaseUrl(SOME_BASE_URL)
+          .withEndpoint(SOME_ENDPOINT)
+          .withMethod(ALLOWED_METHOD)
+          .withPayload(new Payload(''))
+          .withPemString(SOME_PEM_STRING)
+          .build();
+
+        yotiRequestHandler
+          .execute(request)
+          .then((response) => {
+            expect(response.getParsedResponse()).toBeNull();
+            done();
+          })
+          .catch(done);
+      });
+    });
+    describe(`when JSON response is returned for ${ALLOWED_METHOD} method`, () => {
+      beforeEach((done) => {
+        mockResponse(ALLOWED_METHOD, SOME_ENDPOINT_REG_EXP, 200, JSON.stringify(SOME_JSON_DATA));
+        done();
+      });
+
+      it('should return YotiResponse', (done) => {
+        const request = new RequestBuilder()
+          .withBaseUrl(SOME_BASE_URL)
+          .withEndpoint(SOME_ENDPOINT)
+          .withMethod(ALLOWED_METHOD)
+          .withPayload(new Payload(''))
+          .withPemString(SOME_PEM_STRING)
+          .build();
+
+        yotiRequestHandler
+          .execute(request)
+          .then((response) => {
+            expect(response.getParsedResponse())
+              .toStrictEqual(SOME_JSON_DATA);
+            expect(response.getReceipt())
+              .toBeNull();
+            done();
+          })
+          .catch(done);
+      });
+    });
+  });
+  describe('when receipt is returned', () => {
+    beforeEach((done) => {
+      mockResponse('GET', SOME_ENDPOINT_REG_EXP, 200, JSON.stringify(SOME_JSON_RECEIPT_DATA));
+      done();
+    });
+
+    it('should return YotiResponse', (done) => {
+      const request = new RequestBuilder()
+        .withBaseUrl(SOME_BASE_URL)
+        .withEndpoint(SOME_ENDPOINT)
+        .withMethod('GET')
+        .withPemString(SOME_PEM_STRING)
+        .build();
+
+      yotiRequestHandler
+        .execute(request)
+        .then((response) => {
+          expect(response.getParsedResponse())
+            .toStrictEqual(SOME_JSON_RECEIPT_DATA);
+          expect(response.getReceipt())
+            .toStrictEqual(SOME_JSON_RECEIPT_DATA.receipt);
+          done();
+        })
+        .catch(done);
+    });
+  });
+});

--- a/tests/request/request.handler.spec.js
+++ b/tests/request/request.handler.spec.js
@@ -24,7 +24,9 @@ const SOME_DATA = 'someData';
 const mockResponse = (method, uri, responseCode, body) => {
   const scope = nock(SOME_BASE_URL);
   const interceptor = scope[method.toLowerCase()](uri);
-  interceptor.reply(responseCode, body);
+  interceptor.reply(responseCode, body, {
+    'content-type': 'application/json',
+  });
 };
 
 describe('yotiRequest', () => {
@@ -52,7 +54,7 @@ describe('yotiRequest', () => {
         yotiRequestHandler
           .execute(request)
           .then((response) => {
-            expect(response.getParsedResponse()).toBe('');
+            expect(response.getParsedResponse()).toBeNull();
             done();
           })
           .catch(done);
@@ -113,6 +115,7 @@ describe('yotiRequest', () => {
     });
   });
   [
+    'application/octet-stream',
     'image/jpeg',
     'image/png',
   ].forEach((mimeType) => {
@@ -134,7 +137,7 @@ describe('yotiRequest', () => {
           .build();
 
         yotiRequestHandler
-          .execute(request)
+          .execute(request, true)
           .then((response) => {
             expect(response.getParsedResponse())
               .toBeInstanceOf(Buffer);

--- a/tests/request/request.handler.spec.js
+++ b/tests/request/request.handler.spec.js
@@ -10,7 +10,10 @@ const SOME_ENDPOINT_REG_EXP = new RegExp(`^${SOME_ENDPOINT}`);
 const SOME_PEM_STRING = fs.readFileSync('./tests/sample-data/keys/node-sdk-test.pem', 'utf8');
 const ALLOWED_METHODS = ['POST', 'PUT', 'PATCH', 'GET', 'DELETE'];
 const SOME_JSON_DATA = { some: 'json' };
+const SOME_JSON_DATA_STRING = JSON.stringify(SOME_JSON_DATA);
 const SOME_JSON_RECEIPT_DATA = { receipt: 'some receipt' };
+const SOME_JSON_RECEIPT_DATA_STRING = JSON.stringify(SOME_JSON_RECEIPT_DATA);
+const SOME_DATA = 'someData';
 
 /**
  * @param {string} method
@@ -49,7 +52,7 @@ describe('yotiRequest', () => {
         yotiRequestHandler
           .execute(request)
           .then((response) => {
-            expect(response.getParsedResponse()).toBeNull();
+            expect(response.getParsedResponse()).toBe('');
             done();
           })
           .catch(done);
@@ -57,7 +60,7 @@ describe('yotiRequest', () => {
     });
     describe(`when JSON response is returned for ${ALLOWED_METHOD} method`, () => {
       beforeEach((done) => {
-        mockResponse(ALLOWED_METHOD, SOME_ENDPOINT_REG_EXP, 200, JSON.stringify(SOME_JSON_DATA));
+        mockResponse(ALLOWED_METHOD, SOME_ENDPOINT_REG_EXP, 200, SOME_JSON_DATA_STRING);
         done();
       });
 
@@ -85,7 +88,7 @@ describe('yotiRequest', () => {
   });
   describe('when receipt is returned', () => {
     beforeEach((done) => {
-      mockResponse('GET', SOME_ENDPOINT_REG_EXP, 200, JSON.stringify(SOME_JSON_RECEIPT_DATA));
+      mockResponse('GET', SOME_ENDPOINT_REG_EXP, 200, SOME_JSON_RECEIPT_DATA_STRING);
       done();
     });
 
@@ -107,6 +110,40 @@ describe('yotiRequest', () => {
           done();
         })
         .catch(done);
+    });
+  });
+  [
+    'image/jpeg',
+    'image/png',
+  ].forEach((mimeType) => {
+    describe(`when ${mimeType} content is returned`, () => {
+      beforeEach((done) => {
+        nock(SOME_BASE_URL)
+          .get(SOME_ENDPOINT_REG_EXP)
+          .reply(200, SOME_DATA, {
+            'Content-Type': mimeType,
+          });
+        done();
+      });
+      it('should return YotiResponse', (done) => {
+        const request = new RequestBuilder()
+          .withBaseUrl(SOME_BASE_URL)
+          .withEndpoint(SOME_ENDPOINT)
+          .withMethod('GET')
+          .withPemString(SOME_PEM_STRING)
+          .build();
+
+        yotiRequestHandler
+          .execute(request)
+          .then((response) => {
+            expect(response.getParsedResponse())
+              .toBeInstanceOf(Buffer);
+            expect(response.getParsedResponse().toString())
+              .toBe(SOME_DATA);
+            done();
+          })
+          .catch(done);
+      });
     });
   });
 });

--- a/tests/request/request.spec.js
+++ b/tests/request/request.spec.js
@@ -1,5 +1,8 @@
 const { YotiRequest } = require('../../src/request/request');
+const requestHandler = require('../../src/request/request.handler');
 const { Payload } = require('../../src/request/payload');
+
+jest.mock('../../src/request/request.handler');
 
 const SOME_URL = 'https://api.example.com/some-endpoint';
 const SOME_METHOD = 'POST';
@@ -10,6 +13,20 @@ const SOME_HEADERS = {
 const SOME_REQUEST = new YotiRequest(SOME_METHOD, SOME_URL, SOME_HEADERS, SOME_PAYLOAD);
 
 describe('YotiRequest', () => {
+  describe('#execute', () => {
+    it('should execute the request handler', () => {
+      SOME_REQUEST.execute();
+      expect(requestHandler.execute).toHaveBeenCalledWith(SOME_REQUEST, false);
+    });
+    it('should execute the request handler with buffer disabled', () => {
+      SOME_REQUEST.execute(false);
+      expect(requestHandler.execute).toHaveBeenCalledWith(SOME_REQUEST, false);
+    });
+    it('should execute the request handler with buffer enabled', () => {
+      SOME_REQUEST.execute(true);
+      expect(requestHandler.execute).toHaveBeenCalledWith(SOME_REQUEST, true);
+    });
+  });
   describe('#getUrl', () => {
     it('should return the URL', () => {
       expect(SOME_REQUEST.getUrl()).toBe(SOME_URL);

--- a/tests/request/response.spec.js
+++ b/tests/request/response.spec.js
@@ -1,0 +1,51 @@
+const { YotiResponse } = require('../../src/request/response');
+
+const SOME_BODY = '{"some":"response"}';
+const SOME_RECEIPT = { some: 'receipt' };
+const SOME_PARSED_RESPONSE = JSON.parse(SOME_BODY);
+const SOME_RESPONSE = new YotiResponse(
+  SOME_PARSED_RESPONSE,
+  200,
+  SOME_RECEIPT,
+  SOME_BODY
+);
+
+describe('YotiResponse', () => {
+  describe('#getBody', () => {
+    it('should return the body', () => {
+      expect(SOME_RESPONSE.getBody()).toBe(SOME_BODY);
+    });
+  });
+  describe('#getParsedResponse', () => {
+    it('should return the parsed response', () => {
+      expect(SOME_RESPONSE.getParsedResponse()).toBe(SOME_PARSED_RESPONSE);
+    });
+  });
+  describe('#getReceipt', () => {
+    it('should return the receipt', () => {
+      expect(SOME_RESPONSE.getReceipt()).toBe(SOME_RECEIPT);
+    });
+  });
+  describe('#getStatusCode', () => {
+    it('should return the status code', () => {
+      expect(SOME_RESPONSE.getStatusCode()).toBe(200);
+    });
+  });
+  describe('#constructor', () => {
+    it('should not require receipt', () => {
+      const SOME_RESPONSE_WITHOUT_RECEIPT = new YotiResponse(
+        SOME_PARSED_RESPONSE,
+        200
+      );
+      expect(SOME_RESPONSE_WITHOUT_RECEIPT.getReceipt()).toBeNull();
+    });
+    it('should not require body', () => {
+      const SOME_RESPONSE_WITHOUT_BODY = new YotiResponse(
+        SOME_PARSED_RESPONSE,
+        200,
+        SOME_RECEIPT
+      );
+      expect(SOME_RESPONSE_WITHOUT_BODY.getBody()).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
### Fixed
- `YotiResponse.getParsedResponse()` returns
  - `Buffer` for binary responses
  - Parsed _JSON_ for _JSON_ responses
  - `null` for empty responses

### Added
- `YotiRequest.execute(buffer = false)`
  - Optional `buffer` argument that _(default value: `false`)_.
  - Set `true` to return binary content types as a `Buffer`.
- `YotiResponse.getBody()`
  - Returns _string_ for text responses
  - Returns _Buffer_ for binary responses
