### PR TITLE
SDK-2074 support identity profile requirements in dynamic policy

### DIFF
--- a/src/dynamic_sharing_service/policy/dynamic.policy.builder.js
+++ b/src/dynamic_sharing_service/policy/dynamic.policy.builder.js
@@ -305,6 +305,14 @@ module.exports = class DynamicPolicyBuilder {
   }
 
   /**
+   * @param {object} identityProfileRequirements
+   */
+  withIdentityProfileRequirements(identityProfileRequirements) {
+    this.identityProfileRequirements = identityProfileRequirements;
+    return this;
+  }
+
+  /**
    * @returns {DynamicPolicy}
    */
   build() {
@@ -312,7 +320,7 @@ module.exports = class DynamicPolicyBuilder {
       Object.keys(this.wantedAttributes).map((k) => this.wantedAttributes[k]),
       this.wantedAuthTypes.filter((value, index, self) => self.indexOf(value) === index),
       this.wantedRememberMe,
-      false
+      this.identityProfileRequirements
     );
   }
 };

--- a/src/dynamic_sharing_service/policy/dynamic.policy.js
+++ b/src/dynamic_sharing_service/policy/dynamic.policy.js
@@ -19,7 +19,7 @@ module.exports = class DynamicPolicy {
     wantedAttributes,
     wantedAuthTypes,
     wantedRememberMe = false,
-    identityProfileRequirements
+    identityProfileRequirements = null
   ) {
     Validation.isArrayOfType(wantedAttributes, WantedAttribute, 'wantedAttribute');
     this.wantedAttributes = wantedAttributes;

--- a/src/dynamic_sharing_service/policy/dynamic.policy.js
+++ b/src/dynamic_sharing_service/policy/dynamic.policy.js
@@ -13,11 +13,13 @@ module.exports = class DynamicPolicy {
    * @param {WantedAttribute[]} wantedAttributes - array of attributes to be requested.
    * @param {integer[]} wantedAuthTypes - auth types represents the authentication type to be used.
    * @param {boolean} wantedRememberMe
+   * @param {object} identityProfileRequirements
    */
   constructor(
     wantedAttributes,
     wantedAuthTypes,
-    wantedRememberMe = false
+    wantedRememberMe = false,
+    identityProfileRequirements
   ) {
     Validation.isArrayOfType(wantedAttributes, WantedAttribute, 'wantedAttribute');
     this.wantedAttributes = wantedAttributes;
@@ -31,6 +33,11 @@ module.exports = class DynamicPolicy {
 
     Validation.isBoolean(wantedRememberMe, 'wantedRememberMe');
     this.wantedRememberMe = wantedRememberMe;
+
+    if (identityProfileRequirements) {
+      Validation.isPlainObject(identityProfileRequirements, 'identityProfileRequirements');
+      this.identityProfileRequirements = identityProfileRequirements;
+    }
   }
 
   /**
@@ -55,14 +62,26 @@ module.exports = class DynamicPolicy {
   }
 
   /**
+   * @return {Object}
+   */
+  getIdentityProfileRequirements() {
+    return this.identityProfileRequirements;
+  }
+
+  /**
    * @returns {Object} data for JSON.stringify()
    */
   toJSON() {
-    return {
+    const base = {
       wanted: this.getWantedAttributes(),
       wanted_auth_types: this.getWantedAuthTypes(),
       wanted_remember_me: this.getWantedRememberMe(),
       wanted_remember_me_optional: false,
     };
+    const identityProfileRequirements = this.getIdentityProfileRequirements();
+    if (identityProfileRequirements) {
+      return Object.assign(base, { identity_profile_requirements: identityProfileRequirements });
+    }
+    return base;
   }
 };

--- a/tests/dynamic_sharing_service/policy/dynamic.policy.builder.spec.js
+++ b/tests/dynamic_sharing_service/policy/dynamic.policy.builder.spec.js
@@ -11,9 +11,9 @@ const WantedAttribute = require('../../../src/dynamic_sharing_service/policy/wan
 const CONSTRAINT_TYPE_SOURCE = 'SOURCE';
 
 /**
- * Compares serlialized dynamic policy with expected JSON data.
+ * Compares serialized dynamic policy with expected JSON data.
  *
- * @param {DynamicPolicy} dynamicPolicy the dynamic policy to selialize.
+ * @param {DynamicPolicy} dynamicPolicy the dynamic policy to serialize.
  * @param {object} expectedJsonData expected JSON data to serialize.
  */
 const expectDynamicPolicyJson = (dynamicPolicy, expectedJsonData) => {
@@ -397,5 +397,58 @@ describe('DynamicPolicyBuilder', () => {
     };
 
     expectDynamicPolicyJson(dynamicPolicy, expectedWantedAttributeData);
+  });
+
+  describe('when using with identity profile requirements', () => {
+    const identityProfileRequirementsDescriptor = {
+      trust_framework: 'UK_TFIDA',
+      scheme: {
+        type: 'DBS',
+        objective: 'STANDARD',
+      },
+    };
+
+    it('should build with identity profile requirements only', () => {
+      const dynamicPolicy = new DynamicPolicyBuilder()
+        .withIdentityProfileRequirements(identityProfileRequirementsDescriptor)
+        .build();
+
+      expect(dynamicPolicy.getIdentityProfileRequirements())
+        .toEqual(identityProfileRequirementsDescriptor);
+
+      expectDynamicPolicyJson(dynamicPolicy, {
+        wanted: [],
+        wanted_auth_types: [],
+        wanted_remember_me: false,
+        wanted_remember_me_optional: false,
+        identity_profile_requirements: identityProfileRequirementsDescriptor,
+      });
+    });
+
+    it('should build with identity profile requirements alongside other wanted attributes', () => {
+      const dynamicPolicy = new DynamicPolicyBuilder()
+        .withGender()
+        .withNationality()
+        .withIdentityProfileRequirements(identityProfileRequirementsDescriptor)
+        .build();
+
+      const expectedWantedAttributeData = [
+        { name: 'gender', optional: false },
+        { name: 'nationality', optional: false },
+      ];
+
+      expectDynamicPolicyAttributes(dynamicPolicy, expectedWantedAttributeData);
+
+      expect(dynamicPolicy.getIdentityProfileRequirements())
+        .toEqual(identityProfileRequirementsDescriptor);
+
+      expectDynamicPolicyJson(dynamicPolicy, {
+        wanted: expectedWantedAttributeData,
+        wanted_auth_types: [],
+        wanted_remember_me: false,
+        wanted_remember_me_optional: false,
+        identity_profile_requirements: identityProfileRequirementsDescriptor,
+      });
+    });
   });
 });


### PR DESCRIPTION
Updated dynamic.policy and its builder to expose `withIdentityProfileRequirements()`, which then set `identityProfileRequirements` in the policy.

~(includes #304, branch to be rebased once it is merged)~ now rebased