### PR TITLE
SDK-2181 remove unused base64 url

### DIFF
--- a/examples/aml-check/package-lock.json
+++ b/examples/aml-check/package-lock.json
@@ -24,20 +24,20 @@
       }
     },
     "../..": {
+      "name": "yoti",
       "version": "3.22.0",
       "license": "MIT",
       "dependencies": {
-        "base64-url": "2.2.1",
         "node-forge": "1.3.0",
         "protobufjs": "7.1.0",
-        "superagent": "4.1.0",
-        "uuid": "8.2.0"
+        "superagent": "8.0.0",
+        "uuid": "9.0.0"
       },
       "devDependencies": {
         "eslint": "8.23.0",
         "eslint-config-airbnb-base": "15.0.0",
         "eslint-plugin-import": "2.26.0",
-        "eslint-plugin-jest": "27.0.1",
+        "eslint-plugin-jest": "27.0.2",
         "eslint-plugin-node": "11.1.0",
         "husky": "8.0.1",
         "jest": "29.0.1",
@@ -4138,19 +4138,18 @@
     "yoti": {
       "version": "file:../..",
       "requires": {
-        "base64-url": "2.2.1",
         "eslint": "8.23.0",
         "eslint-config-airbnb-base": "15.0.0",
         "eslint-plugin-import": "2.26.0",
-        "eslint-plugin-jest": "27.0.1",
+        "eslint-plugin-jest": "27.0.2",
         "eslint-plugin-node": "11.1.0",
         "husky": "8.0.1",
         "jest": "29.0.1",
         "nock": "13.2.9",
         "node-forge": "1.3.0",
         "protobufjs": "7.1.0",
-        "superagent": "4.1.0",
-        "uuid": "8.2.0"
+        "superagent": "8.0.0",
+        "uuid": "9.0.0"
       }
     }
   }

--- a/examples/idv-identity-checks/package-lock.json
+++ b/examples/idv-identity-checks/package-lock.json
@@ -26,20 +26,20 @@
       }
     },
     "../..": {
+      "name": "yoti",
       "version": "3.22.0",
       "license": "MIT",
       "dependencies": {
-        "base64-url": "2.2.1",
         "node-forge": "1.3.0",
         "protobufjs": "7.1.0",
-        "superagent": "4.1.0",
-        "uuid": "8.2.0"
+        "superagent": "8.0.0",
+        "uuid": "9.0.0"
       },
       "devDependencies": {
         "eslint": "8.23.0",
         "eslint-config-airbnb-base": "15.0.0",
         "eslint-plugin-import": "2.26.0",
-        "eslint-plugin-jest": "27.0.1",
+        "eslint-plugin-jest": "27.0.2",
         "eslint-plugin-node": "11.1.0",
         "husky": "8.0.1",
         "jest": "29.0.1",
@@ -5289,19 +5289,18 @@
     "yoti": {
       "version": "file:../..",
       "requires": {
-        "base64-url": "2.2.1",
         "eslint": "8.23.0",
         "eslint-config-airbnb-base": "15.0.0",
         "eslint-plugin-import": "2.26.0",
-        "eslint-plugin-jest": "27.0.1",
+        "eslint-plugin-jest": "27.0.2",
         "eslint-plugin-node": "11.1.0",
         "husky": "8.0.1",
         "jest": "29.0.1",
         "nock": "13.2.9",
         "node-forge": "1.3.0",
         "protobufjs": "7.1.0",
-        "superagent": "4.1.0",
-        "uuid": "8.2.0"
+        "superagent": "8.0.0",
+        "uuid": "9.0.0"
       }
     }
   }

--- a/examples/idv/package-lock.json
+++ b/examples/idv/package-lock.json
@@ -27,20 +27,20 @@
       }
     },
     "../..": {
+      "name": "yoti",
       "version": "3.22.0",
       "license": "MIT",
       "dependencies": {
-        "base64-url": "2.2.1",
         "node-forge": "1.3.0",
         "protobufjs": "7.1.0",
-        "superagent": "4.1.0",
-        "uuid": "8.2.0"
+        "superagent": "8.0.0",
+        "uuid": "9.0.0"
       },
       "devDependencies": {
         "eslint": "8.23.0",
         "eslint-config-airbnb-base": "15.0.0",
         "eslint-plugin-import": "2.26.0",
-        "eslint-plugin-jest": "27.0.1",
+        "eslint-plugin-jest": "27.0.2",
         "eslint-plugin-node": "11.1.0",
         "husky": "8.0.1",
         "jest": "29.0.1",
@@ -5290,19 +5290,18 @@
     "yoti": {
       "version": "file:../..",
       "requires": {
-        "base64-url": "2.2.1",
         "eslint": "8.23.0",
         "eslint-config-airbnb-base": "15.0.0",
         "eslint-plugin-import": "2.26.0",
-        "eslint-plugin-jest": "27.0.1",
+        "eslint-plugin-jest": "27.0.2",
         "eslint-plugin-node": "11.1.0",
         "husky": "8.0.1",
         "jest": "29.0.1",
         "nock": "13.2.9",
         "node-forge": "1.3.0",
         "protobufjs": "7.1.0",
-        "superagent": "4.1.0",
-        "uuid": "8.2.0"
+        "superagent": "8.0.0",
+        "uuid": "9.0.0"
       }
     }
   }

--- a/examples/profile-identity-checks/package-lock.json
+++ b/examples/profile-identity-checks/package-lock.json
@@ -27,20 +27,20 @@
       }
     },
     "../..": {
+      "name": "yoti",
       "version": "3.22.0",
       "license": "MIT",
       "dependencies": {
-        "base64-url": "2.2.1",
         "node-forge": "1.3.0",
         "protobufjs": "7.1.0",
-        "superagent": "4.1.0",
-        "uuid": "8.2.0"
+        "superagent": "8.0.0",
+        "uuid": "9.0.0"
       },
       "devDependencies": {
         "eslint": "8.23.0",
         "eslint-config-airbnb-base": "15.0.0",
         "eslint-plugin-import": "2.26.0",
-        "eslint-plugin-jest": "27.0.1",
+        "eslint-plugin-jest": "27.0.2",
         "eslint-plugin-node": "11.1.0",
         "husky": "8.0.1",
         "jest": "29.0.1",
@@ -5197,19 +5197,18 @@
     "yoti": {
       "version": "file:../..",
       "requires": {
-        "base64-url": "2.2.1",
         "eslint": "8.23.0",
         "eslint-config-airbnb-base": "15.0.0",
         "eslint-plugin-import": "2.26.0",
-        "eslint-plugin-jest": "27.0.1",
+        "eslint-plugin-jest": "27.0.2",
         "eslint-plugin-node": "11.1.0",
         "husky": "8.0.1",
         "jest": "29.0.1",
         "nock": "13.2.9",
         "node-forge": "1.3.0",
         "protobufjs": "7.1.0",
-        "superagent": "4.1.0",
-        "uuid": "8.2.0"
+        "superagent": "8.0.0",
+        "uuid": "9.0.0"
       }
     }
   }

--- a/examples/profile/package-lock.json
+++ b/examples/profile/package-lock.json
@@ -27,20 +27,20 @@
       }
     },
     "../..": {
+      "name": "yoti",
       "version": "3.22.0",
       "license": "MIT",
       "dependencies": {
-        "base64-url": "2.2.1",
         "node-forge": "1.3.0",
         "protobufjs": "7.1.0",
-        "superagent": "4.1.0",
-        "uuid": "8.2.0"
+        "superagent": "8.0.0",
+        "uuid": "9.0.0"
       },
       "devDependencies": {
         "eslint": "8.23.0",
         "eslint-config-airbnb-base": "15.0.0",
         "eslint-plugin-import": "2.26.0",
-        "eslint-plugin-jest": "27.0.1",
+        "eslint-plugin-jest": "27.0.2",
         "eslint-plugin-node": "11.1.0",
         "husky": "8.0.1",
         "jest": "29.0.1",
@@ -5197,19 +5197,18 @@
     "yoti": {
       "version": "file:../..",
       "requires": {
-        "base64-url": "2.2.1",
         "eslint": "8.23.0",
         "eslint-config-airbnb-base": "15.0.0",
         "eslint-plugin-import": "2.26.0",
-        "eslint-plugin-jest": "27.0.1",
+        "eslint-plugin-jest": "27.0.2",
         "eslint-plugin-node": "11.1.0",
         "husky": "8.0.1",
         "jest": "29.0.1",
         "nock": "13.2.9",
         "node-forge": "1.3.0",
         "protobufjs": "7.1.0",
-        "superagent": "4.1.0",
-        "uuid": "8.2.0"
+        "superagent": "8.0.0",
+        "uuid": "9.0.0"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "3.22.0",
       "license": "MIT",
       "dependencies": {
-        "base64-url": "2.2.1",
         "node-forge": "1.3.0",
         "protobufjs": "7.1.0",
         "superagent": "8.0.0",
@@ -1767,14 +1766,6 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
-    },
-    "node_modules/base64-url": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-2.2.1.tgz",
-      "integrity": "sha512-RWaW1M7+pLUikK1bnGyiDe1oY2BKOtbS30Ua1pSAH41st59qDxi/XiggjVhHVPIejXY1eqJ21W3uxHtZpM6KQw==",
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -7179,11 +7170,6 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
-    },
-    "base64-url": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-2.2.1.tgz",
-      "integrity": "sha512-RWaW1M7+pLUikK1bnGyiDe1oY2BKOtbS30Ua1pSAH41st59qDxi/XiggjVhHVPIejXY1eqJ21W3uxHtZpM6KQw=="
     },
     "brace-expansion": {
       "version": "1.1.11",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "coverageDirectory": "./coverage"
   },
   "dependencies": {
-    "base64-url": "2.2.1",
     "node-forge": "1.3.0",
     "protobufjs": "7.1.0",
     "superagent": "8.0.0",


### PR DESCRIPTION
Uninstalled `base64-url` since it isn't used anywhere.
Updated examples `package-lock.json`.