### PR TITLE
HUB-3813 Add TPI check to the Doc scan example when creating and retrieving the session

### DIFF
--- a/examples/doc-scan/src/controllers/index.controller.js
+++ b/examples/doc-scan/src/controllers/index.controller.js
@@ -11,6 +11,7 @@ const {
   RequiredIdDocumentBuilder,
   OrthogonalRestrictionsFilterBuilder,
   RequestedIdDocumentComparisonCheckBuilder,
+  RequestedThirdPartyIdentityCheckBuilder,
   RequiredSupplementaryDocumentBuilder,
   ProofOfAddressObjectiveBuilder,
   RequestedSupplementaryDocTextExtractionTaskBuilder,
@@ -46,6 +47,10 @@ async function createSession() {
     )
     .withRequestedCheck(
       new RequestedIdDocumentComparisonCheckBuilder()
+        .build()
+    )
+    .withRequestedCheck(
+      new RequestedThirdPartyIdentityCheckBuilder()
         .build()
     )
     .withRequestedTask(

--- a/examples/doc-scan/views/pages/success.ejs
+++ b/examples/doc-scan/views/pages/success.ejs
@@ -169,6 +169,28 @@
                 </div>
                 <% } %>
 
+                <% if (sessionResult.getThirdPartyIdentityChecks().length > 0) { %>
+                <div class="card">
+                    <div class="card-header" id="third-party-identity-checks">
+                        <h3 class="mb-0">
+                            <button class="btn btn-link" type="button" data-toggle="collapse"
+                                data-target="#collapse-third-party-identity-checks" aria-expanded="true"
+                                aria-controls="collapse-third-party-identity-checks">
+                                Third Party Identity Checks
+                            </button>
+                        </h3>
+                    </div>
+
+                    <div id="collapse-third-party-identity-checks" class="collapse" aria-labelledby="collapse-third-party-identity-checks">
+                        <div class="card-body">
+                            <% sessionResult.getThirdPartyIdentityChecks().forEach(function(check){ %>
+                            <%- include('partials/check', { check }); %>
+                            <% }); %>
+                        </div>
+                    </div>
+                </div>
+                <% } %>
+
                 <% if (sessionResult.getSupplementaryDocumentTextDataChecks().length > 0) { %>
                 <div class="card">
                     <div class="card-header" id="sup-text-data-checks">


### PR DESCRIPTION
### Description

> Add TPI check to the example when creating the session and retrieving the session report on the success page

### Testing

- [x] Created a session using the new Third party identity check builder inside of the `examples/doc-scan` folder.
<img width="1629" alt="Screenshot 2021-01-06 at 13 37 45" src="https://user-images.githubusercontent.com/3968227/103774414-69dbf680-5024-11eb-84f2-10c1edf5611b.png">

- [x]  Verified that that the TPI check is included in the list of checks
<img width="376" alt="Screenshot 2021-01-08 at 14 38 10" src="https://user-images.githubusercontent.com/3968227/104028848-1eab1a80-51c1-11eb-8dd0-bf6ad8d79016.png">

### Checklist

- [x] Add third party identity check to session builder when creating the session
- [x] Add third party identity to check view templates