### PR TITLE
SDK-1890 add attempts configuration

### DIFF
--- a/examples/doc-scan/src/controllers/index.controller.js
+++ b/examples/doc-scan/src/controllers/index.controller.js
@@ -104,6 +104,8 @@ async function createSession() {
         .withErrorUrl(`${config.YOTI_APP_BASE_URL}/error`)
         .withPrivacyPolicyUrl(`${config.YOTI_APP_BASE_URL}/privacy-policy`)
         .withAllowHandoff(true)
+        .withIdDocumentTextExtractionGenericRetries(5)
+        .withIdDocumentTextExtractionReclassificationRetries(5)
         .build()
     )
     .withRequiredDocument(

--- a/src/doc_scan_service/doc.scan.constants.js
+++ b/src/doc_scan_service/doc.scan.constants.js
@@ -45,4 +45,6 @@ module.exports = Object.freeze({
   PROFILE: 'PROFILE',
   EXACT: 'EXACT',
   FUZZY: 'FUZZY',
+  GENERIC: 'GENERIC',
+  RECLASSIFICATION: 'RECLASSIFICATION',
 });

--- a/src/doc_scan_service/session/create/sdk.config.builder.js
+++ b/src/doc_scan_service/session/create/sdk.config.builder.js
@@ -31,7 +31,7 @@ class SdkConfigBuilder {
   /**
    * Sets the allowed capture method
    *
-   * @param {string} allowedCaptureMethod the allowed capture method
+   * @param {string} allowedCaptureMethods the allowed capture method
    *
    * @returns {this}
    */
@@ -166,6 +166,61 @@ class SdkConfigBuilder {
   }
 
   /**
+   * Allows configuring the number of attempts permitted for text extraction on an ID document
+   *
+   * @param {string} category the category of retries
+   * @param {number} retries the number of retries (more than 0)
+   *
+   * @returns {this}
+   */
+  withIdDocumentTextExtractionCategoryRetries(category, retries) {
+    Validation.isString(category, 'category');
+    Validation.isInteger(retries, 'retries');
+    Validation.notLessThan(retries, 1, 'retries');
+
+    const attemptsTarget = DocScanConstants.ID_DOCUMENT_TEXT_DATA_EXTRACTION;
+
+    if (!this.attemptsConfiguration) {
+      this.attemptsConfiguration = {};
+    }
+
+    const attemptsConfiguration = this.attemptsConfiguration[attemptsTarget] || {};
+    attemptsConfiguration[category] = retries;
+    this.attemptsConfiguration[attemptsTarget] = attemptsConfiguration;
+    return this;
+  }
+
+  /**
+   * Allows configuring the number of 'Reclassification' attempts permitted for text extraction
+   * on an ID document
+   *
+   * @param {number} retries the number of retries (more than 0)
+   *
+   * @returns {this}
+   */
+  withIdDocumentTextExtractionReclassificationRetries(retries) {
+    return this.withIdDocumentTextExtractionCategoryRetries(
+      DocScanConstants.RECLASSIFICATION,
+      retries
+    );
+  }
+
+  /**
+   * Allows configuring the number of 'Generic' attempts permitted for text extraction
+   * on an ID document
+   *
+   * @param {number} retries the number of retries (more than 0)
+   *
+   * @returns {this}
+   */
+  withIdDocumentTextExtractionGenericRetries(retries) {
+    return this.withIdDocumentTextExtractionCategoryRetries(
+      DocScanConstants.GENERIC,
+      retries
+    );
+  }
+
+  /**
    * Builds the {@link SdkConfig} using the values supplied to the builder
    *
    * @returns {SdkConfig}
@@ -181,7 +236,8 @@ class SdkConfigBuilder {
       this.successUrl,
       this.errorUrl,
       this.privacyPolicyUrl,
-      this.allowHandoff
+      this.allowHandoff,
+      this.attemptsConfiguration
     );
   }
 }

--- a/src/doc_scan_service/session/create/sdk.config.js
+++ b/src/doc_scan_service/session/create/sdk.config.js
@@ -24,6 +24,8 @@ class SdkConfig {
    *   The privacy policy URL
    * @param {boolean} allowHandoff
    *   Allow user to handoff to mobile during session
+   * @param {object} attemptsConfiguration
+   *   The attempts configuration
    */
   constructor(
     allowedCaptureMethods,
@@ -35,7 +37,8 @@ class SdkConfig {
     successUrl,
     errorUrl,
     privacyPolicyUrl,
-    allowHandoff
+    allowHandoff,
+    attemptsConfiguration
   ) {
     Validation.isString(allowedCaptureMethods, 'allowedCaptureMethods', true);
     this.allowedCaptureMethods = allowedCaptureMethods;
@@ -66,6 +69,11 @@ class SdkConfig {
 
     Validation.isBoolean(allowHandoff, 'allowHandoff', true);
     this.allowHandoff = allowHandoff;
+
+    if (attemptsConfiguration) {
+      Validation.isPlainObject(attemptsConfiguration, 'attemptsConfiguration');
+      this.attemptsConfiguration = attemptsConfiguration;
+    }
   }
 
   /**
@@ -83,6 +91,7 @@ class SdkConfig {
       error_url: this.errorUrl,
       privacy_policy_url: this.privacyPolicyUrl,
       allow_handoff: this.allowHandoff,
+      attempts_configuration: this.attemptsConfiguration,
     };
   }
 }

--- a/tests/doc_scan_service/session/create/sdk.config.builder.test.js
+++ b/tests/doc_scan_service/session/create/sdk.config.builder.test.js
@@ -56,4 +56,43 @@ describe('SdkConfigBuilder', () => {
 
     expect(JSON.stringify(sdkConfig)).toBe(expectedJson);
   });
+
+  it('should build SdkConfig with attempts retries', () => {
+    let sdkConfig = new SdkConfigBuilder()
+      .withIdDocumentTextExtractionCategoryRetries('TEST', 2)
+      .withIdDocumentTextExtractionGenericRetries(3)
+      .withIdDocumentTextExtractionReclassificationRetries(4)
+      .withIdDocumentTextExtractionCategoryRetries('test', 5)
+      .build();
+
+    let expectedJson = JSON.stringify({
+      attempts_configuration: {
+        ID_DOCUMENT_TEXT_DATA_EXTRACTION: {
+          TEST: 2,
+          GENERIC: 3,
+          RECLASSIFICATION: 4,
+          test: 5,
+        },
+      },
+    });
+
+    expect(JSON.stringify(sdkConfig)).toBe(expectedJson);
+
+    sdkConfig = new SdkConfigBuilder()
+      .withIdDocumentTextExtractionGenericRetries(1)
+      .withIdDocumentTextExtractionReclassificationRetries(2)
+      .withIdDocumentTextExtractionCategoryRetries('GENERIC', 3)
+      .build();
+
+    expectedJson = JSON.stringify({
+      attempts_configuration: {
+        ID_DOCUMENT_TEXT_DATA_EXTRACTION: {
+          GENERIC: 3,
+          RECLASSIFICATION: 2,
+        },
+      },
+    });
+
+    expect(JSON.stringify(sdkConfig)).toBe(expectedJson);
+  });
 });


### PR DESCRIPTION
Added 3 methods in **SdkConfigBuilder** to allow setting up the retries of ID Document text extraction by category.
```
withIdDocumentTextExtractionCategoryRetries(category, retries)
withIdDocumentTextExtractionReclassificationRetries(retries)
withIdDocumentTextExtractionGenericRetries(retries)
```
The values are expressed in the sdk config within the `attempts_configuration` field:
```
// sdk config
{
  [...]
  attempts_configuration: {
    ID_DOCUMENT_TEXT_DATA_EXTRACTION: {
      GENERIC: 3,
      RECLASSIFICATION: 2,
    },
  },
}
```