### PR TITLE
SDK-2049 bug fix optional tags in CustomAccountWatchlistCaSearchConfig

### DIFF
--- a/src/doc_scan_service/session/create/check/requested.custom.account.watchlist.advanced.ca.config.js
+++ b/src/doc_scan_service/session/create/check/requested.custom.account.watchlist.advanced.ca.config.js
@@ -29,7 +29,7 @@ class RequestedCustomAccountWatchlistAdvancedCaConfig extends RequestedWatchlist
     matchingStrategy,
     apiKey,
     monitoring = false,
-    tags = {},
+    tags,
     clientRef
   ) {
     super(removeDeceased, shareUrl, sources, matchingStrategy);
@@ -40,11 +40,14 @@ class RequestedCustomAccountWatchlistAdvancedCaConfig extends RequestedWatchlist
     Validation.isBoolean(monitoring, 'monitoring');
     this.monitoring = monitoring;
 
-    Validation.isArrayOfStrings(Object.keys(tags), 'tags.keys');
-    Object.keys(tags).forEach((key) => {
-      Validation.notNull(tags[key], `tags.${key}`);
-    });
-    this.tags = tags;
+    if (tags) {
+      Validation.isPlainObject(tags, 'tags');
+      Validation.isArrayOfStrings(Object.keys(tags), 'tags.keys');
+      Object.keys(tags).forEach((key) => {
+        Validation.notNull(tags[key], `tags.${key}`);
+      });
+      this.tags = tags;
+    }
 
     Validation.isString(clientRef, 'clientRef');
     Validation.notNullOrEmpty(clientRef, 'clientRef');

--- a/src/doc_scan_service/session/retrieve/custom.account.watchlist.ca.search.config.response.js
+++ b/src/doc_scan_service/session/retrieve/custom.account.watchlist.ca.search.config.response.js
@@ -13,12 +13,14 @@ class CustomAccountWatchlistCaSearchConfigResponse extends WatchlistAdvancedCaSe
     Validation.isBoolean(searchConfig.monitoring, 'monitoring');
     this.monitoring = searchConfig.monitoring;
 
-    Validation.isPlainObject(searchConfig.tags, 'tags');
-    const keys = Object.keys(searchConfig.tags);
-    const values = keys.map((key) => searchConfig.tags[key]);
-    Validation.isArrayOfStrings(keys, 'tags.keys');
-    Validation.isArrayOfStrings(values, 'tags.values');
-    this.tags = searchConfig.tags;
+    if (searchConfig.tags) {
+      Validation.isPlainObject(searchConfig.tags, 'tags');
+      const keys = Object.keys(searchConfig.tags);
+      const values = keys.map((key) => searchConfig.tags[key]);
+      Validation.isArrayOfStrings(keys, 'tags.keys');
+      Validation.isArrayOfStrings(values, 'tags.values');
+      this.tags = searchConfig.tags;
+    }
 
     Validation.isString(searchConfig.client_ref, 'client_ref');
     this.clientRef = searchConfig.client_ref;

--- a/tests/doc_scan_service/session/create/check/requested.watchlist.advanced.ca.builder.spec.js
+++ b/tests/doc_scan_service/session/create/check/requested.watchlist.advanced.ca.builder.spec.js
@@ -378,7 +378,6 @@ describe('The config builder', () => {
         api_key: 'some-key',
         client_ref: 'some-ref',
         monitoring: false,
-        tags: {},
       });
 
       beforeEach(() => {
@@ -525,7 +524,6 @@ describe('RequestedWatchlistAdvancedCaCheckBuilder', () => {
           type: 'WITH_CUSTOM_ACCOUNT',
           api_key: 'the-key',
           monitoring: false,
-          tags: {},
           client_ref: 'the-referee',
           remove_deceased: false,
           share_url: false,

--- a/tests/doc_scan_service/session/retrieve/custom.account.watchlist.ca.search.config.response.spec.js
+++ b/tests/doc_scan_service/session/retrieve/custom.account.watchlist.ca.search.config.response.spec.js
@@ -76,6 +76,18 @@ describe('CustomAccountWatchlistCaSearchConfigResponse', () => {
         });
       });
     });
+    describe('with missing tags in response body', () => {
+      beforeEach(() => {
+        const response = Object.assign({}, minimumResponseBody);
+        delete response.tags;
+        // eslint-disable-next-line max-len
+        customAccountWatchlistCaSearchConfigResponse = new CustomAccountWatchlistCaSearchConfigResponse(response);
+      });
+
+      it('#getTags', () => {
+        expect(customAccountWatchlistCaSearchConfigResponse.getTags()).toBe(undefined);
+      });
+    });
     describe('with sources in response body', () => {
       describe('of type PROFILE', () => {
         beforeEach(() => {


### PR DESCRIPTION
Made `tags` optional in the _RequestedCustomAccountWatchlistAdvancedCaConfig_ and the _CustomAccountWatchlistCaSearchConfigResponse_, so when not specified by user in the request, no empty object is sent by default anymore, and when retrieving the config in the response, it is no longer assumed that the `tags` must be there.