### PR TITLE
SDK-1279: Prevent empty wanted attribute name

### DIFF
--- a/src/dynamic_sharing_service/policy/wanted.attribute.js
+++ b/src/dynamic_sharing_service/policy/wanted.attribute.js
@@ -17,6 +17,7 @@ module.exports = class WantedAttribute {
    */
   constructor(name, derivation = null, acceptSelfAsserted = null, constraints = null) {
     Validation.isString(name, 'name');
+    Validation.notNullOrEmpty(name, 'name');
     this.name = name;
 
     if (derivation !== null) {

--- a/tests/dynamic_sharing_service/policy/wanted.attribute.builder.spec.js
+++ b/tests/dynamic_sharing_service/policy/wanted.attribute.builder.spec.js
@@ -23,6 +23,24 @@ describe('WantedAttributeBuilder', () => {
     expect(wantedAttribute.getDerivation()).toBe(TEST_DERIVATION);
   });
 
+  it('should throw error when name is an empty string', () => {
+    expect(() => {
+      new WantedAttributeBuilder()
+        .withName('')
+        .build();
+    }).toThrow(new TypeError('name cannot be null or empty'));
+  });
+
+  it('should throw error when name is a non-string value', () => {
+    [null, []].forEach((nonStringValue) => {
+      expect(() => {
+        new WantedAttributeBuilder()
+          .withName(nonStringValue)
+          .build();
+      }).toThrow(new TypeError('name must be a string'));
+    });
+  });
+
   it('should build a wanted attribute with accept self asserted', () => {
     const wantedAttributeDefault = new WantedAttributeBuilder()
       .withName(TEST_NAME)


### PR DESCRIPTION
### Fixed
- Preventing empty wanted attribute names