### PR TITLE
SDK-1368: Support microsecond accuracy using fromDateString()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ coverage
 idea
 .idea
 .scannerwork
+.vscode

--- a/src/data_type/date.js
+++ b/src/data_type/date.js
@@ -60,7 +60,7 @@ function formatSecondsWithMicroseconds(seconds, microseconds) {
 function extractMicrosecondsFromTimestamp(timestamp) {
   let microseconds = timestamp % 1000000;
   if (microseconds < 0) {
-    microseconds = 1000000 + microseconds;
+    microseconds += 1000000;
   }
   return microseconds;
 }

--- a/tests/data_type/date.spec.js
+++ b/tests/data_type/date.spec.js
@@ -1,26 +1,63 @@
 const { YotiDate } = require('../../src/data_type/date');
 
 describe('YotiDate', () => {
-  const date = new YotiDate(1067950267923530);
-
   describe('#toUTCString()', () => {
     it('should return Tue, 04 Nov 2003 12:51:07 GMT', () => {
-      expect(date.toUTCString()).toBe('Tue, 04 Nov 2003 12:51:07 GMT');
+      expect(new YotiDate(1067950267923530).toUTCString())
+        .toBe('Tue, 04 Nov 2003 12:51:07 GMT');
     });
   });
 
-  describe('#getMicrosecondTime', () => {
-    const smallDate = new YotiDate(1571630945010000);
-    it('should return zero padded in correct ISO format', () => {
-      expect(smallDate.getMicrosecondTime()).toBe('04:09:05.010000');
+  describe('#fromDateString()', () => {
+    test.each([
+      ['2006-01-02', '2006-01-02T00:00:00.000000Z'],
+      ['2006-01-02T22:04:05Z', '2006-01-02T22:04:05.000000Z'],
+      ['2006-01-02T22:04:05.1Z', '2006-01-02T22:04:05.100000Z'],
+      ['2006-01-02T22:04:05.12Z', '2006-01-02T22:04:05.120000Z'],
+      ['2006-01-02T22:04:05.123Z', '2006-01-02T22:04:05.123000Z'],
+      ['2006-01-02T22:04:05.1234Z', '2006-01-02T22:04:05.123400Z'],
+      ['2006-01-02T22:04:05.12345Z', '2006-01-02T22:04:05.123450Z'],
+      ['2006-01-02T22:04:05.123956Z', '2006-01-02T22:04:05.123956Z'],
+      ['2006-01-02T22:04:05.123456789Z', '2006-01-02T22:04:05.123456Z'],
+      ['2002-10-02T10:00:00-05:00', '2002-10-02T15:00:00.000000Z'],
+      ['2002-10-02T10:00:00+11:00', '2002-10-01T23:00:00.000000Z'],
+      ['1920-03-13T19:50:53.000001Z', '1920-03-13T19:50:53.000001Z'],
+      ['1920-03-13T19:50:53.999999Z', '1920-03-13T19:50:53.999999Z'],
+      ['1920-03-13T19:50:53.000100Z', '1920-03-13T19:50:53.000100Z'],
+    ])('%s should match %s', (dateString, expected) => {
+      expect(YotiDate.fromDateString(dateString).getMicrosecondTimestamp())
+        .toBe(expected);
+    });
+  });
+
+  describe('#getMicrosecondTime()', () => {
+    test.each([
+      ['-1571630945999999', '19:50:54.000001'],
+      ['1571630945999999', '04:09:05.999999'],
+    ])('%s should have microsecond time %s', (timestamp, microsecondTime) => {
+      expect(new YotiDate(parseInt(timestamp, 10)).getMicrosecondTime())
+        .toBe(microsecondTime);
+    });
+  });
+
+  describe('#getMicrosecondTimestamp()', () => {
+    test.each([
+      ['-1571630945999999', '1920-03-13T19:50:54.000001Z'],
+      ['1571630945999999', '2019-10-21T04:09:05.999999Z'],
+    ])('%s should have microsecond timestamp %s', (timestamp, microsecondTime) => {
+      expect(new YotiDate(parseInt(timestamp, 10)).getMicrosecondTimestamp())
+        .toBe(microsecondTime);
     });
   });
 
   describe('#getMicroseconds()', () => {
-    it('should return 923530', () => {
-      expect(date.getMicroseconds()).toBe(923530);
-      expect(date.getMicrosecondTime()).toBe('12:51:07.923530');
-      expect(date.getMicrosecondTimestamp()).toBe('2003-11-04T12:51:07.923530Z');
+    test.each([
+      [-1571630945999999, 1],
+      [1571630945999999, 999999],
+      [1067950267923530, 923530],
+    ])('%s should return %s', (timestamp, microseconds) => {
+      expect(new YotiDate(timestamp).getMicroseconds())
+        .toBe(microseconds);
     });
   });
 });


### PR DESCRIPTION
### Fixed
- `YotiDate.fromDateString()` now supports microsecond accuracy
- `YotiDate.constructor()` now supports signed microsecond timestamps, e.g. `-1571630945999999` will have **1** microsecond
- Rounding when converting microseconds to `YotiDate`