### PR TITLE
SDK-1836 New auth-type (BEARER)

### DIFF
--- a/src/doc_scan_service/doc.scan.constants.js
+++ b/src/doc_scan_service/doc.scan.constants.js
@@ -33,4 +33,6 @@ module.exports = Object.freeze({
   DESIRED: 'DESIRED',
   IGNORE: 'IGNORE',
   PROOF_OF_ADDRESS: 'PROOF_OF_ADDRESS',
+  BASIC: 'BASIC',
+  BEARER: 'BEARER',
 });

--- a/src/doc_scan_service/session/create/notification.config.builder.js
+++ b/src/doc_scan_service/session/create/notification.config.builder.js
@@ -120,9 +120,9 @@ class NotificationConfigBuilder {
   build() {
     return new NotificationConfig(
       this.authToken,
-      this.authType,
       this.endpoint,
-      this.topics
+      this.topics,
+      this.authType
     );
   }
 }

--- a/src/doc_scan_service/session/create/notification.config.builder.js
+++ b/src/doc_scan_service/session/create/notification.config.builder.js
@@ -31,6 +31,26 @@ class NotificationConfigBuilder {
   }
 
   /**
+   * Sets the authorization type as BASIC
+   *
+   * @returns {this}
+   */
+  withAuthTypeBasic() {
+    this.authType = DocScanConstants.BASIC;
+    return this;
+  }
+
+  /**
+   * Sets the authorization type as BEARER
+   *
+   * @returns {this}
+   */
+  withAuthTypeBearer() {
+    this.authType = DocScanConstants.BEARER;
+    return this;
+  }
+
+  /**
    * Sets the endpoint that notifications should be sent to
    *
    * @param {string} endpoint
@@ -100,6 +120,7 @@ class NotificationConfigBuilder {
   build() {
     return new NotificationConfig(
       this.authToken,
+      this.authType,
       this.endpoint,
       this.topics
     );

--- a/src/doc_scan_service/session/create/notification.config.js
+++ b/src/doc_scan_service/session/create/notification.config.js
@@ -1,13 +1,16 @@
 'use strict';
 
+const DocScanConstants = require('../../doc.scan.constants');
 const Validation = require('../../../yoti_common/validation');
+
+const acceptedAuthTypes = [DocScanConstants.BASIC, DocScanConstants.BEARER];
 
 /**
  * Configures call-back Notifications to some backend endpoint provided
  * by the Relying Business.
  *
  * Notifications can be configured to notified a client backend of certain
- * events, avoiding the neeed to poll for the state of the Session.
+ * events, avoiding the need to poll for the state of the Session.
  *
  * @class NotificationConfig
  */
@@ -15,14 +18,22 @@ class NotificationConfig {
   /**
    * @param {string} authToken
    *   The authorization token to be included in call-back messages
+   * @param {string} authType
+   *   The authorization type to used in call-back messages, accepts BASIC, BEARER
    * @param {string} endpoint
    *   The endpoint that notifications should be sent to
    * @param {string[]} topics
    *   The list of topics that should trigger notifications
    */
-  constructor(authToken, endpoint, topics) {
+  constructor(authToken, authType, endpoint, topics) {
     Validation.isString(authToken, 'authToken', true);
     this.authToken = authToken;
+
+    Validation.isString(authType, 'authType', true);
+    if (authType) {
+      Validation.oneOf(authType, acceptedAuthTypes, 'authType');
+      this.authType = authType;
+    }
 
     Validation.isString(endpoint, 'endpoint', true);
     this.endpoint = endpoint;
@@ -39,6 +50,7 @@ class NotificationConfig {
   toJSON() {
     return {
       auth_token: this.authToken,
+      auth_type: this.authType,
       endpoint: this.endpoint,
       topics: this.topics,
     };

--- a/src/doc_scan_service/session/create/notification.config.js
+++ b/src/doc_scan_service/session/create/notification.config.js
@@ -18,22 +18,16 @@ class NotificationConfig {
   /**
    * @param {string} authToken
    *   The authorization token to be included in call-back messages
-   * @param {string} authType
-   *   The authorization type to used in call-back messages, accepts BASIC, BEARER
    * @param {string} endpoint
    *   The endpoint that notifications should be sent to
    * @param {string[]} topics
    *   The list of topics that should trigger notifications
+   * @param {string} authType
+   *   The authorization type to used in call-back messages, accepts BASIC, BEARER
    */
-  constructor(authToken, authType, endpoint, topics) {
+  constructor(authToken, endpoint, topics, authType) {
     Validation.isString(authToken, 'authToken', true);
     this.authToken = authToken;
-
-    Validation.isString(authType, 'authType', true);
-    if (authType) {
-      Validation.oneOf(authType, acceptedAuthTypes, 'authType');
-      this.authType = authType;
-    }
 
     Validation.isString(endpoint, 'endpoint', true);
     this.endpoint = endpoint;
@@ -41,6 +35,12 @@ class NotificationConfig {
     if (topics) {
       Validation.isArrayOfStrings(topics, 'topics');
       this.topics = topics.filter((elem, pos) => topics.indexOf(elem) === pos);
+    }
+
+    Validation.isString(authType, 'authType', true);
+    if (authType) {
+      Validation.oneOf(authType, acceptedAuthTypes, 'authType');
+      this.authType = authType;
     }
   }
 

--- a/src/yoti_common/validation.js
+++ b/src/yoti_common/validation.js
@@ -236,4 +236,18 @@ module.exports = class Validation {
       throw TypeError(`${name} cannot be null or empty`);
     }
   }
+
+  /**
+   * @param {*} value
+   * @param {array} acceptedValues
+   * @param {string} name
+   *
+   * @throws {TypeError}
+   */
+  static oneOf(value, acceptedValues, name) {
+    this.isArray(acceptedValues, 'acceptedValues');
+    if (!acceptedValues.includes(value)) {
+      throw Error(`${name} is not an accepted value`);
+    }
+  }
 };

--- a/tests/doc_scan_service/session/create/notification.config.builder.test.js
+++ b/tests/doc_scan_service/session/create/notification.config.builder.test.js
@@ -1,18 +1,21 @@
 const {
   NotificationConfigBuilder,
 } = require('../../../../src/doc_scan_service');
+const DocScanConstants = require('../../../../src/doc_scan_service/doc.scan.constants');
 
 describe('NotificationConfigBuilder', () => {
   it('should build NotificationConfig', () => {
     const notificationConfig = new NotificationConfigBuilder()
       .withEndpoint('some-endpoint')
       .withAuthToken('some-auth-token')
+      .withAuthTypeBearer()
       .withTopic('some-topic')
       .withTopic('some-other-topic')
       .build();
 
     const expectedJson = JSON.stringify({
       auth_token: 'some-auth-token',
+      auth_type: DocScanConstants.BEARER,
       endpoint: 'some-endpoint',
       topics: [
         'some-topic',
@@ -98,6 +101,32 @@ describe('NotificationConfigBuilder', () => {
     const notificationConfig = new NotificationConfigBuilder().build();
 
     const expectedJson = JSON.stringify({
+      topics: [],
+    });
+
+    expect(JSON.stringify(notificationConfig)).toBe(expectedJson);
+  });
+
+  it('should build NotificationConfig with authType BEARER', () => {
+    const notificationConfig = new NotificationConfigBuilder()
+      .withAuthTypeBearer()
+      .build();
+
+    const expectedJson = JSON.stringify({
+      auth_type: DocScanConstants.BEARER,
+      topics: [],
+    });
+
+    expect(JSON.stringify(notificationConfig)).toBe(expectedJson);
+  });
+
+  it('should build NotificationConfig with authType BASIC', () => {
+    const notificationConfig = new NotificationConfigBuilder()
+      .withAuthTypeBasic()
+      .build();
+
+    const expectedJson = JSON.stringify({
+      auth_type: DocScanConstants.BASIC,
       topics: [],
     });
 

--- a/tests/doc_scan_service/session/create/notification.config.test.js
+++ b/tests/doc_scan_service/session/create/notification.config.test.js
@@ -5,31 +5,31 @@ const SOME_AUTH_TOKEN = 'some-auth-token';
 const SOME_ENDPOINT = 'some-endpoint';
 
 describe('NotificationConfig', () => {
-  it('should serialize without topics', () => {
+  it('should serialize without topics and no auth_type', () => {
     const notificationConfig = new NotificationConfig(
       SOME_AUTH_TOKEN,
-      DocScanConstants.BASIC,
       SOME_ENDPOINT
     );
 
     const expectedJson = JSON.stringify({
       auth_token: SOME_AUTH_TOKEN,
-      auth_type: DocScanConstants.BASIC,
       endpoint: SOME_ENDPOINT,
     });
 
     expect(JSON.stringify(notificationConfig)).toBe(expectedJson);
   });
 
-  it('should not default auth_type ', () => {
+  it('should serialize with auth_type when provided', () => {
     const notificationConfig = new NotificationConfig(
       SOME_AUTH_TOKEN,
+      SOME_ENDPOINT,
       undefined,
-      SOME_ENDPOINT
+      DocScanConstants.BEARER
     );
 
     const expectedJson = JSON.stringify({
       auth_token: SOME_AUTH_TOKEN,
+      auth_type: DocScanConstants.BEARER,
       endpoint: SOME_ENDPOINT,
     });
 

--- a/tests/doc_scan_service/session/create/notification.config.test.js
+++ b/tests/doc_scan_service/session/create/notification.config.test.js
@@ -1,3 +1,4 @@
+const DocScanConstants = require('../../../../src/doc_scan_service/doc.scan.constants');
 const NotificationConfig = require('../../../../src/doc_scan_service/session/create/notification.config');
 
 const SOME_AUTH_TOKEN = 'some-auth-token';
@@ -5,7 +6,27 @@ const SOME_ENDPOINT = 'some-endpoint';
 
 describe('NotificationConfig', () => {
   it('should serialize without topics', () => {
-    const notificationConfig = new NotificationConfig(SOME_AUTH_TOKEN, SOME_ENDPOINT);
+    const notificationConfig = new NotificationConfig(
+      SOME_AUTH_TOKEN,
+      DocScanConstants.BASIC,
+      SOME_ENDPOINT
+    );
+
+    const expectedJson = JSON.stringify({
+      auth_token: SOME_AUTH_TOKEN,
+      auth_type: DocScanConstants.BASIC,
+      endpoint: SOME_ENDPOINT,
+    });
+
+    expect(JSON.stringify(notificationConfig)).toBe(expectedJson);
+  });
+
+  it('should not default auth_type ', () => {
+    const notificationConfig = new NotificationConfig(
+      SOME_AUTH_TOKEN,
+      undefined,
+      SOME_ENDPOINT
+    );
 
     const expectedJson = JSON.stringify({
       auth_token: SOME_AUTH_TOKEN,

--- a/tests/doc_scan_service/session/create/session.specification.builder.test.js
+++ b/tests/doc_scan_service/session/create/session.specification.builder.test.js
@@ -10,7 +10,7 @@ const {
   SdkConfigBuilder,
   RequiredIdDocumentBuilder,
   DocumentRestrictionsFilterBuilder,
-} = require('../../../../');
+} = require('../../../..');
 
 describe('SessionSpecificationBuilder', () => {
   it('should build SessionSpecification', () => {
@@ -20,6 +20,7 @@ describe('SessionSpecificationBuilder', () => {
 
     const notificationConfig = new NotificationConfigBuilder()
       .withEndpoint('some-endpoint')
+      .withAuthTypeBearer()
       .build();
 
     const textExtractionTask = new RequestedTextExtractionTaskBuilder()
@@ -66,6 +67,7 @@ describe('SessionSpecificationBuilder', () => {
       resources_ttl: 10,
       user_tracking_id: 'some-tracking-id',
       notifications: {
+        auth_type: 'BEARER',
         endpoint: 'some-endpoint',
         topics: [],
       },

--- a/tests/yoti_common/validation.spec.js
+++ b/tests/yoti_common/validation.spec.js
@@ -126,4 +126,30 @@ describe('Validation', () => {
         .toThrow(new TypeError('name cannot be null or empty'));
     });
   });
+
+  describe('#oneOf', () => {
+    const acceptedValues = ['abc', 'def', 123];
+    describe('valid cases', () => {
+      test.each([
+        ['abc'],
+        ['def'],
+        [123],
+      ])('should not throw error as value is an accepted one', (value) => {
+        expect(() => Validation.oneOf(value, acceptedValues, 'name'))
+          .not.toThrow();
+      });
+    });
+    describe('invalid cases', () => {
+      test.each([
+        [''],
+        [null],
+        ['ab'],
+        [12],
+        ['123'],
+      ])('should throw error as value is not an accepted one', (value) => {
+        expect(() => Validation.oneOf(value, acceptedValues, 'name'))
+          .toThrow(new Error('name is not an accepted value'));
+      });
+    });
+  });
 });


### PR DESCRIPTION
### Description

Allows the NotificationConfig to have a authorisation type of either `BASIC` or `BEARER`.
The NotificationConfigBuilder exposes two methods `withAuthTypeBasic()` and `withAuthTypeBearer()`


### Testing

All CI tests pass