### PR TITLE
SDK-1255: Fix YotiDate format

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "yoti",
-  "version": "3.7.2",
+  "version": "3.7.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yoti",
-  "version": "3.7.2",
+  "version": "3.7.3",
   "description": "Yoti NodeJS SDK for back-end integration",
   "author": "Yoti LTD <tech@yoti.com> (https://www.yoti.com/developers)",
   "license": "MIT",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey = yoti-web-sdk:node
 sonar.projectName = node-sdk
-sonar.projectVersion = 3.7.2
+sonar.projectVersion = 3.7.3
 sonar.exclusions=tests/**,examples/**,node_modules/**,coverage/**
 sonar.javascript.lcov.reportPaths=coverage/lcov.info
 sonar.verbose = true

--- a/src/data_type/date.js
+++ b/src/data_type/date.js
@@ -58,7 +58,7 @@ class YotiDate extends Date {
    */
   getMicrosecondTime() {
     const hours = formatDatePart(this.getUTCHours(), 2);
-    const minutes = formatDatePart(this.getUTCMinutes());
+    const minutes = formatDatePart(this.getUTCMinutes(), 2);
     const secondsMicroseconds = formatSecondsWithMicroseconds(
       this.getUTCSeconds(),
       this.getMicroseconds()

--- a/tests/data_type/date.spec.js
+++ b/tests/data_type/date.spec.js
@@ -9,6 +9,13 @@ describe('YotiDate', () => {
     });
   });
 
+  describe('#getMicrosecondTime', () => {
+    const smallDate = new YotiDate(1571630945010000);
+    it('should return zero padded in correct ISO format', () => {
+      expect(smallDate.getMicrosecondTime()).toBe('04:09:05.010000');
+    });
+  });
+
   describe('#getMicroseconds()', () => {
     it('should return 923530', () => {
       expect(date.getMicroseconds()).toBe(923530);


### PR DESCRIPTION
## Changed

* Updated `YotiDate` to return microsecond time format with minutes zero padded