### PR TITLE
SDK-1208: Request Builder Headers

### DIFF
--- a/src/profile_service/index.js
+++ b/src/profile_service/index.js
@@ -9,7 +9,9 @@ module.exports.getReceipt = (token, pem, appId) => {
     'GET',
     `/profile/${token}`,
     pem,
-    appId
+    appId,
+    null,
+    { 'X-Yoti-Auth-Key': yotiCommon.getAuthKeyFromPem(pem) }
   );
 
   return new Promise((resolve, reject) => {

--- a/src/request/index.js
+++ b/src/request/index.js
@@ -11,13 +11,24 @@ const { RequestBuilder } = require('./request.builder');
  *
  * @returns {SignedRequest}
  */
-module.exports.buildConnectApiRequest = (httpMethod, endpoint, pem, appId, payload) => {
+module.exports.buildConnectApiRequest = (
+  httpMethod,
+  endpoint,
+  pem,
+  appId,
+  payload,
+  headers
+) => {
   const requestBuilder = new RequestBuilder()
     .withBaseUrl(config.yoti.connectApi)
     .withPemString(pem)
     .withEndpoint(endpoint)
     .withQueryParam('appId', appId)
     .withMethod(httpMethod);
+
+  if (headers) {
+    Object.keys(headers).forEach(name => requestBuilder.withHeader(name, headers[name]));
+  }
 
   if (payload) {
     requestBuilder.withPayload(payload);

--- a/src/request/request.builder.js
+++ b/src/request/request.builder.js
@@ -138,14 +138,18 @@ class RequestBuilder {
    * @param {*} messageSignature
    */
   getDefaultHeaders(messageSignature) {
-    return {
-      'X-Yoti-Auth-Key': yotiCommon.getAuthKeyFromPem(this.pem),
+    const defaultHeaders = {
       'X-Yoti-Auth-Digest': messageSignature,
       'X-Yoti-SDK': SDK_IDENTIFIER,
       'X-Yoti-SDK-Version': `${SDK_IDENTIFIER}-${yotiPackage.version}`,
-      'Content-Type': 'application/json',
       Accept: 'application/json',
     };
+
+    if (this.payload) {
+      defaultHeaders['Content-Type'] = 'application/json';
+    }
+
+    return defaultHeaders;
   }
 
   /**

--- a/tests/client/index.spec.js
+++ b/tests/client/index.spec.js
@@ -11,6 +11,13 @@ const ShareUrlResult = require('../../src/dynamic_sharing_service/share.url.resu
 const privateKeyFile = fs.readFileSync('./tests/sample-data/keys/node-sdk-test.pem', 'utf8');
 const yotiClient = new yoti.Client('stub-app-id', privateKeyFile);
 
+const CONTENT_TYPE_HEADER_NAME = 'Content-Type';
+const CONTENT_TYPE_JSON = 'application/json';
+const DIGEST_KEY_HEADER_NAME = 'X-Yoti-Auth-Digest';
+const DIGEST_KEY_PATTERN = /^[a-zA-Z0-9/+=]{344}$/;
+const AUTH_KEY_HEADER_NAME = 'X-Yoti-Auth-Key';
+const AUTH_KEY_PATTERN = /^[a-zA-Z0-9/+]{392}$/;
+
 describe('yotiClient', () => {
   const encryptedYotiToken = 'c31Db4y6ClxSWy26xDpa9LEX3ZTUuR-rKaAhjQWnmKilR20IshkysR5Y3Hh3R6hanOyxcu7fl5vbjikkGZZb3_iH6NjxmBXuGY_Fr23AhrHvGL9WMg4EtemVvr6VI2f_5H_PDhDpYUvv-YpEM0f_SReoVxGIc8VGfj1gukuhPyNJ9hs55-SDdUjN77JiA6FPcYZxEIaqQE_yT_c3Y4V72Jnq3RHbG0vL6SefSfY_fFsnx_HeddsJc10qJYCwAkdGzVzbJH2DQ2Swp821Gwyj9eNK54S6HvpIg7LclID7BtymG6z7cTNp3fXX7mgKYoQlh_DHmPmaiqyj398w424RBg==';
   const decryptedToken = 'i79CctmY-22ad195c-d166-49a2-af16-8f356788c9dd-be094d26-19b5-450d-afce-070101760f0b';
@@ -33,10 +40,11 @@ describe('yotiClient', () => {
       beforeEach((done) => {
         nock(`${config.yoti.connectApi}`)
           .get(profileEndpointPattern)
+          .matchHeader(DIGEST_KEY_HEADER_NAME, DIGEST_KEY_PATTERN)
+          .matchHeader(AUTH_KEY_HEADER_NAME, AUTH_KEY_PATTERN)
           .reply(200, responseContent);
         done();
       });
-
       it('should fetch and decrypt the profile', (done) => {
         yotiClient.getActivityDetails(encryptedYotiToken)
           .then((activityDetails) => {
@@ -80,6 +88,8 @@ describe('yotiClient', () => {
       beforeEach((done) => {
         nock(`${config.yoti.connectApi}`)
           .get(profileEndpointPattern)
+          .matchHeader(AUTH_KEY_HEADER_NAME, AUTH_KEY_PATTERN)
+          .matchHeader(DIGEST_KEY_HEADER_NAME, DIGEST_KEY_PATTERN)
           .reply(200, responseContentNull);
         done();
       });
@@ -109,6 +119,8 @@ describe('yotiClient', () => {
       beforeEach((done) => {
         nock(`${config.yoti.connectApi}`)
           .get(profileEndpointPattern)
+          .matchHeader(AUTH_KEY_HEADER_NAME, AUTH_KEY_PATTERN)
+          .matchHeader(DIGEST_KEY_HEADER_NAME, DIGEST_KEY_PATTERN)
           .reply(200, responseContentEmptyObj);
         done();
       });
@@ -138,6 +150,8 @@ describe('yotiClient', () => {
       beforeEach((done) => {
         nock(`${config.yoti.connectApi}`)
           .get(profileEndpointPattern)
+          .matchHeader(AUTH_KEY_HEADER_NAME, AUTH_KEY_PATTERN)
+          .matchHeader(DIGEST_KEY_HEADER_NAME, DIGEST_KEY_PATTERN)
           .reply(200, responseContentNonExistent);
         done();
       });
@@ -171,6 +185,8 @@ describe('yotiClient', () => {
     beforeEach((done) => {
       nock(`${config.yoti.connectApi}`)
         .post(new RegExp('^/api/v1/aml-check?.*appId=stub-app-id&nonce=.*?&timestamp=.*?'), amlPayload.getPayloadJSON())
+        .matchHeader(DIGEST_KEY_HEADER_NAME, DIGEST_KEY_PATTERN)
+        .matchHeader(CONTENT_TYPE_HEADER_NAME, CONTENT_TYPE_JSON)
         .reply(200, amlCheckResult);
 
       done();
@@ -198,7 +214,9 @@ describe('yotiClient', () => {
     const SHARE_URL_RESULT = './tests/sample-data/responses/share-url-result.json';
     beforeEach((done) => {
       nock(`${config.yoti.connectApi}`)
-        .post(new RegExp('^/api/v1/qrcodes/apps/'))
+        .post(new RegExp('^/api/v1/qrcodes/apps/'), JSON.stringify(dynamicScenario))
+        .matchHeader(DIGEST_KEY_HEADER_NAME, DIGEST_KEY_PATTERN)
+        .matchHeader(CONTENT_TYPE_HEADER_NAME, CONTENT_TYPE_JSON)
         .reply(200, fs.readFileSync(SHARE_URL_RESULT));
       done();
     });

--- a/tests/request/request.builder.spec.js
+++ b/tests/request/request.builder.spec.js
@@ -1,54 +1,22 @@
 const nock = require('nock');
 const fs = require('fs');
 
-const { YotiRequest } = require('../../src/request/request');
-const { RequestBuilder } = require('../../');
+const { RequestBuilder, Payload } = require('../../');
 const yotiPackage = require('../../package.json');
 
 const PEM_FILE_PATH = './tests/sample-data/keys/node-sdk-test.pem';
 const PEM_STRING = fs.readFileSync(PEM_FILE_PATH, 'utf8');
 const API_BASE_URL = 'https://api.example.com';
 const API_ENDPOINT = '/some-endpoint';
-
-/**
- * Assert that the signed request was built correctly.
- *
- * @param {Request} request
- */
-const assertExpectedRequest = (request, done) => {
-  expect(request).toBeInstanceOf(YotiRequest);
-
-  // Check that auth headers are present.
-  request.execute()
-    .then((response) => {
-      const sentHeaders = response.getParsedResponse().headers;
-
-      const expectedHeaders = {
-        'X-Yoti-SDK': 'Node',
-        'X-Yoti-SDK-Version': `Node-${yotiPackage.version}`,
-        'Content-Type': 'application/json',
-        Accept: 'application/json',
-      };
-
-      Object.keys(expectedHeaders).forEach((header) => {
-        const sentHeader = sentHeaders[header.toLowerCase()];
-        expect(sentHeader).toBe(expectedHeaders[header], header);
-      });
-
-      const expectedMatchHeaders = {
-        'X-Yoti-Auth-Key': new RegExp('^[a-zA-Z0-9/+]{392}$'),
-        'X-Yoti-Auth-Digest': new RegExp('^[a-zA-Z0-9/+=]{344}$'),
-      };
-
-      Object.keys(expectedMatchHeaders).forEach((header) => {
-        const sentHeader = sentHeaders[header.toLowerCase()];
-        expect(sentHeader).toMatch(expectedMatchHeaders[header], header);
-      });
-
-      done();
-    })
-    .catch(done);
+const CONTENT_TYPE_HEADER_NAME = 'Content-Type';
+const CONTENT_TYPE_JSON = 'application/json';
+const DEFAULT_HEADERS = {
+  'X-Yoti-SDK': 'Node',
+  'X-Yoti-SDK-Version': `Node-${yotiPackage.version}`,
+  Accept: CONTENT_TYPE_JSON,
+  'X-Yoti-Auth-Digest': new RegExp('^[a-zA-Z0-9/+=]{344}$'),
 };
+const SOME_PAYLOAD = new Payload({ some: 'data' });
 
 describe('RequestBuilder', () => {
   beforeEach((done) => {
@@ -60,7 +28,7 @@ describe('RequestBuilder', () => {
     done();
   });
   describe('#build', () => {
-    it('should build a Request with pem string', (done) => {
+    it('should build a Request with pem string', () => {
       const request = new RequestBuilder()
         .withBaseUrl(API_BASE_URL)
         .withPemString(PEM_STRING)
@@ -68,10 +36,11 @@ describe('RequestBuilder', () => {
         .withGet()
         .build();
 
-      assertExpectedRequest(request, done);
+      expect(request).toHaveHeaders(DEFAULT_HEADERS);
+      expect(request.getHeaders()[CONTENT_TYPE_HEADER_NAME]).toBeUndefined();
     });
 
-    it('should build a Request with pem file path', (done) => {
+    it('should build a Request with pem file path', () => {
       const request = new RequestBuilder()
         .withBaseUrl(API_BASE_URL)
         .withPemFilePath(PEM_FILE_PATH)
@@ -79,7 +48,7 @@ describe('RequestBuilder', () => {
         .withGet()
         .build();
 
-      assertExpectedRequest(request, done);
+      expect(request).toHaveHeaders(DEFAULT_HEADERS);
     });
 
     it('should require a PEM string or file', () => {
@@ -98,7 +67,7 @@ describe('RequestBuilder', () => {
       }).toThrow(new Error('Base URL must be specified'));
     });
 
-    it('should build with valid headers', (done) => {
+    it('should build with valid headers', () => {
       const request = new RequestBuilder()
         .withBaseUrl(API_BASE_URL)
         .withPemFilePath(PEM_FILE_PATH)
@@ -108,15 +77,11 @@ describe('RequestBuilder', () => {
         .withGet()
         .build();
 
-      request
-        .execute()
-        .then((response) => {
-          const headers = response.getParsedResponse().headers;
-          expect(headers['custom-1']).toBe('value 1');
-          expect(headers['custom-2']).toBe('value 2');
-          done();
-        })
-        .catch(done);
+      expect(request).toHaveHeaders(DEFAULT_HEADERS);
+      expect(request).toHaveHeaders({
+        'Custom-1': 'value 1',
+        'Custom-2': 'value 2',
+      });
     });
   });
   describe('#withEndpoint', () => {
@@ -124,7 +89,7 @@ describe('RequestBuilder', () => {
       `///${API_ENDPOINT}`,
       API_ENDPOINT.replace(/^\/+/, ''),
     ].forEach((endpoint) => {
-      it(`should ensure "${endpoint}" has one leading slash`, (done) => {
+      it(`should ensure "${endpoint}" has one leading slash`, () => {
         const request = new RequestBuilder()
           .withBaseUrl(`${API_BASE_URL}`)
           .withPemFilePath(PEM_FILE_PATH)
@@ -132,12 +97,12 @@ describe('RequestBuilder', () => {
           .withGet()
           .build();
 
-        assertExpectedRequest(request, done);
+        expect(request).toHaveHeaders(DEFAULT_HEADERS);
       });
     });
   });
   describe('#withBaseUrl', () => {
-    it('should remove trailing slashes', (done) => {
+    it('should remove trailing slashes', () => {
       const request = new RequestBuilder()
         .withBaseUrl(`${API_BASE_URL}///`)
         .withPemFilePath(PEM_FILE_PATH)
@@ -145,7 +110,22 @@ describe('RequestBuilder', () => {
         .withGet()
         .build();
 
-      assertExpectedRequest(request, done);
+      expect(request).toHaveHeaders(DEFAULT_HEADERS);
+    });
+  });
+  describe('#withPayload', () => {
+    it('should set the provided payload', () => {
+      const request = new RequestBuilder()
+        .withBaseUrl(API_BASE_URL)
+        .withPemFilePath(PEM_FILE_PATH)
+        .withEndpoint(API_ENDPOINT)
+        .withPayload(SOME_PAYLOAD)
+        .withPost()
+        .build();
+
+      expect(request.getPayload()).toStrictEqual(SOME_PAYLOAD);
+      expect(request).toHaveHeaders(DEFAULT_HEADERS);
+      expect(request.getHeaders()[CONTENT_TYPE_HEADER_NAME]).toBe(CONTENT_TYPE_JSON);
     });
   });
   describe('#withGet', () => {
@@ -197,4 +177,24 @@ describe('RequestBuilder', () => {
       }).toThrow(new TypeError('Header name must be a string'));
     });
   });
+});
+
+expect.extend({
+  toHaveHeaders(request, expectedHeaders) {
+    Object.keys(expectedHeaders).forEach((header) => {
+      const headerValue = request.getHeaders()[header];
+      const expectedHeaderValue = expectedHeaders[header];
+
+      if (expectedHeaderValue instanceof RegExp) {
+        expect(headerValue).toMatch(expectedHeaderValue);
+      } else {
+        expect(headerValue).toBe(expectedHeaderValue);
+      }
+    });
+    return {
+      message: () =>
+        'Request contains expected headers',
+      pass: true,
+    };
+  },
 });


### PR DESCRIPTION
### Changed
- `X-Yoti-Auth-Key` header is only provided to profile endpoint
- Default `Content-Type` header is only added when payload is provided
