### PR TITLE
[CI] Exclude 'node-forge' from audit

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -17,11 +17,13 @@ jobs:
 
       - uses: actions/setup-node@v2.1.2
 
-      - run: npm install
-
       - run: npm update
 
-      - run: npm audit --production --audit-level=moderate
+      - run: npm install --no-audit
+
+      - run: npm install -D audit-ci
+
+      - run: npx audit-ci --moderate --skip-dev --allowlist node-forge
 
       - run: npm run unit-test
 


### PR DESCRIPTION
Changed the actions "Unit Tests" to use 'audit-ci' so 'node-forge' can be bypassed.