### PR TITLE
SDK-1549: Add type to responses

### DIFF
--- a/src/doc_scan_service/session/retrieve/check.response.js
+++ b/src/doc_scan_service/session/retrieve/check.response.js
@@ -7,6 +7,9 @@ const { YotiDate } = require('../../../data_type/date');
 
 class CheckResponse {
   constructor(check) {
+    Validation.isString(check.type, 'type', true);
+    this.type = check.type;
+
     Validation.isString(check.id, 'id', true);
     this.id = check.id;
 
@@ -40,6 +43,13 @@ class CheckResponse {
       Validation.isString(check.last_updated, 'last_updated');
       this.lastUpdated = YotiDate.fromDateString(check.last_updated);
     }
+  }
+
+  /**
+   * @returns {string}
+   */
+  getType() {
+    return this.type;
   }
 
   /**

--- a/src/doc_scan_service/session/retrieve/generated.check.response.js
+++ b/src/doc_scan_service/session/retrieve/generated.check.response.js
@@ -6,6 +6,9 @@ class GeneratedCheckResponse {
   constructor(check) {
     Validation.isString(check.id, 'id', true);
     this.id = check.id;
+
+    Validation.isString(check.type, 'type', true);
+    this.type = check.type;
   }
 
   /**
@@ -13,6 +16,13 @@ class GeneratedCheckResponse {
    */
   getId() {
     return this.id;
+  }
+
+  /**
+   * @returns {string}
+   */
+  getType() {
+    return this.type;
   }
 }
 

--- a/src/doc_scan_service/session/retrieve/liveness.resource.response.js
+++ b/src/doc_scan_service/session/retrieve/liveness.resource.response.js
@@ -1,8 +1,22 @@
 'use strict';
 
 const ResourceResponse = require('./resource.response');
+const Validation = require('../../../yoti_common/validation');
 
 class LivenessResourceResponse extends ResourceResponse {
+  constructor(resource) {
+    super(resource);
+
+    Validation.isString(resource.liveness_type, 'liveness_type', true);
+    this.livenessType = resource.liveness_type;
+  }
+
+  /**
+   * @returns {string}
+   */
+  getLivenessType() {
+    return this.livenessType;
+  }
 }
 
 module.exports = LivenessResourceResponse;

--- a/src/doc_scan_service/session/retrieve/task.response.js
+++ b/src/doc_scan_service/session/retrieve/task.response.js
@@ -9,6 +9,9 @@ const { YotiDate } = require('../../../data_type/date');
 
 class TaskResponse {
   constructor(task) {
+    Validation.isString(task.type, 'type', true);
+    this.type = task.type;
+
     Validation.isString(task.id, 'id', true);
     this.id = task.id;
 
@@ -46,6 +49,13 @@ class TaskResponse {
     } else {
       this.generatedMedia = [];
     }
+  }
+
+  /**
+   * @returns {string}
+   */
+  getType() {
+    return this.type;
   }
 
   /**

--- a/tests/doc_scan_service/session/retrieve/authenticity.check.response.spec.js
+++ b/tests/doc_scan_service/session/retrieve/authenticity.check.response.spec.js
@@ -9,6 +9,7 @@ describe('AuthenticityCheckResponse', () => {
 
   beforeEach(() => {
     checkResponse = new AuthenticityCheckResponse({
+      type: 'some-type',
       id: 'some-id',
       state: 'some-state',
       created: '2006-01-02T22:04:05.123Z',
@@ -27,6 +28,12 @@ describe('AuthenticityCheckResponse', () => {
 
   it('should be instance of CheckResponse', () => {
     expect(checkResponse).toBeInstanceOf(CheckResponse);
+  });
+
+  describe('#getType', () => {
+    it('should return Type', () => {
+      expect(checkResponse.getType()).toBe('some-type');
+    });
   });
 
   describe('#getId', () => {

--- a/tests/doc_scan_service/session/retrieve/check.response.spec.js
+++ b/tests/doc_scan_service/session/retrieve/check.response.spec.js
@@ -8,6 +8,7 @@ describe('CheckResponse', () => {
 
   beforeEach(() => {
     checkResponse = new CheckResponse({
+      type: 'some-type',
       id: 'some-id',
       state: 'some-state',
       created: '2006-01-02T22:04:05.123Z',
@@ -21,6 +22,12 @@ describe('CheckResponse', () => {
         {},
       ],
       report: {},
+    });
+  });
+
+  describe('#getType', () => {
+    it('should return type', () => {
+      expect(checkResponse.getType()).toBe('some-type');
     });
   });
 

--- a/tests/doc_scan_service/session/retrieve/face.match.check.response.spec.js
+++ b/tests/doc_scan_service/session/retrieve/face.match.check.response.spec.js
@@ -9,6 +9,7 @@ describe('FaceMatchCheckResponse', () => {
 
   beforeEach(() => {
     checkResponse = new FaceMatchCheckResponse({
+      type: 'some-type',
       id: 'some-id',
       state: 'some-state',
       created: '2006-01-02T22:04:05.123Z',
@@ -27,6 +28,12 @@ describe('FaceMatchCheckResponse', () => {
 
   it('should be instance of CheckResponse', () => {
     expect(checkResponse).toBeInstanceOf(CheckResponse);
+  });
+
+  describe('#getType', () => {
+    it('should return Type', () => {
+      expect(checkResponse.getType()).toBe('some-type');
+    });
   });
 
   describe('#getId', () => {

--- a/tests/doc_scan_service/session/retrieve/generated.check.response.spec.js
+++ b/tests/doc_scan_service/session/retrieve/generated.check.response.spec.js
@@ -7,12 +7,19 @@ describe('GeneratedCheckResponse', () => {
   beforeEach(() => {
     generatedCheckResponse = new GeneratedCheckResponse({
       id: 'some-id',
+      type: 'some-type',
     });
   });
 
   describe('#getId', () => {
     it('should return ID', () => {
       expect(generatedCheckResponse.getId()).toBe('some-id');
+    });
+  });
+
+  describe('#getType', () => {
+    it('should return type', () => {
+      expect(generatedCheckResponse.getType()).toBe('some-type');
     });
   });
 });

--- a/tests/doc_scan_service/session/retrieve/generated.text.data.check.response.spec.js
+++ b/tests/doc_scan_service/session/retrieve/generated.text.data.check.response.spec.js
@@ -7,12 +7,19 @@ describe('GeneratedTextDataCheckResponse', () => {
   beforeEach(() => {
     generatedCheckResponse = new GeneratedTextDataCheckResponse({
       id: 'some-id',
+      type: 'some-type',
     });
   });
 
   describe('#getId', () => {
     it('should return ID', () => {
       expect(generatedCheckResponse.getId()).toBe('some-id');
+    });
+  });
+
+  describe('#getType', () => {
+    it('should return type', () => {
+      expect(generatedCheckResponse.getType()).toBe('some-type');
     });
   });
 });

--- a/tests/doc_scan_service/session/retrieve/get.session.result.spec.js
+++ b/tests/doc_scan_service/session/retrieve/get.session.result.spec.js
@@ -6,6 +6,11 @@ const TextDataCheckResponse = require('../../../../src/doc_scan_service/session/
 const ZoomLivenessCheckResponse = require('../../../../src/doc_scan_service/session/retrieve/liveness.check.response');
 const ResourceContainer = require('../../../../src/doc_scan_service/session/retrieve/resource.container');
 
+const ID_DOCUMENT_AUTHENTICITY = 'ID_DOCUMENT_AUTHENTICITY';
+const ID_DOCUMENT_FACE_MATCH = 'ID_DOCUMENT_FACE_MATCH';
+const ID_DOCUMENT_TEXT_DATA_CHECK = 'ID_DOCUMENT_TEXT_DATA_CHECK';
+const LIVENESS = 'LIVENESS';
+
 describe('GetSessionResult', () => {
   let session;
 
@@ -22,16 +27,16 @@ describe('GetSessionResult', () => {
       },
       checks: [
         {
-          type: 'ID_DOCUMENT_AUTHENTICITY',
+          type: ID_DOCUMENT_AUTHENTICITY,
         },
         {
-          type: 'LIVENESS',
+          type: LIVENESS,
         },
         {
-          type: 'ID_DOCUMENT_FACE_MATCH',
+          type: ID_DOCUMENT_FACE_MATCH,
         },
         {
-          type: 'ID_DOCUMENT_TEXT_DATA_CHECK',
+          type: ID_DOCUMENT_TEXT_DATA_CHECK,
         },
       ],
     });
@@ -94,6 +99,7 @@ describe('GetSessionResult', () => {
       const checks = session.getAuthenticityChecks();
       expect(checks.length).toBe(1);
       expect(checks[0]).toBeInstanceOf(AuthenticityCheckResponse);
+      expect(checks[0].getType()).toBe(ID_DOCUMENT_AUTHENTICITY);
     });
   });
 
@@ -102,6 +108,7 @@ describe('GetSessionResult', () => {
       const checks = session.getLivenessChecks();
       expect(checks.length).toBe(1);
       expect(checks[0]).toBeInstanceOf(ZoomLivenessCheckResponse);
+      expect(checks[0].getType()).toBe(LIVENESS);
     });
   });
 
@@ -110,6 +117,7 @@ describe('GetSessionResult', () => {
       const checks = session.getTextDataChecks();
       expect(checks.length).toBe(1);
       expect(checks[0]).toBeInstanceOf(TextDataCheckResponse);
+      expect(checks[0].getType()).toBe(ID_DOCUMENT_TEXT_DATA_CHECK);
     });
   });
 
@@ -118,6 +126,7 @@ describe('GetSessionResult', () => {
       const checks = session.getFaceMatchChecks();
       expect(checks.length).toBe(1);
       expect(checks[0]).toBeInstanceOf(FaceMatchCheckResponse);
+      expect(checks[0].getType()).toBe(ID_DOCUMENT_FACE_MATCH);
     });
   });
 

--- a/tests/doc_scan_service/session/retrieve/get.session.result.spec.js
+++ b/tests/doc_scan_service/session/retrieve/get.session.result.spec.js
@@ -10,6 +10,7 @@ const ID_DOCUMENT_AUTHENTICITY = 'ID_DOCUMENT_AUTHENTICITY';
 const ID_DOCUMENT_FACE_MATCH = 'ID_DOCUMENT_FACE_MATCH';
 const ID_DOCUMENT_TEXT_DATA_CHECK = 'ID_DOCUMENT_TEXT_DATA_CHECK';
 const LIVENESS = 'LIVENESS';
+const SOME_UNKNOWN_CHECK = 'SOME_UNKNOWN_CHECK';
 
 describe('GetSessionResult', () => {
   let session;
@@ -142,7 +143,7 @@ describe('GetSessionResult', () => {
       session = new GetSessionResult({
         checks: [
           {
-            type: 'SOME_UNKNOWN_CHECK',
+            type: SOME_UNKNOWN_CHECK,
           },
         ],
       });
@@ -150,6 +151,7 @@ describe('GetSessionResult', () => {
       const checks = session.getChecks();
       expect(checks.length).toBe(1);
       expect(checks[0]).toBeInstanceOf(CheckResponse);
+      expect(checks[0].getType()).toBe(SOME_UNKNOWN_CHECK);
     });
   });
 });

--- a/tests/doc_scan_service/session/retrieve/id.document.resource.response.spec.js
+++ b/tests/doc_scan_service/session/retrieve/id.document.resource.response.spec.js
@@ -2,6 +2,7 @@
 const IdDocumentResourceResponse = require('../../../../src/doc_scan_service/session/retrieve/id.document.resource.response');
 const PageResponse = require('../../../../src/doc_scan_service/session/retrieve/page.response');
 const DocumentFieldsResponse = require('../../../../src/doc_scan_service/session/retrieve/document.fields.response');
+const TaskResponse = require('../../../../src/doc_scan_service/session/retrieve/task.response');
 const TextExtractionTaskResponse = require('../../../../src/doc_scan_service/session/retrieve/text.extraction.task.response');
 
 describe('IdDocumentResourceResponse', () => {
@@ -50,6 +51,15 @@ describe('IdDocumentResourceResponse', () => {
     it('should return document fields', () => {
       const fields = documentResourceResponse.getDocumentFields();
       expect(fields).toBeInstanceOf(DocumentFieldsResponse);
+    });
+  });
+
+  describe('#getTasks', () => {
+    it('should return a list of TaskResponse', () => {
+      const tasks = documentResourceResponse.getTasks();
+      tasks.forEach((task) => {
+        expect(task).toBeInstanceOf(TaskResponse);
+      });
     });
   });
 

--- a/tests/doc_scan_service/session/retrieve/liveness.check.response.spec.js
+++ b/tests/doc_scan_service/session/retrieve/liveness.check.response.spec.js
@@ -9,6 +9,7 @@ describe('LivenessCheckResponse', () => {
 
   beforeEach(() => {
     checkResponse = new LivenessCheckResponse({
+      type: 'some-type',
       id: 'some-id',
       state: 'some-state',
       created: '2006-01-02T22:04:05.123Z',
@@ -27,6 +28,12 @@ describe('LivenessCheckResponse', () => {
 
   it('should be instance of CheckResponse', () => {
     expect(checkResponse).toBeInstanceOf(CheckResponse);
+  });
+
+  describe('#getType', () => {
+    it('should return Type', () => {
+      expect(checkResponse.getType()).toBe('some-type');
+    });
   });
 
   describe('#getId', () => {

--- a/tests/doc_scan_service/session/retrieve/liveness.resource.response.spec.js
+++ b/tests/doc_scan_service/session/retrieve/liveness.resource.response.spec.js
@@ -8,6 +8,7 @@ describe('LivenessResourceResponse', () => {
 
   beforeEach(() => {
     resourceResponse = new LivenessResourceResponse({
+      liveness_type: 'some-liveness-type',
       id: 'some-id',
       tasks: [
         {
@@ -23,6 +24,12 @@ describe('LivenessResourceResponse', () => {
   describe('#getId', () => {
     it('should return ID', () => {
       expect(resourceResponse.getId()).toBe('some-id');
+    });
+  });
+
+  describe('#getType', () => {
+    it('should return type', () => {
+      expect(resourceResponse.getLivenessType()).toBe('some-liveness-type');
     });
   });
 

--- a/tests/doc_scan_service/session/retrieve/resource.container.spec.js
+++ b/tests/doc_scan_service/session/retrieve/resource.container.spec.js
@@ -3,6 +3,9 @@ const IdDocumentResourceResponse = require('../../../../src/doc_scan_service/ses
 const ZoomLivenessResourceResponse = require('../../../../src/doc_scan_service/session/retrieve/zoom.liveness.resource.response');
 const LivenessResourceResponse = require('../../../../src/doc_scan_service/session/retrieve/liveness.resource.response');
 
+const ZOOM = 'ZOOM';
+const SOME_UNKNOWN_LIVENESS_TYPE = 'SOME_UNKNOWN_LIVENESS_TYPE';
+
 describe('ResourceContainer', () => {
   let resourceContainer;
 
@@ -14,9 +17,11 @@ describe('ResourceContainer', () => {
       ],
       liveness_capture: [
         {
-          liveness_type: 'ZOOM',
+          liveness_type: ZOOM,
         },
-        {},
+        {
+          liveness_type: SOME_UNKNOWN_LIVENESS_TYPE,
+        },
       ],
     });
   });
@@ -54,6 +59,13 @@ describe('ResourceContainer', () => {
       it('should return zoom liveness resource response', () => {
         const livenessCapture = resourceContainer.getLivenessCapture();
         expect(livenessCapture[0]).toBeInstanceOf(ZoomLivenessResourceResponse);
+        expect(livenessCapture[0].getLivenessType()).toBe(ZOOM);
+      });
+
+      it('should return unknown liveness resource response', () => {
+        const livenessCapture = resourceContainer.getLivenessCapture();
+        expect(livenessCapture[1]).toBeInstanceOf(LivenessResourceResponse);
+        expect(livenessCapture[1].getLivenessType()).toBe(SOME_UNKNOWN_LIVENESS_TYPE);
       });
     });
     describe('when liveness capture is not available', () => {
@@ -71,6 +83,7 @@ describe('ResourceContainer', () => {
       const livenessCapture = resourceContainer.getZoomLivenessResources();
       livenessCapture.forEach((item) => {
         expect(item).toBeInstanceOf(ZoomLivenessResourceResponse);
+        expect(item.getLivenessType()).toBe(ZOOM);
       });
     });
   });

--- a/tests/doc_scan_service/session/retrieve/resource.response.spec.js
+++ b/tests/doc_scan_service/session/retrieve/resource.response.spec.js
@@ -3,6 +3,9 @@ const ResourceResponse = require('../../../../src/doc_scan_service/session/retri
 const TaskResponse = require('../../../../src/doc_scan_service/session/retrieve/task.response');
 const TextExtractionTaskResponse = require('../../../../src/doc_scan_service/session/retrieve/text.extraction.task.response');
 
+const ID_DOCUMENT_TEXT_DATA_EXTRACTION = 'ID_DOCUMENT_TEXT_DATA_EXTRACTION';
+const SOME_UNKNOWN_TASK = 'SOME_UNKNOWN_TASK';
+
 describe('ResourceResponse', () => {
   let resourceResponse;
 
@@ -11,10 +14,10 @@ describe('ResourceResponse', () => {
       id: 'some-id',
       tasks: [
         {
-          type: 'ID_DOCUMENT_TEXT_DATA_EXTRACTION',
+          type: ID_DOCUMENT_TEXT_DATA_EXTRACTION,
         },
         {
-          type: 'SOME_UNKNOWN_TYPE',
+          type: SOME_UNKNOWN_TASK,
         },
       ],
     });
@@ -38,6 +41,9 @@ describe('ResourceResponse', () => {
         });
 
         expect(tasks[0]).toBeInstanceOf(TextExtractionTaskResponse);
+        expect(tasks[0].getType()).toBe(ID_DOCUMENT_TEXT_DATA_EXTRACTION);
+
+        expect(tasks[1].getType()).toBe(SOME_UNKNOWN_TASK);
       });
     });
     describe('when tasks are not available', () => {

--- a/tests/doc_scan_service/session/retrieve/task.response.spec.js
+++ b/tests/doc_scan_service/session/retrieve/task.response.spec.js
@@ -9,6 +9,7 @@ describe('TaskResponse', () => {
 
   beforeEach(() => {
     taskResponse = new TaskResponse({
+      type: 'some-type',
       id: 'some-id',
       state: 'some-state',
       created: '2006-01-02T22:04:05.123Z',
@@ -29,9 +30,9 @@ describe('TaskResponse', () => {
     });
   });
 
-  describe('#getId', () => {
-    it('should be instance of TaskResponse', () => {
-      expect(taskResponse).toBeInstanceOf(TaskResponse);
+  describe('#getType', () => {
+    it('should return Type', () => {
+      expect(taskResponse.getType()).toBe('some-type');
     });
   });
 

--- a/tests/doc_scan_service/session/retrieve/task.response.spec.js
+++ b/tests/doc_scan_service/session/retrieve/task.response.spec.js
@@ -4,6 +4,9 @@ const GeneratedCheckResponse = require('../../../../src/doc_scan_service/session
 const GeneratedTextDataCheckResponse = require('../../../../src/doc_scan_service/session/retrieve/generated.text.data.check.response');
 const GeneratedMedia = require('../../../../src/doc_scan_service/session/retrieve/generated.media');
 
+const ID_DOCUMENT_TEXT_DATA_CHECK = 'ID_DOCUMENT_TEXT_DATA_CHECK';
+const SOME_UNKNOWN_TYPE = 'SOME_UNKNOWN_TYPE';
+
 describe('TaskResponse', () => {
   let taskResponse;
 
@@ -16,11 +19,11 @@ describe('TaskResponse', () => {
       last_updated: '2006-02-02T22:04:05.123Z',
       generated_checks: [
         {
-          type: 'ID_DOCUMENT_TEXT_DATA_CHECK',
+          type: ID_DOCUMENT_TEXT_DATA_CHECK,
           id: 'some-id',
         },
         {
-          type: 'SOME_UNKNOWN_TYPE',
+          type: SOME_UNKNOWN_TYPE,
         },
       ],
       generated_media: [
@@ -69,11 +72,11 @@ describe('TaskResponse', () => {
 
         expect(checks.length).toBe(2);
 
-        checks.forEach((check) => {
-          expect(check).toBeInstanceOf(GeneratedCheckResponse);
-        });
-
         expect(checks[0]).toBeInstanceOf(GeneratedTextDataCheckResponse);
+        expect(checks[0].getType()).toBe(ID_DOCUMENT_TEXT_DATA_CHECK);
+
+        expect(checks[1]).toBeInstanceOf(GeneratedCheckResponse);
+        expect(checks[1].getType()).toBe(SOME_UNKNOWN_TYPE);
       });
     });
     describe('when checks are not available', () => {

--- a/tests/doc_scan_service/session/retrieve/text.extraction.task.response.spec.js
+++ b/tests/doc_scan_service/session/retrieve/text.extraction.task.response.spec.js
@@ -9,6 +9,7 @@ describe('TextExtractionTaskResponse', () => {
 
   beforeEach(() => {
     taskResponse = new TextExtractionTaskResponse({
+      type: 'some-type',
       id: 'some-id',
       state: 'some-state',
       created: '2006-01-02T22:04:05.123Z',
@@ -26,15 +27,19 @@ describe('TextExtractionTaskResponse', () => {
     });
   });
 
-  describe('#getId', () => {
-    it('should be instance of TaskResponse', () => {
-      expect(taskResponse).toBeInstanceOf(TaskResponse);
-    });
+  it('should be instance of TaskResponse', () => {
+    expect(taskResponse).toBeInstanceOf(TaskResponse);
   });
 
   describe('#getId', () => {
     it('should return ID', () => {
       expect(taskResponse.getId()).toBe('some-id');
+    });
+  });
+
+  describe('#getType', () => {
+    it('should return type', () => {
+      expect(taskResponse.getType()).toBe('some-type');
     });
   });
 

--- a/tests/doc_scan_service/session/retrieve/zoom.liveness.resource.response.spec.js
+++ b/tests/doc_scan_service/session/retrieve/zoom.liveness.resource.response.spec.js
@@ -8,11 +8,25 @@ describe('ZoomLivenessResourceResponse', () => {
 
   beforeEach(() => {
     zoomLivenessResourceResponse = new ZoomLivenessResourceResponse({
+      liveness_type: 'some-liveness-type',
+      id: 'some-id',
       facemap: {},
       frames: [
         {},
         {},
       ],
+    });
+  });
+
+  describe('#getId', () => {
+    it('should return ID', () => {
+      expect(zoomLivenessResourceResponse.getId()).toBe('some-id');
+    });
+  });
+
+  describe('#getType', () => {
+    it('should return type', () => {
+      expect(zoomLivenessResourceResponse.getLivenessType()).toBe('some-liveness-type');
     });
   });
 


### PR DESCRIPTION
### Added
- `CheckResponse.getType()`
- `TaskResponse.getType()`
- `LivenessResourceResponse.getLivenessType()`
- `GeneratedCheckResponse.getType()`