### PR TITLE
SDK-1996 Add support for mobile handoff

### DIFF
--- a/examples/doc-scan/src/controllers/index.controller.js
+++ b/examples/doc-scan/src/controllers/index.controller.js
@@ -103,6 +103,7 @@ async function createSession() {
         .withSuccessUrl(`${config.YOTI_APP_BASE_URL}/success`)
         .withErrorUrl(`${config.YOTI_APP_BASE_URL}/error`)
         .withPrivacyPolicyUrl(`${config.YOTI_APP_BASE_URL}/privacy-policy`)
+        .withAllowHandoff(true)
         .build()
     )
     .withRequiredDocument(

--- a/src/doc_scan_service/session/create/sdk.config.builder.js
+++ b/src/doc_scan_service/session/create/sdk.config.builder.js
@@ -152,6 +152,20 @@ class SdkConfigBuilder {
   }
 
   /**
+   * Sets whether mobile handoff is allowed, so the user can start a session on their desktop
+   * and then switch to mobile to finish
+   *
+   * @param {boolean} allowHandoff allow mobile handoff
+   *
+   * @returns {this}
+   */
+  withAllowHandoff(allowHandoff) {
+    Validation.isBoolean(allowHandoff, 'allowHandoff');
+    this.allowHandoff = allowHandoff;
+    return this;
+  }
+
+  /**
    * Builds the {@link SdkConfig} using the values supplied to the builder
    *
    * @returns {SdkConfig}
@@ -166,7 +180,8 @@ class SdkConfigBuilder {
       this.presetIssuingCountry,
       this.successUrl,
       this.errorUrl,
-      this.privacyPolicyUrl
+      this.privacyPolicyUrl,
+      this.allowHandoff
     );
   }
 }

--- a/src/doc_scan_service/session/create/sdk.config.js
+++ b/src/doc_scan_service/session/create/sdk.config.js
@@ -22,6 +22,8 @@ class SdkConfig {
    *   The error URL
    * @param {string} privacyPolicyUrl
    *   The privacy policy URL
+   * @param {boolean} allowHandoff
+   *   Allow user to handoff to mobile during session
    */
   constructor(
     allowedCaptureMethods,
@@ -32,7 +34,8 @@ class SdkConfig {
     presetIssuingCountry,
     successUrl,
     errorUrl,
-    privacyPolicyUrl
+    privacyPolicyUrl,
+    allowHandoff
   ) {
     Validation.isString(allowedCaptureMethods, 'allowedCaptureMethods', true);
     this.allowedCaptureMethods = allowedCaptureMethods;
@@ -60,6 +63,9 @@ class SdkConfig {
 
     Validation.isString(privacyPolicyUrl, 'privacyPolicyUrl', true);
     this.privacyPolicyUrl = privacyPolicyUrl;
+
+    Validation.isBoolean(allowHandoff, 'allowHandoff', true);
+    this.allowHandoff = allowHandoff;
   }
 
   /**
@@ -76,6 +82,7 @@ class SdkConfig {
       success_url: this.successUrl,
       error_url: this.errorUrl,
       privacy_policy_url: this.privacyPolicyUrl,
+      allow_handoff: this.allowHandoff,
     };
   }
 }

--- a/tests/doc_scan_service/session/create/sdk.config.builder.test.js
+++ b/tests/doc_scan_service/session/create/sdk.config.builder.test.js
@@ -14,6 +14,7 @@ describe('SdkConfigBuilder', () => {
       .withLocale('some-url')
       .withPresetIssuingCountry('some-country')
       .withPrivacyPolicyUrl('some-privacy-policy-url')
+      .withAllowHandoff(true)
       .build();
 
     const expectedJson = JSON.stringify({
@@ -26,6 +27,7 @@ describe('SdkConfigBuilder', () => {
       success_url: 'some-success-url',
       error_url: 'some-error-url',
       privacy_policy_url: 'some-privacy-policy-url',
+      allow_handoff: true,
     });
 
     expect(JSON.stringify(sdkConfig)).toBe(expectedJson);


### PR DESCRIPTION
* Added support for the allow_handoff property in the SDK configuration
* Updated test to include the new method
* Incorporated it into the main example