### PR TITLE
SDK-2338 enabling expanded document fields

### DIFF
--- a/examples/idv/src/controllers/index.controller.js
+++ b/examples/idv/src/controllers/index.controller.js
@@ -116,6 +116,7 @@ async function createSession() {
       new RequestedTextExtractionTaskBuilder()
         .withManualCheckAlways()
         .withChipDataDesired()
+        .withCreateExpandedDocumentFields(true) // default is false
         .build()
     )
     .withRequestedTask(

--- a/src/idv_service/session/create/check/requested.watchlist.advanced.ca.config.js
+++ b/src/idv_service/session/create/check/requested.watchlist.advanced.ca.config.js
@@ -28,7 +28,7 @@ class RequestedWatchlistAdvancedCaConfig {
     Validation.isBoolean(removeDeceased, 'removeDeceased');
     this.removeDeceased = removeDeceased;
 
-    Validation.isBoolean(removeDeceased, 'shareUrl');
+    Validation.isBoolean(shareUrl, 'shareUrl');
     this.shareUrl = shareUrl;
 
     if (sources) {

--- a/src/idv_service/session/create/task/requested.text.extraction.config.js
+++ b/src/idv_service/session/create/task/requested.text.extraction.config.js
@@ -14,12 +14,15 @@ class RequestedTextExtractionConfig {
    * @param {string} chipData
    *   Describes the chip data requirement for each Task
    */
-  constructor(manualCheck, chipData) {
+  constructor(manualCheck, chipData, createExpandedDocumentFields) {
     Validation.isString(manualCheck, 'manualCheck');
     this.manualCheck = manualCheck;
 
     Validation.isString(chipData, 'chipData', true);
     this.chipData = chipData;
+
+    Validation.isBoolean(createExpandedDocumentFields, 'createExpandedDocumentFields', true);
+    this.createExpandedDocumentFields = createExpandedDocumentFields;
   }
 
   /**
@@ -29,6 +32,7 @@ class RequestedTextExtractionConfig {
     return {
       manual_check: this.manualCheck,
       chip_data: this.chipData,
+      create_expanded_document_fields: this.createExpandedDocumentFields,
     };
   }
 }

--- a/src/idv_service/session/create/task/requested.text.extraction.task.builder.js
+++ b/src/idv_service/session/create/task/requested.text.extraction.task.builder.js
@@ -58,6 +58,15 @@ class RequestedTextExtractionTaskBuilder {
   }
 
   /**
+   * @param {boolean} createExpandedDocumentFields boolean
+   * @returns {this}
+   */
+  withCreateExpandedDocumentFields(createExpandedDocumentFields) {
+    this.createExpandedDocumentFields = createExpandedDocumentFields;
+    return this;
+  }
+
+  /**
    * Builds a {@link RequestedTextExtractionTask} using the values supplied to the builder
    *
    * @returns {RequestedTextExtractionTask}
@@ -65,7 +74,11 @@ class RequestedTextExtractionTaskBuilder {
   build() {
     Validation.notNullOrEmpty(this.manualCheck, 'manualCheck');
 
-    const config = new RequestedTextExtractionConfig(this.manualCheck, this.chipData);
+    const config = new RequestedTextExtractionConfig(
+      this.manualCheck,
+      this.chipData,
+      this.createExpandedDocumentFields
+    );
     return new RequestedTextExtractionTask(config);
   }
 }

--- a/tests/idv_service/session/create/task/requested.text.extraction.task.builder.spec.js
+++ b/tests/idv_service/session/create/task/requested.text.extraction.task.builder.spec.js
@@ -79,4 +79,38 @@ describe('RequestedTextExtractionBuilder', () => {
 
     expect(JSON.stringify(task)).toBe(expectedJson);
   });
+
+  it('should build RequestedTextExtractionTask with create expanded document fields set to true', () => {
+    const expectedJson = JSON.stringify({
+      type: 'ID_DOCUMENT_TEXT_DATA_EXTRACTION',
+      config: {
+        manual_check: 'NEVER',
+        create_expanded_document_fields: true,
+      },
+    });
+
+    const task = new RequestedTextExtractionTaskBuilder()
+      .withManualCheckNever()
+      .withCreateExpandedDocumentFields(true)
+      .build();
+
+    expect(JSON.stringify(task)).toBe(expectedJson);
+  });
+
+  it('should build RequestedTextExtractionTask with create expanded document fields set to false', () => {
+    const expectedJson = JSON.stringify({
+      type: 'ID_DOCUMENT_TEXT_DATA_EXTRACTION',
+      config: {
+        manual_check: 'NEVER',
+        create_expanded_document_fields: false,
+      },
+    });
+
+    const task = new RequestedTextExtractionTaskBuilder()
+      .withManualCheckNever()
+      .withCreateExpandedDocumentFields(false)
+      .build();
+
+    expect(JSON.stringify(task)).toBe(expectedJson);
+  });
 });


### PR DESCRIPTION
Added `withCreateExpandedDocumentFields` method to set a boolean value for `createExpandedDocumentFields` for the `RequestedTextExtractionTask`.