### PR TITLE
SDK-2310 Add biometric consent flow

### DIFF
--- a/examples/idv/src/controllers/index.controller.js
+++ b/examples/idv/src/controllers/index.controller.js
@@ -135,6 +135,7 @@ async function createSession() {
         .withErrorUrl(`${config.YOTI_APP_BASE_URL}/error`)
         .withPrivacyPolicyUrl(`${config.YOTI_APP_BASE_URL}/privacy-policy`)
         .withAllowHandoff(true)
+        .withEarlyBiometricConsentFlow() // or withJustInTimeBiometricConsentFlow()
         .withIdDocumentTextExtractionGenericRetries(5)
         .withIdDocumentTextExtractionReclassificationRetries(5)
         .build()

--- a/src/idv_service/idv.constants.js
+++ b/src/idv_service/idv.constants.js
@@ -49,4 +49,6 @@ module.exports = Object.freeze({
   FUZZY: 'FUZZY',
   GENERIC: 'GENERIC',
   RECLASSIFICATION: 'RECLASSIFICATION',
+  EARLY: 'EARLY',
+  JUST_IN_TIME: 'JUST_IN_TIME',
 });

--- a/src/idv_service/session/create/sdk.config.builder.js
+++ b/src/idv_service/session/create/sdk.config.builder.js
@@ -152,6 +152,37 @@ class SdkConfigBuilder {
   }
 
   /**
+   * Sets the biometric consent flow to "EARLY"
+   *
+   * @returns {this}
+   */
+  withEarlyBiometricConsentFlow() {
+    return this.withBiometricConsentFlow(IDVConstants.EARLY);
+  }
+
+  /**
+   * Sets the biometric consent flow to "JUST_IN_TIME"
+   *
+   * @returns {this}
+   */
+  withJustInTimeBiometricConsentFlow() {
+    return this.withBiometricConsentFlow(IDVConstants.JUST_IN_TIME);
+  }
+
+  /**
+   * Sets the biometric consent flow
+   *
+   * @param {string} biometricConsentFlow the biometric consent flow
+   *
+   * @returns {this}
+   */
+  withBiometricConsentFlow(biometricConsentFlow) {
+    Validation.isString(biometricConsentFlow, 'biometricConsentFlow');
+    this.biometricConsentFlow = biometricConsentFlow;
+    return this;
+  }
+
+  /**
    * Sets whether mobile handoff is allowed, so the user can start a session on their desktop
    * and then switch to mobile to finish
    *
@@ -236,6 +267,7 @@ class SdkConfigBuilder {
       this.successUrl,
       this.errorUrl,
       this.privacyPolicyUrl,
+      this.biometricConsentFlow,
       this.allowHandoff,
       this.attemptsConfiguration
     );

--- a/src/idv_service/session/create/sdk.config.js
+++ b/src/idv_service/session/create/sdk.config.js
@@ -37,6 +37,7 @@ class SdkConfig {
     successUrl,
     errorUrl,
     privacyPolicyUrl,
+    biometricConsentFlow,
     allowHandoff,
     attemptsConfiguration
   ) {
@@ -67,6 +68,9 @@ class SdkConfig {
     Validation.isString(privacyPolicyUrl, 'privacyPolicyUrl', true);
     this.privacyPolicyUrl = privacyPolicyUrl;
 
+    Validation.isString(biometricConsentFlow, 'biometricConsentFlow', true);
+    this.biometricConsentFlow = biometricConsentFlow;
+
     Validation.isBoolean(allowHandoff, 'allowHandoff', true);
     this.allowHandoff = allowHandoff;
 
@@ -90,6 +94,7 @@ class SdkConfig {
       success_url: this.successUrl,
       error_url: this.errorUrl,
       privacy_policy_url: this.privacyPolicyUrl,
+      biometric_consent_flow: this.biometricConsentFlow,
       allow_handoff: this.allowHandoff,
       attempts_configuration: this.attemptsConfiguration,
     };

--- a/tests/idv_service/session/create/sdk.config.builder.test.js
+++ b/tests/idv_service/session/create/sdk.config.builder.test.js
@@ -14,6 +14,7 @@ describe('SdkConfigBuilder', () => {
       .withLocale('some-url')
       .withPresetIssuingCountry('some-country')
       .withPrivacyPolicyUrl('some-privacy-policy-url')
+      .withBiometricConsentFlow('some-flow')
       .withAllowHandoff(true)
       .build();
 
@@ -27,6 +28,7 @@ describe('SdkConfigBuilder', () => {
       success_url: 'some-success-url',
       error_url: 'some-error-url',
       privacy_policy_url: 'some-privacy-policy-url',
+      biometric_consent_flow: 'some-flow',
       allow_handoff: true,
     });
 
@@ -52,6 +54,30 @@ describe('SdkConfigBuilder', () => {
 
     const expectedJson = JSON.stringify({
       allowed_capture_methods: 'CAMERA',
+    });
+
+    expect(JSON.stringify(sdkConfig)).toBe(expectedJson);
+  });
+
+  it('should build SdkConfig with early biometric consent flow', () => {
+    const sdkConfig = new SdkConfigBuilder()
+      .withEarlyBiometricConsentFlow()
+      .build();
+
+    const expectedJson = JSON.stringify({
+      biometric_consent_flow: 'EARLY',
+    });
+
+    expect(JSON.stringify(sdkConfig)).toBe(expectedJson);
+  });
+
+  it('should build SdkConfig with just in time biometric consent flow', () => {
+    const sdkConfig = new SdkConfigBuilder()
+      .withJustInTimeBiometricConsentFlow()
+      .build();
+
+    const expectedJson = JSON.stringify({
+      biometric_consent_flow: 'JUST_IN_TIME',
     });
 
     expect(JSON.stringify(sdkConfig)).toBe(expectedJson);


### PR DESCRIPTION
Added `biometricConsentFlow` to the SDK config by using `withEarlyBiometricConsentFlow` or `withJustInTimeBiometricConsentFlow` methods.