### PR TITLE
Fix GitHub actions (lint examples to run with Node 14)

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -44,10 +44,15 @@ jobs:
       - uses: actions/checkout@v2
 
       - uses: actions/setup-node@v2.1.2
+        with:
+          node-version: '14'
 
       - run: npm install
 
       - run: npm update
+
+      - name: print versions
+        run: echo npm $(npm -v), node $(node -v)
 
       - run: pushd ./examples/aml-check && npm install && npm update && npm run lint && popd
 


### PR DESCRIPTION
* Fix GitHub actions: lint examples test should run with Node 14
* Also print npm and node version