### PR TITLE
Changed tests GitHub action 

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -23,8 +23,6 @@ jobs:
 
       - run: npm audit --production
 
-      - run: set -o pipefail && npm audit --audit-level=high --parseable | awk -F $'\t' 'NF {print $2,"("$3") - "$4" - "$5" - "$6}' | awk '!visited[$0]++'
-
       - run: npm test
 
       - name: Fix code coverage paths


### PR DESCRIPTION
Removed from the **tests** Github action step `npm audit --audit-level=high` as it runs after the `npm audit --production` one, which is already a blocking step, that already provides the list of dependencies to be updated (but only for prod).