### PR TITLE
SDK-2091 get attribute by id

### DIFF
--- a/src/data_type/attribute.js
+++ b/src/data_type/attribute.js
@@ -15,6 +15,7 @@ class Attribute {
     this.name = attrObj.name;
     this.sources = attrObj.sources;
     this.verifiers = attrObj.verifiers;
+    this.id = attrObj.id;
 
     this.anchors = [];
     if (attrObj.anchors) {
@@ -22,6 +23,15 @@ class Attribute {
         this.anchors = this.anchors.concat(attrObj.anchors[key]);
       });
     }
+  }
+
+  /**
+   * Retrieves the id of an attribute. It can be undefined.
+   *
+   * @returns {*}
+   */
+  getId() {
+    return this.id;
   }
 
   /**

--- a/src/profile_service/base.profile.js
+++ b/src/profile_service/base.profile.js
@@ -57,6 +57,17 @@ class BaseProfile {
   }
 
   /**
+   * Return first attribute found by id.
+   *
+   * @param attrId
+   *
+   * @returns {Attribute}
+   */
+  getAttributeById(attrId) {
+    return this.attributes.find((attr) => attr.getId() === attrId);
+  }
+
+  /**
    * Return array of all attributes for the profile.
    *
    * @returns {Attribute[]}

--- a/src/proto-root/proto.attribute.list.js
+++ b/src/proto-root/proto.attribute.list.js
@@ -25,6 +25,7 @@ module.exports = {
       const attrName = attribute.getName();
       const attrValue = attribute.getValue();
       const attrType = attribute.getContentType();
+      const attrId = attribute.getEphemeralId();
       const processedAnchors = AnchorProcessor.process(attribute.anchors);
       const attrNameInCamelCase = this.toCamelCase(attrName);
 
@@ -51,6 +52,7 @@ module.exports = {
           sources: processedAnchors.sources,
           verifiers: processedAnchors.verifiers,
           anchors: processedAnchors,
+          id: attrId,
         };
       } catch (err) {
         console.log(`${err.message} (Attribute: ${attrName})`);

--- a/tests/data_type/attribute.spec.js
+++ b/tests/data_type/attribute.spec.js
@@ -22,12 +22,14 @@ describe('Attribute', () => {
     verifiers,
     unknown: parseAnchorData(unknownAnchor).unknown,
   };
+  const id = '123-id';
   const attributeObj = new Attribute({
     value: documentDetails,
     name: 'document_details',
     sources,
     verifiers,
     anchors,
+    id,
   });
 
   describe('Attribute.getValue()', () => {
@@ -73,6 +75,11 @@ describe('Attribute', () => {
       expect(source.getType()).toBe('SOURCE');
       expect(verifier.getType()).toBe('VERIFIER');
       expect(unknown.getType()).toBe('UNKNOWN');
+    });
+  });
+  describe('Attribute.getId()', () => {
+    it('it should return the ephemeralId', () => {
+      expect(attributeObj.getId()).toBe(id);
     });
   });
   describe('When Attribute value is a DocumentDetails', () => {

--- a/tests/profile_service/profile.spec.js
+++ b/tests/profile_service/profile.spec.js
@@ -71,7 +71,6 @@ const profileDataAsArrayWithSameAttributes = [...loadProfileDataArray(), ...load
     }
     return attr;
   });
-console.log('>>>>', profileDataAsArrayWithSameAttributes, '<<<< profileDataAsArrayWithSameAttributes');
 
 describe('Profile', () => {
   [

--- a/tests/profile_service/profile.spec.js
+++ b/tests/profile_service/profile.spec.js
@@ -63,16 +63,26 @@ const createAttribute = (name, value) => new Attribute({
   verifiers: [],
 });
 
+const profileDataAsObject = loadProfileData();
+const profileDataAsArrayWithSameAttributes = [...loadProfileDataArray(), ...loadProfileDataArray()]
+  .map((attr, index) => {
+    if (['selfie', 'document_images'].includes(attr.name)) {
+      return Object.assign({}, attr, { id: `${attr.name}-${index}` });
+    }
+    return attr;
+  });
+console.log('>>>>', profileDataAsArrayWithSameAttributes, '<<<< profileDataAsArrayWithSameAttributes');
+
 describe('Profile', () => {
   [
     {
       describe: 'When profile data is provided as Object keyed by attribute name',
-      profileData: loadProfileData(),
+      profileData: profileDataAsObject,
     },
     {
       describe: 'When profile data is provided as an Array (with attributes sharing names)',
       // (here each attribute are duplicated, so to check handling of several with the same name)
-      profileData: [...loadProfileDataArray(), ...loadProfileDataArray()],
+      profileData: profileDataAsArrayWithSameAttributes,
       profileDataAsArray: true,
     },
   ].forEach((testItem) => {
@@ -322,6 +332,24 @@ describe('Profile', () => {
           }
           expect(profileObj.getIdentityProfileReport().getValue())
             .toEqual(expectedSource.value);
+        });
+      });
+
+      describe('#getAttributeById', () => {
+        it('should return corresponding attributes', () => {
+          if (testItem.profileDataAsArray) {
+            const selfies = profileObj.getAttributesByName('selfie');
+            expect(selfies.length).toBe(2);
+            expect(selfies[0].getId()).not.toBe(selfies[1].getId());
+            expect(profileObj.getAttributeById(selfies[0].getId())).toBe(selfies[0]);
+            expect(profileObj.getAttributeById(selfies[1].getId())).toBe(selfies[1]);
+
+            const documentImages = profileObj.getAttributesByName('document_images');
+            expect(documentImages.length).toBe(2);
+            expect(documentImages[0].getId()).not.toBe(documentImages[1].getId());
+            expect(profileObj.getAttributeById(documentImages[0].getId())).toBe(documentImages[0]);
+            expect(profileObj.getAttributeById(documentImages[1].getId())).toBe(documentImages[1]);
+          }
         });
       });
     });

--- a/tests/proto-root/index.spec.js
+++ b/tests/proto-root/index.spec.js
@@ -1,0 +1,182 @@
+const ProtoBuf = require('protobufjs');
+const { initializeProtoBufObjects } = require('../../src/proto-root');
+
+function stringAttributeValueToByteBuffer(value) {
+  return ProtoBuf.ByteBuffer.fromUTF8(value);
+}
+
+describe('the proto-root', () => {
+  let protoRoot;
+
+  beforeAll(() => {
+    protoRoot = initializeProtoBufObjects();
+  });
+
+  describe('once initialised', () => {
+    it('should expose its proto definitions builder with registered definition namespaces', () => {
+      expect(protoRoot.builder.attrpubapi_v1).toBeDefined();
+      expect(protoRoot.builder.compubapi_v1).toBeDefined();
+      expect(protoRoot.builder.sharepubapi_v1).toBeDefined();
+    });
+
+    it('should expose commodity methods', () => {
+      expect(protoRoot.encodeAttributeList).toEqual(expect.any(Function));
+      expect(protoRoot.decodeAttributeList).toEqual(expect.any(Function));
+      //
+      expect(protoRoot.encodeEncryptedData).toEqual(expect.any(Function));
+      expect(protoRoot.decodeEncryptedData).toEqual(expect.any(Function));
+      //
+      expect(protoRoot.encodeSignedTimeStamp).toEqual(expect.any(Function));
+      expect(protoRoot.decodeSignedTimeStamp).toEqual(expect.any(Function));
+
+      expect(protoRoot.decodeExtraData).toEqual(expect.any(Function));
+      expect(protoRoot.decodeThirdPartyAttribute).toEqual(expect.any(Function));
+    });
+  });
+
+  describe('#decodeAttributeList()', () => {
+    describe('extracts and returns an array with attributes and the extendedProfile and extendedProfileList', () => {
+      let rawAttributesList;
+      let decodedAttrList;
+
+      beforeEach(() => {
+        rawAttributesList = [
+          {
+            name: 'name',
+            value: stringAttributeValueToByteBuffer('Bob'),
+            contentType: 1,
+          },
+          {
+            name: 'gender',
+            value: stringAttributeValueToByteBuffer('male'),
+            contentType: 1,
+          },
+        ];
+        const encodedAttrList = protoRoot.encodeAttributeList(rawAttributesList);
+        decodedAttrList = protoRoot.decodeAttributeList(encodedAttrList);
+      });
+
+      describe('where the first item ', () => {
+        it('should be the first attribute', () => {
+          const [firstItem] = decodedAttrList;
+          expect(firstItem).toEqual({ name: 'Bob' });
+        });
+      });
+
+      describe('where the second item ', () => {
+        it('should be the second attribute', () => {
+          const [, secondItem] = decodedAttrList;
+          expect(secondItem).toEqual({ gender: 'male' });
+        });
+      });
+
+      describe('where the before last item ', () => {
+        it('should be containing the extendedProfile', () => {
+          const [, , beforeLastItem] = decodedAttrList;
+          const { extendedProfile } = beforeLastItem;
+          expect(extendedProfile).toBeDefined();
+          expect(extendedProfile).toEqual({
+            name: expect.objectContaining({
+              name: 'name',
+              value: 'Bob',
+              sources: expect.any(Object),
+              verifiers: expect.any(Object),
+              anchors: expect.any(Object),
+            }),
+            gender: expect.objectContaining({
+              name: 'gender',
+              value: 'male',
+              sources: expect.any(Object),
+              verifiers: expect.any(Object),
+              anchors: expect.any(Object),
+            }),
+          });
+        });
+      });
+
+      describe('where the last item ', () => {
+        it('should be containing the extendedProfileList', () => {
+          const [, , , lastItem] = decodedAttrList;
+          const { extendedProfileList } = lastItem;
+          expect(extendedProfileList).toBeDefined();
+          expect(extendedProfileList).toEqual([
+            expect.objectContaining({
+              name: 'name',
+              value: 'Bob',
+              sources: expect.any(Object),
+              verifiers: expect.any(Object),
+              anchors: expect.any(Object),
+            }),
+            expect.objectContaining({
+              name: 'gender',
+              value: 'male',
+              sources: expect.any(Object),
+              verifiers: expect.any(Object),
+              anchors: expect.any(Object),
+            }),
+          ]);
+        });
+      });
+    });
+
+    describe('handles attribute\'s ephemeralId', () => {
+      let rawAttributesList;
+      let decodedAttrList;
+
+      beforeEach(() => {
+        rawAttributesList = [
+          {
+            name: 'name',
+            value: stringAttributeValueToByteBuffer('Bob1'),
+            contentType: 1,
+            ephemeralId: 'firstBob',
+          },
+          {
+            name: 'name',
+            value: stringAttributeValueToByteBuffer('Bob2'),
+            contentType: 1,
+            ephemeralId: 'secondBob',
+          },
+        ];
+        const encodedAttrList = protoRoot.encodeAttributeList(rawAttributesList);
+        decodedAttrList = protoRoot.decodeAttributeList(encodedAttrList);
+      });
+
+      it('should include an id (with the ephemeralId value)', () => {
+        const [
+          firstItem,
+          secondItem,
+          { extendedProfile },
+          { extendedProfileList },
+        ] = decodedAttrList;
+        expect(firstItem).toEqual({ name: 'Bob1' });
+        expect(secondItem).toEqual({ name: 'Bob2' });
+        expect(extendedProfile.name).toEqual({
+          name: 'name',
+          value: 'Bob2',
+          id: 'secondBob',
+          sources: expect.any(Object),
+          verifiers: expect.any(Object),
+          anchors: expect.any(Object),
+        });
+        expect(extendedProfileList.length).toBe(2);
+        expect(extendedProfileList[0]).toEqual({
+          name: 'name',
+          value: 'Bob1',
+          id: 'firstBob',
+          sources: expect.any(Object),
+          verifiers: expect.any(Object),
+          anchors: expect.any(Object),
+        });
+        expect(extendedProfileList[1]).toEqual({
+          name: 'name',
+          value: 'Bob2',
+          id: 'secondBob',
+          sources: expect.any(Object),
+          verifiers: expect.any(Object),
+          anchors: expect.any(Object),
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
Updated the Attribute so it assigns a field `id` if present within raw attribute data argument.
Added in BaseProfile the method getAttributeById()
Amended proto.attribute.list so the ephemeralId field from attribute proto is read and assign to the raw attribute id field.