### PR TITLE
SDK-2079 retrieve identity profile requirements attribute

### DIFF
--- a/src/profile_service/profile.js
+++ b/src/profile_service/profile.js
@@ -224,6 +224,15 @@ class Profile extends BaseProfile {
   getDocumentImages() {
     return this.getAttribute(constants.ATTR_DOCUMENT_IMAGES);
   }
+
+  /**
+   * Identity Profile Report.
+   *
+   * @returns {null|Attribute}
+   */
+  getIdentityProfileReport() {
+    return this.getAttribute(constants.ATTR_IDENTITY_PROFILE_REPORT);
+  }
 }
 
 module.exports = {

--- a/src/yoti_common/constants.js
+++ b/src/yoti_common/constants.js
@@ -27,6 +27,7 @@ module.exports = Object.freeze({
   ATTR_DOCUMENT_DETAILS: 'document_details',
   ATTR_STRUCTURED_POSTAL_ADDRESS: 'structured_postal_address',
   ATTR_DOCUMENT_IMAGES: 'document_images',
+  ATTR_IDENTITY_PROFILE_REPORT: 'identity_profile_report',
   ATTR_APPLICATION_NAME: 'application_name',
   ATTR_APPLICATION_LOGO: 'application_logo',
   ATTR_APPLICATION_URL: 'application_url',

--- a/tests/profile_service/profile.spec.js
+++ b/tests/profile_service/profile.spec.js
@@ -73,7 +73,7 @@ describe('Profile', () => {
       describe: 'When profile data is provided as an Array (with attributes sharing names)',
       // (here each attribute are duplicated, so to check handling of several with the same name)
       profileData: [...loadProfileDataArray(), ...loadProfileDataArray()],
-      testCaseSameNameAttributes: true,
+      profileDataAsArray: true,
     },
   ].forEach((testItem) => {
     describe(testItem.describe, () => {
@@ -214,7 +214,7 @@ describe('Profile', () => {
       describe('#getAttributes', () => {
         it('should return all attributes keyed by name', () => {
           const attributes = profileObj.getAttributes();
-          expect(Object.keys(attributes).length).toBe(16);
+          expect(Object.keys(attributes).length).toBe(17);
           Object.keys(attributes).forEach((attributeName) => {
             expect(attributes[attributeName]).toBeInstanceOf(Attribute);
           });
@@ -227,7 +227,7 @@ describe('Profile', () => {
         it('should return all attributes as an array', () => {
           const attributes = profileObj.getAttributesList();
           expect(attributes).toBeInstanceOf(Array);
-          expect(attributes.length).toBe(testItem.testCaseSameNameAttributes ? 32 : 16);
+          expect(attributes.length).toBe(testItem.profileDataAsArray ? 34 : 17);
           attributes.forEach((attribute) => {
             expect(attribute).toBeInstanceOf(Attribute);
           });
@@ -239,7 +239,7 @@ describe('Profile', () => {
           const attributes = profileObj.getAttributes();
           const allGenderAttributes = profileObj.getAttributesByName('gender');
 
-          if (!testItem.testCaseSameNameAttributes) {
+          if (!testItem.profileDataAsArray) {
             expect(allGenderAttributes.length).toBe(1);
             expect(allGenderAttributes[0]).toBe(attributes.gender);
           } else {
@@ -311,6 +311,17 @@ describe('Profile', () => {
         it('should return NULL for no match', () => {
           const verification = profileObj.findAgeOverVerification(100);
           expect(verification).toBe(null);
+        });
+      });
+
+      describe('#getIdentityProfileReport', () => {
+        it('should return identity_profile_report value', () => {
+          let expectedSource = testItem.profileData.identity_profile_report;
+          if (testItem.profileDataAsArray) {
+            expectedSource = testItem.profileData.find((item) => item.name === 'identity_profile_report');
+          }
+          expect(profileObj.getIdentityProfileReport().getValue())
+            .toEqual(expectedSource.value);
         });
       });
     });

--- a/tests/sample-data/profile-service/profile.json
+++ b/tests/sample-data/profile-service/profile.json
@@ -140,5 +140,129 @@
     ],
     "sources": [],
     "verifiers": []
+  },
+  "identity_profile_report":
+  {
+    "name": "identity_profile_report",
+    "value": {
+      "identity_assertion": {
+        "current_name": {
+          "given_names": "JOHN JIM FRED",
+          "first_name": "JOHN",
+          "middle_name": "JIM FRED",
+          "family_name": "FOO",
+          "full_name": "JOHN JIM FRED FOO"
+        },
+        "date_of_birth": "1979-01-01"
+      },
+      "verification_report": {
+        "report_id": "61b99534-116d-4a25-9750-2d708c0fb168",
+        "timestamp": "2022-01-02T15:04:05Z",
+        "subject_id": "f0726cb6-97c1-4802-9feb-eb7c6cd07949",
+        "trust_framework": "UK_TFIDA",
+        "schemes_compliance": [
+          {
+            "scheme": {
+              "type": "RTW"
+            },
+            "requirements_met": true
+          }
+        ],
+        "assurance_process": {
+          "level_of_assurance": "MEDIUM",
+          "policy": "GPG45",
+          "procedure": "M1C",
+          "assurance": [
+            {
+              "type": "EVIDENCE_STRENGTH",
+              "classification": "4",
+              "evidence_links": [
+                "41960172-ca91-487c-8bb3-2c547f80fe54"
+              ]
+            },
+            {
+              "type": "EVIDENCE_VALIDITY",
+              "classification": "3",
+              "evidence_links": [
+                "41960172-ca91-487c-8bb3-2c547f80fe54"
+              ]
+            },
+            {
+              "type": "VERIFICATION",
+              "classification": "3",
+              "evidence_links": [
+                "41960172-ca91-487c-8bb3-2c547f80fe54",
+                "fb0880ca-5dd5-4776-badb-17549123c50b"
+              ]
+            }
+          ]
+        },
+        "evidence": {
+          "documents": [
+            {
+              "evidence_id": "41960172-ca91-487c-8bb3-2c547f80fe54",
+              "timestamp": "2022-01-02T15:04:05Z",
+              "document_fields": {
+                "full_name": "JOHN JIM FRED FOO",
+                "date_of_birth": "1979-01-01",
+                "nationality": "GBR",
+                "given_names": "JOHN JIM FRED",
+                "family_name": "FOO",
+                "place_of_birth": "SAMPLETOWN",
+                "gender": "MALE",
+                "document_type": "PASSPORT",
+                "issuing_country": "GBR",
+                "document_number": "123456789",
+                "expiration_date": "2030-01-01",
+                "date_of_issue": "2020-01-01",
+                "issuing_authority": "HMPO",
+                "mrz": {
+                  "type": 2,
+                  "line1": "P<GBRFOO<<JOHN<JIM<FRED<<<<<<<<<<<<<<<<<<<<<",
+                  "line2": "1234567892GBR7901018M3001215<<<<<<<<<<<<<<02"
+                }
+              },
+              "passed_checks": [
+                {
+                  "check": "CHIP_DIGITAL_SIGNATURE"
+                },
+                {
+                  "check": "AUTOMATED_FACE_MATCH"
+                },
+                {
+                  "check": "FRAUD_DOCUMENTS_LIST"
+                }
+              ],
+              "verifying_org": "Yoti Ltd.",
+              "user_activity_ids": [
+                "d4764f67-2992-4a69-9ff4-55b0e77cb3d0"
+              ],
+              "document_images_attribute_id": "f253c8ab-f07b-4aeb-9dd0-50e670c7ebaf"
+            }
+          ],
+          "face_capture": {
+            "evidence_id": "fb0880ca-5dd5-4776-badb-17549123c50b",
+            "initial_liveness": {
+              "type": "ACTIVE",
+              "timestamp": "2022-01-02T15:04:05Z"
+            },
+            "verifying_org": "Yoti Ltd.",
+            "user_activity_ids": [
+              "a8e41187-7f5b-4e83-83d5-dc471452f1a8"
+            ],
+            "selfie_attribute_id": "cc507f84-f1aa-476a-877b-850e949e0fc8"
+          }
+        }
+      },
+      "authentication_report": {
+        "report_id": "d7202b65-657e-47a7-9679-7596db617b8c",
+        "timestamp": "2022-01-02T15:04:05Z",
+        "policy": "GPG44",
+        "level": "MEDIUM"
+      },
+      "proof": "<signature provided here>"
+    },
+    "sources": [],
+    "verifiers": []
   }
 }


### PR DESCRIPTION
Updated profile_service so the add new method `profile.getIdentityProfileReport()`

~(includes #305 , to be rebased once merged)~