### PR TITLE
SDK-1277: Add headers getter to response object

### DIFF
--- a/src/request/request.handler.js
+++ b/src/request/request.handler.js
@@ -44,7 +44,8 @@ module.exports.execute = (yotiRequest, buffer = false) => new Promise((resolve, 
         parsedResponse,
         response.statusCode,
         receipt,
-        body
+        body,
+        response.headers
       ));
     })
     .catch((err) => {

--- a/src/request/response.js
+++ b/src/request/response.js
@@ -9,12 +9,14 @@ class YotiResponse {
    * @param {int} statusCode
    * @param {Object|null} receipt
    * @param {Buffer|string|null} body
+   * @param {Array|null} headers
    */
-  constructor(parsedResponse, statusCode, receipt = null, body = null) {
+  constructor(parsedResponse, statusCode, receipt = null, body = null, headers = null) {
     this.parsedResponse = parsedResponse;
     this.statusCode = statusCode;
     this.receipt = receipt;
     this.body = body;
+    this.headers = headers;
   }
 
   /**
@@ -43,6 +45,13 @@ class YotiResponse {
    */
   getStatusCode() {
     return this.statusCode;
+  }
+
+  /**
+   * @returns {Object.<string, string>} Response headers
+   */
+  getHeaders() {
+    return this.headers;
   }
 }
 

--- a/tests/request/response.spec.js
+++ b/tests/request/response.spec.js
@@ -3,11 +3,16 @@ const { YotiResponse } = require('../../src/request/response');
 const SOME_BODY = '{"some":"response"}';
 const SOME_RECEIPT = { some: 'receipt' };
 const SOME_PARSED_RESPONSE = JSON.parse(SOME_BODY);
+const SOME_HEADERS = {
+  'Some-Header': 'some value',
+  'Some-Other-Header': 'some other value',
+};
 const SOME_RESPONSE = new YotiResponse(
   SOME_PARSED_RESPONSE,
   200,
   SOME_RECEIPT,
-  SOME_BODY
+  SOME_BODY,
+  SOME_HEADERS
 );
 
 describe('YotiResponse', () => {
@@ -31,6 +36,11 @@ describe('YotiResponse', () => {
       expect(SOME_RESPONSE.getStatusCode()).toBe(200);
     });
   });
+  describe('#getHeaders', () => {
+    it('should return the response headers', () => {
+      expect(SOME_RESPONSE.getHeaders()).toEqual(SOME_HEADERS);
+    });
+  });
   describe('#constructor', () => {
     it('should not require receipt', () => {
       const SOME_RESPONSE_WITHOUT_RECEIPT = new YotiResponse(
@@ -46,6 +56,15 @@ describe('YotiResponse', () => {
         SOME_RECEIPT
       );
       expect(SOME_RESPONSE_WITHOUT_BODY.getBody()).toBeNull();
+    });
+    it('should not require headers', () => {
+      const SOME_RESPONSE_WITHOUT_HEADERS = new YotiResponse(
+        SOME_PARSED_RESPONSE,
+        200,
+        SOME_RECEIPT,
+        SOME_BODY
+      );
+      expect(SOME_RESPONSE_WITHOUT_HEADERS.getHeaders()).toBeNull();
     });
   });
 });


### PR DESCRIPTION
### Added
- `YotiResponse.getHeaders()` returns `{Object.<string, string>}` map of headers
