### PR TITLE
SDK-2043 non latin docs support for session creation

### DIFF
--- a/src/idv_service/session/create/filters/document/document.restrictions.filter.builder.js
+++ b/src/idv_service/session/create/filters/document/document.restrictions.filter.builder.js
@@ -49,13 +49,24 @@ class DocumentRestrictionsFilterBuilder {
   }
 
   /**
+   * @param {Boolean} allowNonLatinDocuments
+   *
+   * @returns {this}
+   */
+  withAllowNonLatinDocuments(allowNonLatinDocuments) {
+    this.allowNonLatinDocuments = allowNonLatinDocuments;
+    return this;
+  }
+
+  /**
    * @returns {DocumentRestrictionsFilter}
    */
   build() {
     return new DocumentRestrictionsFilter(
       this.inclusion,
       this.documents,
-      this.allowExpiredDocuments
+      this.allowExpiredDocuments,
+      this.allowNonLatinDocuments
     );
   }
 }

--- a/src/idv_service/session/create/filters/document/document.restrictions.filter.js
+++ b/src/idv_service/session/create/filters/document/document.restrictions.filter.js
@@ -10,8 +10,9 @@ class DocumentRestrictionsFilter extends DocumentFilter {
    * @param {string} inclusion
    * @param {DocumentRestriction[]} documents
    * @param {Boolean} allowExpiredDocuments
+   * @param {Boolean} allowNonLatinDocuments
    */
-  constructor(inclusion, documents, allowExpiredDocuments) {
+  constructor(inclusion, documents, allowExpiredDocuments, allowNonLatinDocuments) {
     super(IDVConstants.DOCUMENT_RESTRICTIONS);
 
     Validation.isString(inclusion, 'inclusion');
@@ -22,6 +23,9 @@ class DocumentRestrictionsFilter extends DocumentFilter {
 
     Validation.isBoolean(allowExpiredDocuments, 'allowExpiredDocuments', true);
     this.allowExpiredDocuments = allowExpiredDocuments;
+
+    Validation.isBoolean(allowNonLatinDocuments, 'allowNonLatinDocuments', true);
+    this.allowNonLatinDocuments = allowNonLatinDocuments;
   }
 
   toJSON() {
@@ -30,6 +34,7 @@ class DocumentRestrictionsFilter extends DocumentFilter {
     json.inclusion = this.inclusion;
     json.documents = this.documents;
     json.allow_expired_documents = this.allowExpiredDocuments;
+    json.allow_non_latin_documents = this.allowNonLatinDocuments;
 
     return json;
   }

--- a/src/idv_service/session/create/filters/orthogonal/orthogonal.restrictions.filter.builder.js
+++ b/src/idv_service/session/create/filters/orthogonal/orthogonal.restrictions.filter.builder.js
@@ -8,6 +8,8 @@ const IDVConstants = require('../../../../idv.constants');
 class OrthogonalRestrictionsFilterBuilder {
   /**
    * @param {string[]} countryCodes
+   *
+   * @returns {this}
    */
   withWhitelistedCountries(countryCodes) {
     this.countryRestriction = new CountryRestriction(
@@ -19,6 +21,8 @@ class OrthogonalRestrictionsFilterBuilder {
 
   /**
    * @param {string[]} countryCodes
+   *
+   * @returns {this}
    */
   withBlacklistedCountries(countryCodes) {
     this.countryRestriction = new CountryRestriction(
@@ -30,6 +34,8 @@ class OrthogonalRestrictionsFilterBuilder {
 
   /**
    * @param {string[]} documentTypes
+   *
+   * @returns {this}
    */
   withWhitelistedDocumentTypes(documentTypes) {
     this.typeRestriction = new TypeRestriction(
@@ -41,6 +47,8 @@ class OrthogonalRestrictionsFilterBuilder {
 
   /**
    * @param {string[]} documentTypes
+   *
+   * @returns {this}
    */
   withBlacklistedDocumentTypes(documentTypes) {
     this.typeRestriction = new TypeRestriction(
@@ -61,13 +69,24 @@ class OrthogonalRestrictionsFilterBuilder {
   }
 
   /**
+   * @param {Boolean} allowNonLatinDocuments
+   *
+   * @returns {this}
+   */
+  withAllowNonLatinDocuments(allowNonLatinDocuments) {
+    this.allowNonLatinDocuments = allowNonLatinDocuments;
+    return this;
+  }
+
+  /**
    * @returns {OrthogonalRestrictionsFilter}
    */
   build() {
     return new OrthogonalRestrictionsFilter(
       this.countryRestriction,
       this.typeRestriction,
-      this.allowExpiredDocuments
+      this.allowExpiredDocuments,
+      this.allowNonLatinDocuments
     );
   }
 }

--- a/src/idv_service/session/create/filters/orthogonal/orthogonal.restrictions.filter.js
+++ b/src/idv_service/session/create/filters/orthogonal/orthogonal.restrictions.filter.js
@@ -11,8 +11,9 @@ class OrthogonalRestrictionsFilter extends DocumentFilter {
    * @param {CountryRestriction} countryRestriction
    * @param {TypeRestriction} typeRestriction
    * @param {Boolean} allowExpiredDocuments
+   * @param {Boolean} allowNonLatinDocuments
    */
-  constructor(countryRestriction, typeRestriction, allowExpiredDocuments) {
+  constructor(countryRestriction, typeRestriction, allowExpiredDocuments, allowNonLatinDocuments) {
     super(IDVConstants.ORTHOGONAL_RESTRICTIONS);
 
     if (countryRestriction) {
@@ -27,6 +28,9 @@ class OrthogonalRestrictionsFilter extends DocumentFilter {
 
     Validation.isBoolean(allowExpiredDocuments, 'allowExpiredDocuments', true);
     this.allowExpiredDocuments = allowExpiredDocuments;
+
+    Validation.isBoolean(allowNonLatinDocuments, 'allowNonLatinDocuments', true);
+    this.allowNonLatinDocuments = allowNonLatinDocuments;
   }
 
   toJSON() {
@@ -35,6 +39,7 @@ class OrthogonalRestrictionsFilter extends DocumentFilter {
     json.country_restriction = this.countryRestriction;
     json.type_restriction = this.typeRestriction;
     json.allow_expired_documents = this.allowExpiredDocuments;
+    json.allow_non_latin_documents = this.allowNonLatinDocuments;
 
     return json;
   }

--- a/tests/idv_service/session/create/filters/document/document.restrictions.filter.builder.spec.js
+++ b/tests/idv_service/session/create/filters/document/document.restrictions.filter.builder.spec.js
@@ -104,7 +104,7 @@ describe('DocumentRestrictionsFilterBuilder', () => {
   it('should build DocumentRestrictionsFilter with expired documents not allowed', () => {
     const documentRestrictionsFilter = new DocumentRestrictionsFilterBuilder()
       .forWhitelist()
-      .withAllowExpiredDocuments(false)
+      .withAllowExpiredDocuments(true)
       .build();
 
     expect(JSON.stringify(documentRestrictionsFilter))
@@ -112,7 +112,22 @@ describe('DocumentRestrictionsFilterBuilder', () => {
         type: 'DOCUMENT_RESTRICTIONS',
         inclusion: 'WHITELIST',
         documents: [],
-        allow_expired_documents: false,
+        allow_expired_documents: true,
+      }));
+  });
+
+  it('should build DocumentRestrictionsFilter with non latin documents allowed', () => {
+    const documentRestrictionsFilter = new DocumentRestrictionsFilterBuilder()
+      .forWhitelist()
+      .withAllowNonLatinDocuments(true)
+      .build();
+
+    expect(JSON.stringify(documentRestrictionsFilter))
+      .toBe(JSON.stringify({
+        type: 'DOCUMENT_RESTRICTIONS',
+        inclusion: 'WHITELIST',
+        documents: [],
+        allow_non_latin_documents: true,
       }));
   });
 });

--- a/tests/idv_service/session/create/filters/orthogonal/orthogonal.restrictions.filter.builder.spec.js
+++ b/tests/idv_service/session/create/filters/orthogonal/orthogonal.restrictions.filter.builder.spec.js
@@ -97,21 +97,15 @@ describe('OrthogonalRestrictionsFilterBuilder', () => {
       }));
   });
 
-  it('should build OrthogonalRestrictionsFilter with blacklisted document types', () => {
+  it('should build OrthogonalRestrictionsFilter with allow non latin documents', () => {
     const orthogonalRestrictionsFilter = new OrthogonalRestrictionsFilterBuilder()
-      .withBlacklistedDocumentTypes([SOME_DOCUMENT_TYPE, SOME_OTHER_DOCUMENT_TYPE])
+      .withAllowNonLatinDocuments()
       .build();
 
     expect(JSON.stringify(orthogonalRestrictionsFilter))
       .toBe(JSON.stringify({
         type: 'ORTHOGONAL_RESTRICTIONS',
-        type_restriction: {
-          inclusion: 'BLACKLIST',
-          document_types: [
-            SOME_DOCUMENT_TYPE,
-            SOME_OTHER_DOCUMENT_TYPE,
-          ],
-        },
+        allow_non_latin_documents: true,
       }));
   });
 

--- a/tests/idv_service/session/create/filters/orthogonal/orthogonal.restrictions.filter.builder.spec.js
+++ b/tests/idv_service/session/create/filters/orthogonal/orthogonal.restrictions.filter.builder.spec.js
@@ -115,18 +115,6 @@ describe('OrthogonalRestrictionsFilterBuilder', () => {
       }));
   });
 
-  it('should build OrthogonalRestrictionsFilter with allow non latin documents', () => {
-    const orthogonalRestrictionsFilter = new OrthogonalRestrictionsFilterBuilder()
-      .withAllowNonLatinDocuments()
-      .build();
-
-    expect(JSON.stringify(orthogonalRestrictionsFilter))
-      .toBe(JSON.stringify({
-        type: 'ORTHOGONAL_RESTRICTIONS',
-        allow_non_latin_documents: true,
-      }));
-  });
-
   it('should build OrthogonalRestrictionsFilter with expired document not allowed', () => {
     const orthogonalRestrictionsFilter = new OrthogonalRestrictionsFilterBuilder()
       .withBlacklistedDocumentTypes([SOME_DOCUMENT_TYPE, SOME_OTHER_DOCUMENT_TYPE])
@@ -144,6 +132,18 @@ describe('OrthogonalRestrictionsFilterBuilder', () => {
           ],
         },
         allow_expired_documents: false,
+      }));
+  });
+
+  it('should build OrthogonalRestrictionsFilter with allow non latin documents', () => {
+    const orthogonalRestrictionsFilter = new OrthogonalRestrictionsFilterBuilder()
+      .withAllowNonLatinDocuments(true)
+      .build();
+
+    expect(JSON.stringify(orthogonalRestrictionsFilter))
+      .toBe(JSON.stringify({
+        type: 'ORTHOGONAL_RESTRICTIONS',
+        allow_non_latin_documents: true,
       }));
   });
 });

--- a/tests/idv_service/session/create/filters/orthogonal/orthogonal.restrictions.filter.builder.spec.js
+++ b/tests/idv_service/session/create/filters/orthogonal/orthogonal.restrictions.filter.builder.spec.js
@@ -97,6 +97,24 @@ describe('OrthogonalRestrictionsFilterBuilder', () => {
       }));
   });
 
+  it('should build OrthogonalRestrictionsFilter with blacklisted document types', () => {
+    const orthogonalRestrictionsFilter = new OrthogonalRestrictionsFilterBuilder()
+      .withBlacklistedDocumentTypes([SOME_DOCUMENT_TYPE, SOME_OTHER_DOCUMENT_TYPE])
+      .build();
+
+    expect(JSON.stringify(orthogonalRestrictionsFilter))
+      .toBe(JSON.stringify({
+        type: 'ORTHOGONAL_RESTRICTIONS',
+        type_restriction: {
+          inclusion: 'BLACKLIST',
+          document_types: [
+            SOME_DOCUMENT_TYPE,
+            SOME_OTHER_DOCUMENT_TYPE,
+          ],
+        },
+      }));
+  });
+
   it('should build OrthogonalRestrictionsFilter with allow non latin documents', () => {
     const orthogonalRestrictionsFilter = new OrthogonalRestrictionsFilterBuilder()
       .withAllowNonLatinDocuments()


### PR DESCRIPTION
Added `withAllowNonLatinDocuments` for `OrthogonalRestrictionsFilterBuilder`.