### PR TITLE
SDK-1579: DocScanError message

### DIFF
--- a/src/doc_scan_service/doc.scan.error.js
+++ b/src/doc_scan_service/doc.scan.error.js
@@ -17,13 +17,12 @@ function errorMessage(error) {
         .response
         .body
         .errors
-        .map((e) => {
-          if (e.property && e.message) {
-            return `${e.property} "${e.message}"`;
+        .reduce((acc, current) => {
+          if (current.property && current.message) {
+            acc.push(`${current.property} "${current.message}"`);
           }
-          return null;
-        })
-        .filter(e => e !== null);
+          return acc;
+        }, []);
 
       if (propertyErrors.length > 0) {
         return `${message}: ${propertyErrors.join(', ')}`;

--- a/src/doc_scan_service/doc.scan.error.js
+++ b/src/doc_scan_service/doc.scan.error.js
@@ -1,13 +1,24 @@
 'use strict';
 
 /**
+ * @param {Error} error
+ */
+function errorMessage(error) {
+  if (!error.response || !error.response.text) {
+    return error.message;
+  }
+  return `${error.message}: ${error.response.text}`;
+}
+
+/**
  * Signals that a problem occurred in a Yoti Doc Scan call
  *
  * @class DocScanError
  */
 class DocScanError extends Error {
   constructor(error) {
-    super(error.message);
+    super(errorMessage(error));
+
     this.name = this.constructor.name;
     this.response = error.response || null;
   }

--- a/src/doc_scan_service/doc.scan.error.js
+++ b/src/doc_scan_service/doc.scan.error.js
@@ -13,7 +13,21 @@ function errorMessage(error) {
     const message = `${error.response.body.code} - ${error.response.body.message}`;
 
     if (error.response.body.errors) {
-      return `${message}: ${JSON.stringify(error.response.body.errors)}`;
+      const propertyErrors = error
+        .response
+        .body
+        .errors
+        .map((e) => {
+          if (e.property && e.message) {
+            return `${e.property} "${e.message}"`;
+          }
+          return null;
+        })
+        .filter(e => e !== null);
+
+      if (propertyErrors.length > 0) {
+        return `${message}: ${propertyErrors.join(', ')}`;
+      }
     }
 
     return message;

--- a/src/doc_scan_service/doc.scan.error.js
+++ b/src/doc_scan_service/doc.scan.error.js
@@ -4,10 +4,22 @@
  * @param {Error} error
  */
 function errorMessage(error) {
-  if (!error.response || !error.response.text) {
-    return error.message;
+  if (
+    error.response
+    && error.response.body
+    && error.response.body.code
+    && error.response.body.message
+  ) {
+    const message = `${error.response.body.code} - ${error.response.body.message}`;
+
+    if (error.response.body.errors) {
+      return `${message}: ${JSON.stringify(error.response.body.errors)}`;
+    }
+
+    return message;
   }
-  return `${error.message}: ${error.response.text}`;
+
+  return error.message;
 }
 
 /**

--- a/tests/doc_scan_service/doc.scan.error.spec.js
+++ b/tests/doc_scan_service/doc.scan.error.spec.js
@@ -9,7 +9,7 @@ const SOME_RESPONSE = {
 };
 
 const SOME_PROPERTY = 'some.property';
-const SOME_PROPERTY_MESSAGE = 'some.property';
+const SOME_PROPERTY_MESSAGE = 'some property message';
 const SOME_OTHER_PROPERTY = 'some.other.property';
 const SOME_OTHER_PROPERTY_MESSAGE = 'some other property message';
 

--- a/tests/doc_scan_service/doc.scan.error.spec.js
+++ b/tests/doc_scan_service/doc.scan.error.spec.js
@@ -1,5 +1,8 @@
 const DocScanError = require('../../src/doc_scan_service/doc.scan.error');
 
+const SOME_RESPONSE_BODY = { some: 'body' };
+const SOME_RESPONSE_TEXT = JSON.stringify(SOME_RESPONSE_BODY);
+
 describe('DocScanError', () => {
   let docScanError;
 
@@ -9,7 +12,8 @@ describe('DocScanError', () => {
 
       someError.response = {
         statusCode: 400,
-        body: 'some-body',
+        body: SOME_RESPONSE_BODY,
+        text: SOME_RESPONSE_TEXT,
       };
 
       docScanError = new DocScanError(someError);
@@ -21,7 +25,7 @@ describe('DocScanError', () => {
 
     describe('#message', () => {
       it('should return the error message', () => {
-        expect(docScanError.message).toBe('some error message');
+        expect(docScanError.message).toBe(`some error message: ${SOME_RESPONSE_TEXT}`);
       });
     });
 
@@ -39,7 +43,7 @@ describe('DocScanError', () => {
 
     describe('#getResponseBody', () => {
       it('should return the response body', () => {
-        expect(docScanError.getResponseBody()).toBe('some-body');
+        expect(docScanError.getResponseBody()).toBe(SOME_RESPONSE_BODY);
       });
     });
   });

--- a/tests/doc_scan_service/doc.scan.error.spec.js
+++ b/tests/doc_scan_service/doc.scan.error.spec.js
@@ -1,7 +1,21 @@
 const DocScanError = require('../../src/doc_scan_service/doc.scan.error');
 
-const SOME_RESPONSE_BODY = { some: 'body' };
-const SOME_RESPONSE_TEXT = JSON.stringify(SOME_RESPONSE_BODY);
+const SOME_CODE = 'SOME_CODE';
+const SOME_MESSAGE = 'SOME_MESSAGE';
+
+const SOME_RESPONSE = {
+  code: SOME_CODE,
+  message: SOME_MESSAGE,
+};
+
+const SOME_RESPONSE_WITH_ERRORS = {
+  code: SOME_CODE,
+  message: SOME_MESSAGE,
+  errors: [
+    'some error',
+    'some other error',
+  ],
+};
 
 describe('DocScanError', () => {
   let docScanError;
@@ -12,8 +26,8 @@ describe('DocScanError', () => {
 
       someError.response = {
         statusCode: 400,
-        body: SOME_RESPONSE_BODY,
-        text: SOME_RESPONSE_TEXT,
+        body: SOME_RESPONSE,
+        text: JSON.stringify(SOME_RESPONSE),
       };
 
       docScanError = new DocScanError(someError);
@@ -25,7 +39,7 @@ describe('DocScanError', () => {
 
     describe('#message', () => {
       it('should return the error message', () => {
-        expect(docScanError.message).toBe(`some error message: ${SOME_RESPONSE_TEXT}`);
+        expect(docScanError.message).toBe(`${SOME_CODE} - ${SOME_MESSAGE}`);
       });
     });
 
@@ -43,7 +57,49 @@ describe('DocScanError', () => {
 
     describe('#getResponseBody', () => {
       it('should return the response body', () => {
-        expect(docScanError.getResponseBody()).toBe(SOME_RESPONSE_BODY);
+        expect(docScanError.getResponseBody()).toBe(SOME_RESPONSE);
+      });
+    });
+  });
+  describe('when error has response with errors', () => {
+    beforeEach(() => {
+      const someError = new Error('some error message');
+
+      someError.response = {
+        statusCode: 400,
+        body: SOME_RESPONSE_WITH_ERRORS,
+        text: JSON.stringify(SOME_RESPONSE_WITH_ERRORS),
+      };
+
+      docScanError = new DocScanError(someError);
+    });
+
+    it('should be instance of Error', () => {
+      expect(docScanError).toBeInstanceOf(Error);
+    });
+
+    describe('#message', () => {
+      it('should return the error message', () => {
+        expect(docScanError.message)
+          .toBe(`${SOME_CODE} - ${SOME_MESSAGE}: ${JSON.stringify(SOME_RESPONSE_WITH_ERRORS.errors)}`);
+      });
+    });
+
+    describe('#name', () => {
+      it('should return the error name', () => {
+        expect(docScanError.name).toBe('DocScanError');
+      });
+    });
+
+    describe('#getResponseStatusCode', () => {
+      it('should return the status code', () => {
+        expect(docScanError.getResponseStatusCode()).toBe(400);
+      });
+    });
+
+    describe('#getResponseBody', () => {
+      it('should return the response body', () => {
+        expect(docScanError.getResponseBody()).toBe(SOME_RESPONSE_WITH_ERRORS);
       });
     });
   });

--- a/tests/doc_scan_service/doc.scan.error.spec.js
+++ b/tests/doc_scan_service/doc.scan.error.spec.js
@@ -8,12 +8,23 @@ const SOME_RESPONSE = {
   message: SOME_MESSAGE,
 };
 
+const SOME_PROPERTY = 'some.property';
+const SOME_PROPERTY_MESSAGE = 'some.property';
+const SOME_OTHER_PROPERTY = 'some.other.property';
+const SOME_OTHER_PROPERTY_MESSAGE = 'some other property message';
+
 const SOME_RESPONSE_WITH_ERRORS = {
   code: SOME_CODE,
   message: SOME_MESSAGE,
   errors: [
-    'some error',
-    'some other error',
+    {
+      property: SOME_PROPERTY,
+      message: SOME_PROPERTY_MESSAGE,
+    },
+    {
+      property: SOME_OTHER_PROPERTY,
+      message: SOME_OTHER_PROPERTY_MESSAGE,
+    },
   ],
 };
 
@@ -81,7 +92,7 @@ describe('DocScanError', () => {
     describe('#message', () => {
       it('should return the error message', () => {
         expect(docScanError.message)
-          .toBe(`${SOME_CODE} - ${SOME_MESSAGE}: ${JSON.stringify(SOME_RESPONSE_WITH_ERRORS.errors)}`);
+          .toBe(`${SOME_CODE} - ${SOME_MESSAGE}: ${SOME_PROPERTY} "${SOME_PROPERTY_MESSAGE}", ${SOME_OTHER_PROPERTY} "${SOME_OTHER_PROPERTY_MESSAGE}"`);
       });
     });
 

--- a/tests/doc_scan_service/doc.scan.error.spec.js
+++ b/tests/doc_scan_service/doc.scan.error.spec.js
@@ -28,6 +28,16 @@ const SOME_RESPONSE_WITH_ERRORS = {
   ],
 };
 
+const SOME_RESPONSE_WITH_UNKNOWN_ERRORS = {
+  code: SOME_CODE,
+  message: SOME_MESSAGE,
+  errors: [
+    {
+      some: 'unknown error',
+    },
+  ],
+};
+
 describe('DocScanError', () => {
   let docScanError;
 
@@ -111,6 +121,26 @@ describe('DocScanError', () => {
     describe('#getResponseBody', () => {
       it('should return the response body', () => {
         expect(docScanError.getResponseBody()).toBe(SOME_RESPONSE_WITH_ERRORS);
+      });
+    });
+  });
+  describe('when error has response with unknown errors', () => {
+    beforeEach(() => {
+      const someError = new Error('some error message');
+
+      someError.response = {
+        statusCode: 400,
+        body: SOME_RESPONSE_WITH_UNKNOWN_ERRORS,
+        text: JSON.stringify(SOME_RESPONSE_WITH_UNKNOWN_ERRORS),
+      };
+
+      docScanError = new DocScanError(someError);
+    });
+
+    describe('#message', () => {
+      it('should exclude unknown errors', () => {
+        expect(docScanError.message)
+          .toBe(`${SOME_CODE} - ${SOME_MESSAGE}`);
       });
     });
   });

--- a/tests/doc_scan_service/doc.scan.service.spec.js
+++ b/tests/doc_scan_service/doc.scan.service.spec.js
@@ -23,6 +23,7 @@ const SESSION_CREATE_URI = new RegExp(`^/idverify/v1/sessions\\?sdkId=${APP_ID}`
 const SESSION_URI = new RegExp(`^/idverify/v1/sessions/${SESSION_ID}\\?sdkId=${APP_ID}`);
 const MEDIA_URI = new RegExp(`^/idverify/v1/sessions/${SESSION_ID}/media/${MEDIA_ID}/content\\?sdkId=${APP_ID}`);
 const SUPPORTED_DOCUMENTS_URI = new RegExp('^/idverify/v1/supported-documents');
+const SOME_RESPONSE = JSON.stringify({ some: 'response' });
 
 describe('DocScanService', () => {
   let docScanService;
@@ -89,6 +90,26 @@ describe('DocScanService', () => {
           .catch(done);
       });
     });
+    describe('when an invalid response code is returned with body', () => {
+      it('should log error and reject with response body', (done) => {
+        nock(config.yoti.docScanApi)
+          .post(
+            SESSION_CREATE_URI,
+            JSON.stringify(sessionSpec)
+          )
+          .reply(400, SOME_RESPONSE);
+
+        docScanService
+          .createSession(sessionSpec)
+          .catch((err) => {
+            expect(err.message).toBe(`Bad Request: ${SOME_RESPONSE}`);
+            expect(consoleLog)
+              .toHaveBeenCalledWith('Error getting data from Connect API: Bad Request');
+            done();
+          })
+          .catch(done);
+      });
+    });
     describe('when an invalid response body is returned', () => {
       it('should reject', (done) => {
         nock(config.yoti.docScanApi)
@@ -145,16 +166,31 @@ describe('DocScanService', () => {
           .catch(done);
       });
     });
-    describe('when response is invalid', () => {
+    describe('when response code is invalid', () => {
       it('should reject', (done) => {
         nock(config.yoti.docScanApi)
           .get(SESSION_URI)
-          .reply(400, '');
+          .reply(400);
 
         docScanService
           .getSession(SESSION_ID)
           .catch((err) => {
             expect(err.message).toBe('Bad Request');
+            done();
+          })
+          .catch(done);
+      });
+    });
+    describe('when response code is invalid with body', () => {
+      it('should reject with response body and message', (done) => {
+        nock(config.yoti.docScanApi)
+          .get(SESSION_URI)
+          .reply(400, SOME_RESPONSE);
+
+        docScanService
+          .getSession(SESSION_ID)
+          .catch((err) => {
+            expect(err.message).toBe(`Bad Request: ${SOME_RESPONSE}`);
             done();
           })
           .catch(done);
@@ -178,16 +214,31 @@ describe('DocScanService', () => {
           .catch(done);
       });
     });
-    describe('when response is invalid', () => {
+    describe('when response code is invalid', () => {
       it('should reject', (done) => {
         nock(config.yoti.docScanApi)
           .delete(SESSION_URI)
-          .reply(400, '');
+          .reply(400);
 
         docScanService
           .deleteSession(SESSION_ID)
           .catch((err) => {
             expect(err.message).toBe('Bad Request');
+            done();
+          })
+          .catch(done);
+      });
+    });
+    describe('when response code is invalid with body', () => {
+      it('should reject with response message and body', (done) => {
+        nock(config.yoti.docScanApi)
+          .delete(SESSION_URI)
+          .reply(400, SOME_RESPONSE);
+
+        docScanService
+          .deleteSession(SESSION_ID)
+          .catch((err) => {
+            expect(err.message).toBe(`Bad Request: ${SOME_RESPONSE}`);
             done();
           })
           .catch(done);
@@ -258,12 +309,27 @@ describe('DocScanService', () => {
       it('should reject', (done) => {
         nock(config.yoti.docScanApi)
           .get(MEDIA_URI)
-          .reply(400, '');
+          .reply(400);
 
         docScanService
           .getMediaContent(SESSION_ID, MEDIA_ID)
           .catch((err) => {
             expect(err.message).toBe('Bad Request');
+            done();
+          })
+          .catch(done);
+      });
+    });
+    describe('when response code is invalid with response body', () => {
+      it('should reject with response message and body', (done) => {
+        nock(config.yoti.docScanApi)
+          .get(MEDIA_URI)
+          .reply(400, SOME_RESPONSE);
+
+        docScanService
+          .getMediaContent(SESSION_ID, MEDIA_ID)
+          .catch((err) => {
+            expect(err.message).toBe(`Bad Request: ${SOME_RESPONSE}`);
             done();
           })
           .catch(done);
@@ -287,16 +353,31 @@ describe('DocScanService', () => {
           .catch(done);
       });
     });
-    describe('when response is invalid', () => {
+    describe('when response code is invalid', () => {
       it('should reject', (done) => {
         nock(config.yoti.docScanApi)
           .delete(MEDIA_URI)
-          .reply(400, '');
+          .reply(400);
 
         docScanService
           .deleteMediaContent(SESSION_ID, MEDIA_ID)
           .catch((err) => {
             expect(err.message).toBe('Bad Request');
+            done();
+          })
+          .catch(done);
+      });
+    });
+    describe('when response code is invalid with response body', () => {
+      it('should reject with response message and body', (done) => {
+        nock(config.yoti.docScanApi)
+          .delete(MEDIA_URI)
+          .reply(400, SOME_RESPONSE);
+
+        docScanService
+          .deleteMediaContent(SESSION_ID, MEDIA_ID)
+          .catch((err) => {
+            expect(err.message).toBe(`Bad Request: ${SOME_RESPONSE}`);
             done();
           })
           .catch(done);
@@ -320,16 +401,31 @@ describe('DocScanService', () => {
           .catch(done);
       });
     });
-    describe('when response is invalid', () => {
+    describe('when response code is invalid', () => {
       it('should reject', (done) => {
         nock(config.yoti.docScanApi)
           .get(SUPPORTED_DOCUMENTS_URI)
-          .reply(400, '{}');
+          .reply(400);
 
         docScanService
           .getSupportedDocuments()
           .catch((err) => {
             expect(err.message).toBe('Bad Request');
+            done();
+          })
+          .catch(done);
+      });
+    });
+    describe('when response code is invalid with response body', () => {
+      it('should reject with response message and body', (done) => {
+        nock(config.yoti.docScanApi)
+          .get(SUPPORTED_DOCUMENTS_URI)
+          .reply(400, SOME_RESPONSE);
+
+        docScanService
+          .getSupportedDocuments()
+          .catch((err) => {
+            expect(err.message).toBe(`Bad Request: ${SOME_RESPONSE}`);
             done();
           })
           .catch(done);

--- a/tests/doc_scan_service/doc.scan.service.spec.js
+++ b/tests/doc_scan_service/doc.scan.service.spec.js
@@ -23,7 +23,11 @@ const SESSION_CREATE_URI = new RegExp(`^/idverify/v1/sessions\\?sdkId=${APP_ID}`
 const SESSION_URI = new RegExp(`^/idverify/v1/sessions/${SESSION_ID}\\?sdkId=${APP_ID}`);
 const MEDIA_URI = new RegExp(`^/idverify/v1/sessions/${SESSION_ID}/media/${MEDIA_ID}/content\\?sdkId=${APP_ID}`);
 const SUPPORTED_DOCUMENTS_URI = new RegExp('^/idverify/v1/supported-documents');
-const SOME_RESPONSE = JSON.stringify({ some: 'response' });
+const SOME_CODE = 'SOME_CODE';
+const SOME_MESSAGE = 'SOME_MESSAGE';
+const SOME_ERROR_RESPONSE = JSON.stringify({ code: SOME_CODE, message: SOME_MESSAGE });
+const SOME_ERROR_MESSAGE = `${SOME_CODE} - ${SOME_MESSAGE}`;
+const JSON_RESPONSE_HEADERS = { 'Content-Type': 'application/json' };
 
 describe('DocScanService', () => {
   let docScanService;
@@ -52,11 +56,14 @@ describe('DocScanService', () => {
             SESSION_CREATE_URI,
             JSON.stringify(sessionSpec)
           )
-          .reply(200, JSON.stringify({
-            client_session_token_ttl: 30,
-            client_session_token: 'some-token',
-            session_id: 'some-id',
-          }));
+          .reply(
+            200,
+            JSON.stringify({
+              client_session_token_ttl: 30,
+              client_session_token: 'some-token',
+              session_id: 'some-id',
+            })
+          );
 
         docScanService
           .createSession(sessionSpec)
@@ -97,12 +104,12 @@ describe('DocScanService', () => {
             SESSION_CREATE_URI,
             JSON.stringify(sessionSpec)
           )
-          .reply(400, SOME_RESPONSE);
+          .reply(400, SOME_ERROR_RESPONSE, JSON_RESPONSE_HEADERS);
 
         docScanService
           .createSession(sessionSpec)
           .catch((err) => {
-            expect(err.message).toBe(`Bad Request: ${SOME_RESPONSE}`);
+            expect(err.message).toBe(SOME_ERROR_MESSAGE);
             expect(consoleLog)
               .toHaveBeenCalledWith('Error getting data from Connect API: Bad Request');
             done();
@@ -117,9 +124,10 @@ describe('DocScanService', () => {
             SESSION_CREATE_URI,
             JSON.stringify(sessionSpec)
           )
-          .reply(200, {
-            client_session_token_ttl: { some: 'invalid ttl' },
-          });
+          .reply(
+            200,
+            { client_session_token_ttl: { some: 'invalid ttl' } }
+          );
 
         docScanService
           .createSession(sessionSpec)
@@ -137,9 +145,10 @@ describe('DocScanService', () => {
       it('should return a DocScan session', (done) => {
         nock(config.yoti.docScanApi)
           .get(SESSION_URI)
-          .reply(200, JSON.stringify({
-            session_id: 'some-session-id',
-          }));
+          .reply(
+            200,
+            JSON.stringify({ session_id: 'some-session-id' })
+          );
 
         docScanService
           .getSession(SESSION_ID)
@@ -185,12 +194,12 @@ describe('DocScanService', () => {
       it('should reject with response body and message', (done) => {
         nock(config.yoti.docScanApi)
           .get(SESSION_URI)
-          .reply(400, SOME_RESPONSE);
+          .reply(400, SOME_ERROR_RESPONSE, JSON_RESPONSE_HEADERS);
 
         docScanService
           .getSession(SESSION_ID)
           .catch((err) => {
-            expect(err.message).toBe(`Bad Request: ${SOME_RESPONSE}`);
+            expect(err.message).toBe(SOME_ERROR_MESSAGE);
             done();
           })
           .catch(done);
@@ -233,12 +242,12 @@ describe('DocScanService', () => {
       it('should reject with response message and body', (done) => {
         nock(config.yoti.docScanApi)
           .delete(SESSION_URI)
-          .reply(400, SOME_RESPONSE);
+          .reply(400, SOME_ERROR_RESPONSE, JSON_RESPONSE_HEADERS);
 
         docScanService
           .deleteSession(SESSION_ID)
           .catch((err) => {
-            expect(err.message).toBe(`Bad Request: ${SOME_RESPONSE}`);
+            expect(err.message).toBe(SOME_ERROR_MESSAGE);
             done();
           })
           .catch(done);
@@ -324,12 +333,12 @@ describe('DocScanService', () => {
       it('should reject with response message and body', (done) => {
         nock(config.yoti.docScanApi)
           .get(MEDIA_URI)
-          .reply(400, SOME_RESPONSE);
+          .reply(400, SOME_ERROR_RESPONSE, JSON_RESPONSE_HEADERS);
 
         docScanService
           .getMediaContent(SESSION_ID, MEDIA_ID)
           .catch((err) => {
-            expect(err.message).toBe(`Bad Request: ${SOME_RESPONSE}`);
+            expect(err.message).toBe(SOME_ERROR_MESSAGE);
             done();
           })
           .catch(done);
@@ -372,12 +381,12 @@ describe('DocScanService', () => {
       it('should reject with response message and body', (done) => {
         nock(config.yoti.docScanApi)
           .delete(MEDIA_URI)
-          .reply(400, SOME_RESPONSE);
+          .reply(400, SOME_ERROR_RESPONSE, JSON_RESPONSE_HEADERS);
 
         docScanService
           .deleteMediaContent(SESSION_ID, MEDIA_ID)
           .catch((err) => {
-            expect(err.message).toBe(`Bad Request: ${SOME_RESPONSE}`);
+            expect(err.message).toBe(SOME_ERROR_MESSAGE);
             done();
           })
           .catch(done);
@@ -420,12 +429,12 @@ describe('DocScanService', () => {
       it('should reject with response message and body', (done) => {
         nock(config.yoti.docScanApi)
           .get(SUPPORTED_DOCUMENTS_URI)
-          .reply(400, SOME_RESPONSE);
+          .reply(400, SOME_ERROR_RESPONSE, JSON_RESPONSE_HEADERS);
 
         docScanService
           .getSupportedDocuments()
           .catch((err) => {
-            expect(err.message).toBe(`Bad Request: ${SOME_RESPONSE}`);
+            expect(err.message).toBe(SOME_ERROR_MESSAGE);
             done();
           })
           .catch(done);


### PR DESCRIPTION
### Changed
- API error message is now included in `DocScanError` message. Falls back on the message of the error it is wrapping (e.g. "Bad Request")

This follows similar format to AML errors:
```
{CODE} - {MESSAGE}
```
```
{CODE} - {MESSAGE}: {PROPERTY} "{PROPERTY_MESSAGE}", {OTHER_PROPERTY} "{OTHER_PROPERTY_MESSAGE}"
```
