### PR TITLE
SDK-2044 Expose is_strictly_latin property

### DIFF
--- a/src/idv_service/session/retrieve/configuration/capture/document/supported.document.response.js
+++ b/src/idv_service/session/retrieve/configuration/capture/document/supported.document.response.js
@@ -9,6 +9,8 @@ class SupportedDocumentResponse {
   constructor(supportedDocument) {
     Validation.isString(supportedDocument.type, 'type');
     this.type = supportedDocument.type;
+    Validation.isBoolean(supportedDocument.is_strictly_latin);
+    this.is_strictly_latin = supportedDocument.is_strictly_latin;
   }
 
   /**
@@ -18,6 +20,10 @@ class SupportedDocumentResponse {
    */
   getType() {
     return this.type;
+  }
+
+  getIsStrictlyLatin() {
+    return this.is_strictly_latin;
   }
 }
 

--- a/src/idv_service/session/retrieve/configuration/capture/document/supported.document.response.js
+++ b/src/idv_service/session/retrieve/configuration/capture/document/supported.document.response.js
@@ -9,7 +9,7 @@ class SupportedDocumentResponse {
   constructor(supportedDocument) {
     Validation.isString(supportedDocument.type, 'type');
     this.type = supportedDocument.type;
-    Validation.isBoolean(supportedDocument.is_strictly_latin);
+    Validation.isBoolean(supportedDocument.is_strictly_latin, 'is_strictly_latin');
     this.is_strictly_latin = supportedDocument.is_strictly_latin;
   }
 
@@ -22,6 +22,11 @@ class SupportedDocumentResponse {
     return this.type;
   }
 
+  /**
+   * Returns whether the document is strictly latin.
+   *
+   * @return {boolean}
+   */
   getIsStrictlyLatin() {
     return this.is_strictly_latin;
   }

--- a/tests/idv_service/session/retrieve/configuration/capture/document/supported.country.response.spec.js
+++ b/tests/idv_service/session/retrieve/configuration/capture/document/supported.country.response.spec.js
@@ -10,9 +10,11 @@ describe('SupportedCountryResponse', () => {
       supported_documents: [
         {
           type: 'DRIVING_LICENCE',
+          is_strictly_latin: true,
         },
         {
           type: 'PASSPORT',
+          is_strictly_latin: true,
         },
       ],
     });

--- a/tests/idv_service/session/retrieve/configuration/capture/document/supported.country.response.spec.js
+++ b/tests/idv_service/session/retrieve/configuration/capture/document/supported.country.response.spec.js
@@ -14,7 +14,7 @@ describe('SupportedCountryResponse', () => {
         },
         {
           type: 'PASSPORT',
-          is_strictly_latin: true,
+          is_strictly_latin: false,
         },
       ],
     });
@@ -29,9 +29,16 @@ describe('SupportedCountryResponse', () => {
   describe('#getSupportedDocuments', () => {
     it('should return requested tasks', () => {
       expect(supportedCountryResponse.getSupportedDocuments()).toHaveLength(2);
-      expect(
-        supportedCountryResponse.getSupportedDocuments()[0]
-      ).toBeInstanceOf(SupportedDocumentResponse);
+
+      const [firstResponse, secondResponse] = supportedCountryResponse.getSupportedDocuments();
+
+      expect(firstResponse).toBeInstanceOf(SupportedDocumentResponse);
+      expect(firstResponse.getType()).toBe('DRIVING_LICENCE');
+      expect(firstResponse.getIsStrictlyLatin()).toBe(true);
+
+      expect(secondResponse).toBeInstanceOf(SupportedDocumentResponse);
+      expect(secondResponse.getType()).toBe('PASSPORT');
+      expect(secondResponse.getIsStrictlyLatin()).toBe(false);
     });
   });
 });

--- a/tests/idv_service/session/retrieve/configuration/capture/document/supported.document.response.spec.js
+++ b/tests/idv_service/session/retrieve/configuration/capture/document/supported.document.response.spec.js
@@ -6,12 +6,19 @@ describe('SupportedDocumentResponse', () => {
   beforeEach(() => {
     supportedDocumentResponse = new SupportedDocumentResponse({
       type: 'DRIVING_LICENCE',
+      is_strictly_latin: true,
     });
   });
 
   describe('#getType', () => {
     it('should return code', () => {
       expect(supportedDocumentResponse.getType()).toBe('DRIVING_LICENCE');
+    });
+  });
+
+  describe('#getIsStrictlyLatin', () => {
+    it('should return boolean', () => {
+      expect(supportedDocumentResponse.getIsStrictlyLatin()).toBe(true);
     });
   });
 });


### PR DESCRIPTION
Expose `is_strictly_latin` property in the supported documents of the session configuration.