### PR TITLE
NA: Update dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,11 +3,12 @@ updates:
 - package-ecosystem: npm
   directory: "/"
   schedule:
-    interval: daily
+    interval: monthly
   open-pull-requests-limit: 3
   target-branch: development
   reviewers:
-  - echarrod
-  - davidgrayston
+  - laurent-yoti
+  - vishmimoney
+  - taranchauhan
   assignees:
-  - davidgrayston
+  - laurent-yoti


### PR DESCRIPTION
- Went into `master` before `development` as we want this to stop dependabot running daily now, and don't want to have to wait for the privacy policy release (currently in development)