### PR TITLE
SDK-2142 Surface error details in share receipt response

### DIFF
--- a/src/profile_service/activity.details.js
+++ b/src/profile_service/activity.details.js
@@ -146,8 +146,8 @@ class ActivityDetails {
     let errorDetails;
     if (responseErrorDetails) {
       errorDetails = {
-        errorCode: errorDetails.error_code,
-        description: errorDetails.description,
+        errorCode: responseErrorDetails.error_code,
+        description: responseErrorDetails.description,
       };
     }
     return errorDetails;

--- a/src/profile_service/activity.details.js
+++ b/src/profile_service/activity.details.js
@@ -142,14 +142,15 @@ class ActivityDetails {
 
   getErrorDetails() {
     // eslint-disable-next-line camelcase
-    const errorDetails = this.parsedResponse.error_details;
-    if (errorDetails) {
-      return {
+    const responseErrorDetails = this.parsedResponse.error_details;
+    let errorDetails;
+    if (responseErrorDetails) {
+      errorDetails = {
         errorCode: errorDetails.error_code,
         description: errorDetails.description,
       };
     }
-    return undefined;
+    return errorDetails;
   }
 
   /**

--- a/src/profile_service/activity.details.js
+++ b/src/profile_service/activity.details.js
@@ -140,6 +140,18 @@ class ActivityDetails {
     return this.receipt.sharing_outcome;
   }
 
+  getErrorDetails() {
+    // eslint-disable-next-line camelcase
+    const errorDetails = this.parsedResponse.error_details;
+    if (errorDetails) {
+      return {
+        errorCode: errorDetails.error_code,
+        description: errorDetails.description,
+      };
+    }
+    return undefined;
+  }
+
   /**
    * Base64 encoded selfie image.
    *

--- a/tests/profile_service/activity.details.spec.js
+++ b/tests/profile_service/activity.details.spec.js
@@ -130,6 +130,23 @@ describe('ActivityDetails', () => {
       expect(activityDetails.getOutcome()).toBe('test_outcome');
     });
   });
+  describe('#getErrorDetails', () => {
+    it('should return error_details value', () => {
+      const activityDetails = new ActivityDetails({
+        error_details: {
+          error_code: 'ERROR_CODE_FOR_SHARE',
+          description: 'Something terrible happened...users had no documents!',
+        },
+        receipt: {
+          sharing_outcome: 'NOT_SUCCESS',
+        },
+      });
+      expect(activityDetails.getErrorDetails()).toEqual({
+        errorCode: 'ERROR_CODE_FOR_SHARE',
+        description: 'Something terrible happened...users had no documents!',
+      });
+    });
+  });
   describe('#getBase64SelfieUri', () => {
     it('should return base64 encoded selfie uri', () => {
       const activityDetails = new ActivityDetails({}, [


### PR DESCRIPTION
Modified in profile_service activity.details.js, so it exposes a getErrorDetails() method, that returns an object corresponding to the 'error_details' from the response.

```javascript
// given a response with failure
{
  "session_data": { ... },
  "receipt": {
     sharing_outcome: "FAILURE"
   },
  "error_details": { 
    "error_code": "the-error-code-from-the-failure-receipt"
    "description": "some error desc"
  }
}

// usage:
const activityDetails = await getReceipt(token, pem, sdkId)
const outcome = activityDetails.getOutcome()
console.log(outcome) // FAILURE
const errorDetails = activityDetails.getErrorDetails()
console.log(errorDetails)
// {
//   errorCode: "the-error-code-from-the-failure-receipt"
//   description: "some error desc"
// }
```

