### PR TITLE
SDK-1476: Use YotiDate for sandbox anchors

### DIFF
--- a/sandbox/profile/request/attribute/anchor.js
+++ b/sandbox/profile/request/attribute/anchor.js
@@ -1,3 +1,6 @@
+const Validation = require('../../../../src/yoti_common/validation');
+const { YotiDate } = require('../../../../');
+
 /**
  * @class SandboxAnchor
  */
@@ -6,12 +9,19 @@ class SandboxAnchor {
    * @param {string} type
    * @param {string} value
    * @param {string} subType
-   * @param {DateTime} timestamp
+   * @param {YotiDate} timestamp
    */
   constructor(type, value, subType, timestamp) {
+    Validation.isString(type, 'type');
     this.type = type;
+
+    Validation.isString(value, 'value');
     this.value = value;
+
+    Validation.isString(subType, 'subType');
     this.subType = subType;
+
+    Validation.instanceOf(timestamp, YotiDate, 'timestamp');
     this.timestamp = timestamp;
   }
 
@@ -37,7 +47,7 @@ class SandboxAnchor {
   }
 
   /**
-   * @returns {DateTime}
+   * @returns {YotiDate}
    */
   getTimestamp() {
     return this.timestamp;
@@ -51,7 +61,7 @@ class SandboxAnchor {
       type: this.getType(),
       value: this.getValue(),
       sub_type: this.getSubType(),
-      timestamp: this.getTimestamp(),
+      timestamp: this.getTimestamp().getMicrosecondUnixTimestamp(),
     };
   }
 }

--- a/src/data_type/date.js
+++ b/src/data_type/date.js
@@ -78,6 +78,7 @@ class YotiDate extends Date {
     Validation.isNumber(timestamp);
     super(Math.floor(timestamp / 1000));
     this.microseconds = extractMicrosecondsFromTimestamp(timestamp);
+    this.microsecondUnixTimestamp = timestamp;
   }
 
   /**
@@ -144,6 +145,15 @@ class YotiDate extends Date {
    */
   getMicrosecondTimestamp() {
     return `${this.toISODateString()}T${this.getMicrosecondTime()}Z`;
+  }
+
+  /**
+   * Returns Unix timestamp with microseconds.
+   *
+   * @returns {int}
+   */
+  getMicrosecondUnixTimestamp() {
+    return this.microsecondUnixTimestamp;
   }
 }
 

--- a/tests/data_type/date.spec.js
+++ b/tests/data_type/date.spec.js
@@ -24,7 +24,7 @@ describe('YotiDate', () => {
       ['1920-03-13T19:50:53.000001Z', '1920-03-13T19:50:53.000001Z'],
       ['1920-03-13T19:50:53.999999Z', '1920-03-13T19:50:53.999999Z'],
       ['1920-03-13T19:50:53.000100Z', '1920-03-13T19:50:53.000100Z'],
-    ])('%s should match %s', (dateString, expected) => {
+    ])('%s should convert to RFC-3339 date/time %s', (dateString, expected) => {
       expect(YotiDate.fromDateString(dateString).getMicrosecondTimestamp())
         .toBe(expected);
     });
@@ -32,22 +32,37 @@ describe('YotiDate', () => {
 
   describe('#getMicrosecondTime()', () => {
     test.each([
-      ['-1571630945999999', '19:50:54.000001'],
-      ['1571630945999999', '04:09:05.999999'],
+      [-1571630945999999, '19:50:54.000001'],
+      [1571630945999999, '04:09:05.999999'],
     ])('%s should have microsecond time %s', (timestamp, microsecondTime) => {
       expect(new YotiDate(parseInt(timestamp, 10)).getMicrosecondTime())
         .toBe(microsecondTime);
     });
   });
 
+  const validTimestamps = [
+    [-1571630945999999, '1920-03-13T19:50:54.000001Z'],
+    [1571630945999999, '2019-10-21T04:09:05.999999Z'],
+  ];
+
   describe('#getMicrosecondTimestamp()', () => {
-    test.each([
-      ['-1571630945999999', '1920-03-13T19:50:54.000001Z'],
-      ['1571630945999999', '2019-10-21T04:09:05.999999Z'],
-    ])('%s should have microsecond timestamp %s', (timestamp, microsecondTime) => {
-      expect(new YotiDate(parseInt(timestamp, 10)).getMicrosecondTimestamp())
-        .toBe(microsecondTime);
-    });
+    test.each(validTimestamps)(
+      '%s unix timestamp should have RFC-3339 date/time string %s',
+      (timestamp, dateTimeString) => {
+        expect(new YotiDate(timestamp).getMicrosecondTimestamp())
+          .toBe(dateTimeString);
+      }
+    );
+  });
+
+  describe('#getMicrosecondUnixTimestamp()', () => {
+    test.each(validTimestamps)(
+      '%s unix timestamp should be returned for RFC-3339 date/time string %s',
+      (timestamp, dateTimeString) => {
+        expect(YotiDate.fromDateString(dateTimeString).getMicrosecondUnixTimestamp())
+          .toBe(timestamp);
+      }
+    );
   });
 
   describe('#getMicroseconds()', () => {

--- a/tests/sandbox/request/attribute/anchor.spec.js
+++ b/tests/sandbox/request/attribute/anchor.spec.js
@@ -2,17 +2,19 @@ const {
   SandboxAnchorBuilder,
 } = require('../../../../sandbox');
 
+const { YotiDate } = require('../../../../');
+
 const SOME_ANCHOR_TYPE = 'someAnchorType';
 const SOME_ANCHOR_SUB_TYPE = 'someAnchorSubType';
 const SOME_ANCHOR_VALUE = 'someAnchorValue';
-const SOME_TIMESTAMP = '1569503646050000';
+const SOME_DATE = YotiDate.fromDateString('2020-01-01');
 
 describe('SandboxAnchor', () => {
   it('should build with all properties', () => {
     const sandboxAnchor = new SandboxAnchorBuilder()
       .withType(SOME_ANCHOR_TYPE)
       .withValue(SOME_ANCHOR_VALUE)
-      .withTimestamp(SOME_TIMESTAMP)
+      .withTimestamp(SOME_DATE)
       .withSubType(SOME_ANCHOR_SUB_TYPE)
       .build();
 
@@ -20,7 +22,7 @@ describe('SandboxAnchor', () => {
       type: SOME_ANCHOR_TYPE,
       value: SOME_ANCHOR_VALUE,
       sub_type: SOME_ANCHOR_SUB_TYPE,
-      timestamp: SOME_TIMESTAMP,
+      timestamp: SOME_DATE.getMicrosecondUnixTimestamp(),
     };
 
     expect(JSON.stringify(sandboxAnchor))

--- a/tests/sandbox/request/attribute/attribute.spec.js
+++ b/tests/sandbox/request/attribute/attribute.spec.js
@@ -3,11 +3,15 @@ const {
   SandboxAnchorBuilder,
 } = require('../../../../sandbox');
 
+const { YotiDate } = require('../../../../');
+
 const SOME_NAME = 'someName';
 const SOME_VALUE = 'someValue';
 const SOME_DERIVATION = 'someDerivation';
 const SOME_ANCHOR_TYPE = 'someAnchorType';
 const SOME_ANCHOR_VALUE = 'someAnchorValue';
+const SOME_ANCHOR_SUB_TYPE = 'someAnchorSubType';
+const SOME_DATE = YotiDate.fromDateString('2020-01-01');
 
 describe('SandboxAttribute', () => {
   it('should build with required properties', () => {
@@ -46,6 +50,8 @@ describe('SandboxAttribute', () => {
     const sandboxAnchor = new SandboxAnchorBuilder()
       .withType(SOME_ANCHOR_TYPE)
       .withValue(SOME_ANCHOR_VALUE)
+      .withSubType(SOME_ANCHOR_SUB_TYPE)
+      .withTimestamp(SOME_DATE)
       .build();
 
     const sandboxAttribute = new SandboxAttributeBuilder()
@@ -58,10 +64,9 @@ describe('SandboxAttribute', () => {
       name: SOME_NAME,
       value: SOME_VALUE,
       optional: false,
-      anchors: [{
-        type: SOME_ANCHOR_TYPE,
-        value: SOME_ANCHOR_VALUE,
-      }],
+      anchors: [
+        sandboxAnchor,
+      ],
     };
 
     expect(JSON.stringify(sandboxAttribute))

--- a/tests/sandbox/request/attribute/derivation/age.verification.spec.js
+++ b/tests/sandbox/request/attribute/derivation/age.verification.spec.js
@@ -3,9 +3,7 @@ const {
   SandboxAnchorBuilder,
 } = require('../../../../../sandbox');
 
-const {
-  YotiDate,
-} = require('../../../../..');
+const { YotiDate } = require('../../../../..');
 
 const SOME_DATE_OF_BIRTH_STRING = '1989-01-02';
 const SOME_DATE_OF_BIRTH = YotiDate.fromDateString(SOME_DATE_OF_BIRTH_STRING);
@@ -14,6 +12,8 @@ const SOME_AGE_OVER_DERIVATION_VALUE = `age_over:${SOME_AGE_VALUE}`;
 const SOME_AGE_UNDER_DERIVATION_VALUE = `age_under:${SOME_AGE_VALUE}`;
 const SOME_ANCHOR_TYPE = 'someAnchorType';
 const SOME_ANCHOR_VALUE = 'someAnchorValue';
+const SOME_ANCHOR_SUB_TYPE = 'someAnchorSubType';
+const SOME_DATE = YotiDate.fromDateString('2020-01-01');
 
 describe('SandboxAgeVerification', () => {
   it('should build age over attribute', () => {
@@ -79,6 +79,8 @@ describe('SandboxAgeVerification', () => {
     const sandboxAnchor = new SandboxAnchorBuilder()
       .withType(SOME_ANCHOR_TYPE)
       .withValue(SOME_ANCHOR_VALUE)
+      .withSubType(SOME_ANCHOR_SUB_TYPE)
+      .withTimestamp(SOME_DATE)
       .build();
 
     const sandboxAttribute = new SandboxAgeVerificationBuilder()
@@ -93,10 +95,9 @@ describe('SandboxAgeVerification', () => {
       value: SOME_DATE_OF_BIRTH_STRING,
       optional: false,
       derivation: SOME_AGE_OVER_DERIVATION_VALUE,
-      anchors: [{
-        type: SOME_ANCHOR_TYPE,
-        value: SOME_ANCHOR_VALUE,
-      }],
+      anchors: [
+        sandboxAnchor,
+      ],
     };
 
     expect(JSON.stringify(sandboxAttribute))

--- a/tests/sandbox/request/token.spec.js
+++ b/tests/sandbox/request/token.spec.js
@@ -4,14 +4,15 @@ const {
   SandboxAnchorBuilder,
 } = require('../../../sandbox');
 
-const {
-  YotiDate,
-} = require('../../..');
+const { YotiDate } = require('../../..');
 
 const SOME_REMEMEBER_ME_ID = 'someRememberMeId';
 const SOME_VALUE = 'someStringValue';
 const SOME_ANCHOR = new SandboxAnchorBuilder()
   .withType('someAnchorType')
+  .withSubType('someSubType')
+  .withValue('someValue')
+  .withTimestamp(YotiDate.fromDateString('2020-01-02'))
   .build();
 const SOME_DATE_OF_BIRTH_STRING = '1989-01-02';
 const SOME_DATE_OF_BIRTH = YotiDate.fromDateString(SOME_DATE_OF_BIRTH_STRING);


### PR DESCRIPTION
### Changed
- Sandbox anchors now use `YotiDate`

### Added
- `YotiDate.getMicrosecondUnixTimestamp()` to get the microsecond Unix timestamp from a Yoti date
