### PR TITLE
SDK-2027 non latin documents support

### DIFF
--- a/examples/idv/src/controllers/use-cases/allow.non.latin.document.check.controller.js
+++ b/examples/idv/src/controllers/use-cases/allow.non.latin.document.check.controller.js
@@ -39,8 +39,8 @@ async function createSession() {
       (new RequiredIdDocumentBuilder())
         .withFilter(
           (new OrthogonalRestrictionsFilterBuilder())
-            .withWhitelistedDocumentTypes(['PASSPORT'])
-            .withAllowExpiredDocuments(true)
+            .withWhitelistedDocumentTypes(['DRIVING_LICENCE'])
+            .withAllowNonLatinDocuments(true)
             .build()
         )
         .build()
@@ -51,10 +51,10 @@ async function createSession() {
     //     .withFilter(
     //       (new DocumentRestrictionsFilterBuilder())
     //         .withDocumentRestriction((new DocumentRestrictionBuilder())
-    //           .withDocumentTypes(['PASSPORT'])
+    //           .withDocumentTypes(['DRIVING_LICENCE'])
     //           .build())
     //         .forWhitelist()
-    //         .withAllowExpiredDocuments(true)
+    //         .withAllowNonLatinDocuments(true)
     //         .build()
     //     )
     //     .build()
@@ -72,6 +72,34 @@ async function createSession() {
 
   return idvClient.createSession(sessionSpec);
 }
+
+// async function getListOfAllowedNonLatinDocuments() {
+//   const idvClient = new IDVClient(config.YOTI_CLIENT_SDK_ID, config.YOTI_PEM);
+//   const supportedDocumentsResponse = await idvClient.getSupportedDocuments(true);
+//
+//   console.log('\nThe list of allowed non Latin documents: \n');
+//   supportedDocumentsResponse.getSupportedCountries().forEach((supportedCountry) => {
+//     supportedCountry.getSupportedDocuments()
+//       .filter((supportedDoc) => !supportedDoc.getIsStrictlyLatin())
+//       .forEach((supportedDoc) => {
+//         console.log(`${supportedDoc.getType()} of ${supportedCountry.getCode()}`);
+//       });
+//   });
+// }
+//
+// async function getListOfStrictlyLatinDocuments() {
+//   const idvClient = new IDVClient(config.YOTI_CLIENT_SDK_ID, config.YOTI_PEM);
+//   const supportedDocumentsResponse = await idvClient.getSupportedDocuments(true);
+//
+//   console.log('\nThe list of strictly Latin documents: \n');
+//   supportedDocumentsResponse.getSupportedCountries().forEach((supportedCountry) => {
+//     supportedCountry.getSupportedDocuments()
+//       .filter((supportedDoc) => supportedDoc.getIsStrictlyLatin())
+//       .forEach((supportedDoc) => {
+//         console.log(`${supportedDoc.getType()} of ${supportedCountry.getCode()}`);
+//       });
+//   });
+// }
 
 module.exports = async (req, res) => {
   try {

--- a/examples/idv/src/controllers/use-cases/index.js
+++ b/examples/idv/src/controllers/use-cases/index.js
@@ -1,5 +1,6 @@
 const authenticityAndIdentityCheckController = require('./authenticity.and.identity.check.controller');
 const documentComparisonCheckController = require('./document.comparison.check.controller');
+const allowNonLatinDocumentCheckController = require('./allow.non.latin.document.check.controller');
 const allowExpiredDocumentCheckController = require('./allow.expired.document.check.controller');
 const faceComparisonCheckController = require('./face.comparison.check.controller');
 const faceMatchCheckController = require('./face.match.check.controller');
@@ -8,6 +9,7 @@ const watchlistCheckController = require('./watchlist.check.controller');
 module.exports = {
   authenticityAndIdentityCheckController,
   documentComparisonCheckController,
+  allowNonLatinDocumentCheckController,
   allowExpiredDocumentCheckController,
   faceComparisonCheckController,
   faceMatchCheckController,

--- a/examples/idv/src/routes/use-cases-router.js
+++ b/examples/idv/src/routes/use-cases-router.js
@@ -10,6 +10,7 @@ const {
   authenticityAndIdentityCheckController,
   documentComparisonCheckController,
   allowExpiredDocumentCheckController,
+  allowNonLatinDocumentCheckController,
   faceComparisonCheckController,
   faceMatchCheckController,
   watchlistCheckController,
@@ -18,6 +19,7 @@ const {
 const caseIdToControllerMapping = {
   [Cases.DOCUMENT_AUTHENTICITY_AND_IDENTITY]: authenticityAndIdentityCheckController,
   [Cases.DOCUMENT_COMPARISON]: documentComparisonCheckController,
+  [Cases.AllOW_NON_LATIN_DOCUMENT]: allowNonLatinDocumentCheckController,
   [Cases.AllOW_EXPIRED_DOCUMENT]: allowExpiredDocumentCheckController,
   [Cases.FACE_COMPARISON]: faceComparisonCheckController,
   [Cases.FACE_MATCH]: faceMatchCheckController,

--- a/examples/idv/src/useCases.js
+++ b/examples/idv/src/useCases.js
@@ -1,6 +1,7 @@
 const Cases = {
   DOCUMENT_AUTHENTICITY_AND_IDENTITY: 'documentAuthenticityAndIdentity',
   DOCUMENT_COMPARISON: 'documentComparison',
+  AllOW_NON_LATIN_DOCUMENT: 'allowNonLatinDocument',
   AllOW_EXPIRED_DOCUMENT: 'allowExpiredDocument',
   FACE_COMPARISON: 'faceComparison',
   FACE_MATCH: 'faceMatch',
@@ -15,6 +16,10 @@ const CasesMap = new Map([
   [Cases.DOCUMENT_COMPARISON, {
     name: 'Document comparison check',
     path: '/document-comparison-check',
+  }],
+  [Cases.AllOW_NON_LATIN_DOCUMENT, {
+    name: 'Allow non Latin document',
+    path: '/allow-non-latin-document',
   }],
   [Cases.AllOW_EXPIRED_DOCUMENT, {
     name: 'Allow expired document',

--- a/src/client/idv.client.js
+++ b/src/client/idv.client.js
@@ -87,10 +87,12 @@ class IDVClient {
   /**
    * Gets a list of supported documents.
    *
+   * @param {boolean} includeNonLatin
+   *
    * @returns {Promise<SupportedDocumentsResponse>}
    */
-  getSupportedDocuments() {
-    return this.idvService.getSupportedDocuments();
+  getSupportedDocuments(includeNonLatin) {
+    return this.idvService.getSupportedDocuments(includeNonLatin);
   }
 
   /**

--- a/src/idv_service/idv.service.js
+++ b/src/idv_service/idv.service.js
@@ -216,15 +216,22 @@ class IDVService {
   /**
    * Gets a list of supported documents.
    *
+   * @param {boolean} includeNonLatin
+   *
    * @returns {Promise<SupportedDocumentsResponse>}
    */
-  getSupportedDocuments() {
-    const request = new RequestBuilder()
+  getSupportedDocuments(includeNonLatin) {
+    const requestBuilder = new RequestBuilder()
       .withPemString(this.pem)
       .withBaseUrl(this.apiUrl)
       .withEndpoint('/supported-documents')
-      .withGet()
-      .build();
+      .withGet();
+
+    if (includeNonLatin) {
+      requestBuilder.withQueryParam('includeNonLatin', true);
+    }
+
+    const request = requestBuilder.build();
 
     return new Promise((resolve, reject) => {
       request.execute()

--- a/src/idv_service/session/create/filters/document/document.restrictions.filter.builder.js
+++ b/src/idv_service/session/create/filters/document/document.restrictions.filter.builder.js
@@ -49,13 +49,24 @@ class DocumentRestrictionsFilterBuilder {
   }
 
   /**
+   * @param {Boolean} allowNonLatinDocuments
+   *
+   * @returns {this}
+   */
+  withAllowNonLatinDocuments(allowNonLatinDocuments) {
+    this.allowNonLatinDocuments = allowNonLatinDocuments;
+    return this;
+  }
+
+  /**
    * @returns {DocumentRestrictionsFilter}
    */
   build() {
     return new DocumentRestrictionsFilter(
       this.inclusion,
       this.documents,
-      this.allowExpiredDocuments
+      this.allowExpiredDocuments,
+      this.allowNonLatinDocuments
     );
   }
 }

--- a/src/idv_service/session/create/filters/document/document.restrictions.filter.js
+++ b/src/idv_service/session/create/filters/document/document.restrictions.filter.js
@@ -10,8 +10,9 @@ class DocumentRestrictionsFilter extends DocumentFilter {
    * @param {string} inclusion
    * @param {DocumentRestriction[]} documents
    * @param {Boolean} allowExpiredDocuments
+   * @param {Boolean} allowNonLatinDocuments
    */
-  constructor(inclusion, documents, allowExpiredDocuments) {
+  constructor(inclusion, documents, allowExpiredDocuments, allowNonLatinDocuments) {
     super(IDVConstants.DOCUMENT_RESTRICTIONS);
 
     Validation.isString(inclusion, 'inclusion');
@@ -22,6 +23,9 @@ class DocumentRestrictionsFilter extends DocumentFilter {
 
     Validation.isBoolean(allowExpiredDocuments, 'allowExpiredDocuments', true);
     this.allowExpiredDocuments = allowExpiredDocuments;
+
+    Validation.isBoolean(allowNonLatinDocuments, 'allowNonLatinDocuments', true);
+    this.allowNonLatinDocuments = allowNonLatinDocuments;
   }
 
   toJSON() {
@@ -30,6 +34,7 @@ class DocumentRestrictionsFilter extends DocumentFilter {
     json.inclusion = this.inclusion;
     json.documents = this.documents;
     json.allow_expired_documents = this.allowExpiredDocuments;
+    json.allow_non_latin_documents = this.allowNonLatinDocuments;
 
     return json;
   }

--- a/src/idv_service/session/create/filters/orthogonal/orthogonal.restrictions.filter.builder.js
+++ b/src/idv_service/session/create/filters/orthogonal/orthogonal.restrictions.filter.builder.js
@@ -8,6 +8,8 @@ const IDVConstants = require('../../../../idv.constants');
 class OrthogonalRestrictionsFilterBuilder {
   /**
    * @param {string[]} countryCodes
+   *
+   * @returns {this}
    */
   withWhitelistedCountries(countryCodes) {
     this.countryRestriction = new CountryRestriction(
@@ -19,6 +21,8 @@ class OrthogonalRestrictionsFilterBuilder {
 
   /**
    * @param {string[]} countryCodes
+   *
+   * @returns {this}
    */
   withBlacklistedCountries(countryCodes) {
     this.countryRestriction = new CountryRestriction(
@@ -30,6 +34,8 @@ class OrthogonalRestrictionsFilterBuilder {
 
   /**
    * @param {string[]} documentTypes
+   *
+   * @returns {this}
    */
   withWhitelistedDocumentTypes(documentTypes) {
     this.typeRestriction = new TypeRestriction(
@@ -41,6 +47,8 @@ class OrthogonalRestrictionsFilterBuilder {
 
   /**
    * @param {string[]} documentTypes
+   *
+   * @returns {this}
    */
   withBlacklistedDocumentTypes(documentTypes) {
     this.typeRestriction = new TypeRestriction(
@@ -61,13 +69,24 @@ class OrthogonalRestrictionsFilterBuilder {
   }
 
   /**
+   * @param {Boolean} allowNonLatinDocuments
+   *
+   * @returns {this}
+   */
+  withAllowNonLatinDocuments(allowNonLatinDocuments) {
+    this.allowNonLatinDocuments = allowNonLatinDocuments;
+    return this;
+  }
+
+  /**
    * @returns {OrthogonalRestrictionsFilter}
    */
   build() {
     return new OrthogonalRestrictionsFilter(
       this.countryRestriction,
       this.typeRestriction,
-      this.allowExpiredDocuments
+      this.allowExpiredDocuments,
+      this.allowNonLatinDocuments
     );
   }
 }

--- a/src/idv_service/session/create/filters/orthogonal/orthogonal.restrictions.filter.js
+++ b/src/idv_service/session/create/filters/orthogonal/orthogonal.restrictions.filter.js
@@ -11,8 +11,9 @@ class OrthogonalRestrictionsFilter extends DocumentFilter {
    * @param {CountryRestriction} countryRestriction
    * @param {TypeRestriction} typeRestriction
    * @param {Boolean} allowExpiredDocuments
+   * @param {Boolean} allowNonLatinDocuments
    */
-  constructor(countryRestriction, typeRestriction, allowExpiredDocuments) {
+  constructor(countryRestriction, typeRestriction, allowExpiredDocuments, allowNonLatinDocuments) {
     super(IDVConstants.ORTHOGONAL_RESTRICTIONS);
 
     if (countryRestriction) {
@@ -27,6 +28,9 @@ class OrthogonalRestrictionsFilter extends DocumentFilter {
 
     Validation.isBoolean(allowExpiredDocuments, 'allowExpiredDocuments', true);
     this.allowExpiredDocuments = allowExpiredDocuments;
+
+    Validation.isBoolean(allowNonLatinDocuments, 'allowNonLatinDocuments', true);
+    this.allowNonLatinDocuments = allowNonLatinDocuments;
   }
 
   toJSON() {
@@ -35,6 +39,7 @@ class OrthogonalRestrictionsFilter extends DocumentFilter {
     json.country_restriction = this.countryRestriction;
     json.type_restriction = this.typeRestriction;
     json.allow_expired_documents = this.allowExpiredDocuments;
+    json.allow_non_latin_documents = this.allowNonLatinDocuments;
 
     return json;
   }

--- a/src/idv_service/session/retrieve/configuration/capture/document/supported.document.response.js
+++ b/src/idv_service/session/retrieve/configuration/capture/document/supported.document.response.js
@@ -9,6 +9,8 @@ class SupportedDocumentResponse {
   constructor(supportedDocument) {
     Validation.isString(supportedDocument.type, 'type');
     this.type = supportedDocument.type;
+    Validation.isBoolean(supportedDocument.is_strictly_latin, 'is_strictly_latin');
+    this.is_strictly_latin = supportedDocument.is_strictly_latin;
   }
 
   /**
@@ -18,6 +20,15 @@ class SupportedDocumentResponse {
    */
   getType() {
     return this.type;
+  }
+
+  /**
+   * Returns whether the document is strictly latin.
+   *
+   * @return {boolean}
+   */
+  getIsStrictlyLatin() {
+    return this.is_strictly_latin;
   }
 }
 

--- a/src/idv_service/session/retrieve/configuration/capture/document/supported.document.response.js
+++ b/src/idv_service/session/retrieve/configuration/capture/document/supported.document.response.js
@@ -9,8 +9,6 @@ class SupportedDocumentResponse {
   constructor(supportedDocument) {
     Validation.isString(supportedDocument.type, 'type');
     this.type = supportedDocument.type;
-    Validation.isBoolean(supportedDocument.is_strictly_latin, 'is_strictly_latin');
-    this.is_strictly_latin = supportedDocument.is_strictly_latin;
   }
 
   /**
@@ -20,15 +18,6 @@ class SupportedDocumentResponse {
    */
   getType() {
     return this.type;
-  }
-
-  /**
-   * Returns whether the document is strictly latin.
-   *
-   * @return {boolean}
-   */
-  getIsStrictlyLatin() {
-    return this.is_strictly_latin;
   }
 }
 

--- a/src/idv_service/support/supported.document.js
+++ b/src/idv_service/support/supported.document.js
@@ -7,16 +7,22 @@ class SupportedDocument {
     Validation.isString(document.type, 'type', true);
     this.type = document.type;
 
-    if (document.is_strictly_latin !== undefined) {
-      Validation.isBoolean(document.is_strictly_latin);
-      this.isStrictlyLatin = document.is_strictly_latin;
-    }
+    Validation.isBoolean(document.is_strictly_latin, 'is_strictly_latin', true);
+    this.isStrictlyLatin = document.is_strictly_latin;
   }
 
+  /**
+   *
+   * @return {string|undefined}
+   */
   getType() {
     return this.type;
   }
 
+  /**
+   *
+   * @return {boolean|undefined}
+   */
   getIsStrictlyLatin() {
     return this.isStrictlyLatin;
   }

--- a/src/idv_service/support/supported.document.js
+++ b/src/idv_service/support/supported.document.js
@@ -6,10 +6,19 @@ class SupportedDocument {
   constructor(document) {
     Validation.isString(document.type, 'type', true);
     this.type = document.type;
+
+    if (document.is_strictly_latin !== undefined) {
+      Validation.isBoolean(document.is_strictly_latin);
+      this.isStrictlyLatin = document.is_strictly_latin;
+    }
   }
 
   getType() {
     return this.type;
+  }
+
+  getIsStrictlyLatin() {
+    return this.isStrictlyLatin;
   }
 }
 

--- a/tests/client/idv.client.spec.js
+++ b/tests/client/idv.client.spec.js
@@ -11,6 +11,7 @@ const {
   UploadFaceCaptureImagePayloadBuilder,
 } = require('../..');
 
+const { IDVService } = require('../../src/idv_service');
 const CreateSessionResult = require('../../src/idv_service/session/create/create.session.result');
 const GetSessionResult = require('../../src/idv_service/session/retrieve/get.session.result');
 const Media = require('../../src/data_type/media');
@@ -191,11 +192,18 @@ describe.each([
         .reply(responseStatusCode, responseBody);
     };
 
-    describe('when a valid response is returned', () => {
-      beforeEach(() => {
-        setupResponse(JSON.stringify({}));
-      });
+    let spyOnIDVServiceRelatedMethod;
 
+    beforeEach(() => {
+      setupResponse(JSON.stringify({}));
+      spyOnIDVServiceRelatedMethod = jest.spyOn(IDVService.prototype, 'getSupportedDocuments');
+    });
+
+    afterEach(() => {
+      spyOnIDVServiceRelatedMethod.mockRestore();
+    });
+
+    describe('when a valid response is returned', () => {
       it('should return SupportedDocumentResponse', (done) => {
         idvClient
           .getSupportedDocuments()
@@ -204,6 +212,22 @@ describe.each([
             done();
           })
           .catch(done);
+        expect(spyOnIDVServiceRelatedMethod).toHaveBeenCalledTimes(1);
+        expect(spyOnIDVServiceRelatedMethod).not.toHaveBeenCalledWith(true);
+      });
+    });
+
+    describe('when includeNonLatin is passed', () => {
+      it('should return SupportedDocumentResponse', (done) => {
+        idvClient
+          .getSupportedDocuments(true)
+          .then((result) => {
+            expect(result).toBeInstanceOf(SupportedDocumentResponse);
+            done();
+          })
+          .catch(done);
+        expect(spyOnIDVServiceRelatedMethod).toHaveBeenCalledTimes(1);
+        expect(spyOnIDVServiceRelatedMethod).toHaveBeenCalledWith(true);
       });
     });
   });

--- a/tests/idv_service/idv.service.spec.js
+++ b/tests/idv_service/idv.service.spec.js
@@ -419,6 +419,22 @@ describe('IDVService', () => {
           .catch(done);
       });
     });
+    describe('when includeNonLatin is passed', () => {
+      it('should return SupportedDocumentResponse', (done) => {
+        nock(config.yoti.idvApi)
+          .get(SUPPORTED_DOCUMENTS_URI)
+          .query((queryParams) => queryParams.includeNonLatin === 'true')
+          .reply(200, '{}');
+
+        idvService
+          .getSupportedDocuments(true)
+          .then((result) => {
+            expect(result).toBeInstanceOf(SupportedDocumentResponse);
+            done();
+          })
+          .catch(done);
+      });
+    });
     describe('when response code is invalid', () => {
       it('should reject', (done) => {
         nock(config.yoti.idvApi)

--- a/tests/idv_service/session/create/filters/document/document.restrictions.filter.builder.spec.js
+++ b/tests/idv_service/session/create/filters/document/document.restrictions.filter.builder.spec.js
@@ -104,7 +104,7 @@ describe('DocumentRestrictionsFilterBuilder', () => {
   it('should build DocumentRestrictionsFilter with expired documents not allowed', () => {
     const documentRestrictionsFilter = new DocumentRestrictionsFilterBuilder()
       .forWhitelist()
-      .withAllowExpiredDocuments(false)
+      .withAllowExpiredDocuments(true)
       .build();
 
     expect(JSON.stringify(documentRestrictionsFilter))
@@ -112,7 +112,22 @@ describe('DocumentRestrictionsFilterBuilder', () => {
         type: 'DOCUMENT_RESTRICTIONS',
         inclusion: 'WHITELIST',
         documents: [],
-        allow_expired_documents: false,
+        allow_expired_documents: true,
+      }));
+  });
+
+  it('should build DocumentRestrictionsFilter with non latin documents allowed', () => {
+    const documentRestrictionsFilter = new DocumentRestrictionsFilterBuilder()
+      .forWhitelist()
+      .withAllowNonLatinDocuments(true)
+      .build();
+
+    expect(JSON.stringify(documentRestrictionsFilter))
+      .toBe(JSON.stringify({
+        type: 'DOCUMENT_RESTRICTIONS',
+        inclusion: 'WHITELIST',
+        documents: [],
+        allow_non_latin_documents: true,
       }));
   });
 });

--- a/tests/idv_service/session/create/filters/orthogonal/orthogonal.restrictions.filter.builder.spec.js
+++ b/tests/idv_service/session/create/filters/orthogonal/orthogonal.restrictions.filter.builder.spec.js
@@ -134,4 +134,16 @@ describe('OrthogonalRestrictionsFilterBuilder', () => {
         allow_expired_documents: false,
       }));
   });
+
+  it('should build OrthogonalRestrictionsFilter with allow non latin documents', () => {
+    const orthogonalRestrictionsFilter = new OrthogonalRestrictionsFilterBuilder()
+      .withAllowNonLatinDocuments(true)
+      .build();
+
+    expect(JSON.stringify(orthogonalRestrictionsFilter))
+      .toBe(JSON.stringify({
+        type: 'ORTHOGONAL_RESTRICTIONS',
+        allow_non_latin_documents: true,
+      }));
+  });
 });

--- a/tests/idv_service/session/retrieve/configuration/capture/document/supported.country.response.spec.js
+++ b/tests/idv_service/session/retrieve/configuration/capture/document/supported.country.response.spec.js
@@ -10,11 +10,9 @@ describe('SupportedCountryResponse', () => {
       supported_documents: [
         {
           type: 'DRIVING_LICENCE',
-          is_strictly_latin: true,
         },
         {
           type: 'PASSPORT',
-          is_strictly_latin: false,
         },
       ],
     });
@@ -34,11 +32,9 @@ describe('SupportedCountryResponse', () => {
 
       expect(firstResponse).toBeInstanceOf(SupportedDocumentResponse);
       expect(firstResponse.getType()).toBe('DRIVING_LICENCE');
-      expect(firstResponse.getIsStrictlyLatin()).toBe(true);
 
       expect(secondResponse).toBeInstanceOf(SupportedDocumentResponse);
       expect(secondResponse.getType()).toBe('PASSPORT');
-      expect(secondResponse.getIsStrictlyLatin()).toBe(false);
     });
   });
 });

--- a/tests/idv_service/session/retrieve/configuration/capture/document/supported.country.response.spec.js
+++ b/tests/idv_service/session/retrieve/configuration/capture/document/supported.country.response.spec.js
@@ -10,9 +10,11 @@ describe('SupportedCountryResponse', () => {
       supported_documents: [
         {
           type: 'DRIVING_LICENCE',
+          is_strictly_latin: true,
         },
         {
           type: 'PASSPORT',
+          is_strictly_latin: false,
         },
       ],
     });
@@ -27,9 +29,16 @@ describe('SupportedCountryResponse', () => {
   describe('#getSupportedDocuments', () => {
     it('should return requested tasks', () => {
       expect(supportedCountryResponse.getSupportedDocuments()).toHaveLength(2);
-      expect(
-        supportedCountryResponse.getSupportedDocuments()[0]
-      ).toBeInstanceOf(SupportedDocumentResponse);
+
+      const [firstResponse, secondResponse] = supportedCountryResponse.getSupportedDocuments();
+
+      expect(firstResponse).toBeInstanceOf(SupportedDocumentResponse);
+      expect(firstResponse.getType()).toBe('DRIVING_LICENCE');
+      expect(firstResponse.getIsStrictlyLatin()).toBe(true);
+
+      expect(secondResponse).toBeInstanceOf(SupportedDocumentResponse);
+      expect(secondResponse.getType()).toBe('PASSPORT');
+      expect(secondResponse.getIsStrictlyLatin()).toBe(false);
     });
   });
 });

--- a/tests/idv_service/session/retrieve/configuration/capture/document/supported.document.response.spec.js
+++ b/tests/idv_service/session/retrieve/configuration/capture/document/supported.document.response.spec.js
@@ -6,19 +6,12 @@ describe('SupportedDocumentResponse', () => {
   beforeEach(() => {
     supportedDocumentResponse = new SupportedDocumentResponse({
       type: 'DRIVING_LICENCE',
-      is_strictly_latin: true,
     });
   });
 
   describe('#getType', () => {
     it('should return code', () => {
       expect(supportedDocumentResponse.getType()).toBe('DRIVING_LICENCE');
-    });
-  });
-
-  describe('#getIsStrictlyLatin', () => {
-    it('should return boolean', () => {
-      expect(supportedDocumentResponse.getIsStrictlyLatin()).toBe(true);
     });
   });
 });

--- a/tests/idv_service/session/retrieve/configuration/capture/document/supported.document.response.spec.js
+++ b/tests/idv_service/session/retrieve/configuration/capture/document/supported.document.response.spec.js
@@ -6,12 +6,19 @@ describe('SupportedDocumentResponse', () => {
   beforeEach(() => {
     supportedDocumentResponse = new SupportedDocumentResponse({
       type: 'DRIVING_LICENCE',
+      is_strictly_latin: true,
     });
   });
 
   describe('#getType', () => {
     it('should return code', () => {
       expect(supportedDocumentResponse.getType()).toBe('DRIVING_LICENCE');
+    });
+  });
+
+  describe('#getIsStrictlyLatin', () => {
+    it('should return boolean', () => {
+      expect(supportedDocumentResponse.getIsStrictlyLatin()).toBe(true);
     });
   });
 });

--- a/tests/idv_service/support/supported.documents.response.spec.js
+++ b/tests/idv_service/support/supported.documents.response.spec.js
@@ -66,4 +66,39 @@ describe('SupportedDocumentsResponse', () => {
 
     expect(supportedCountries).toHaveLength(0);
   });
+
+  it('parses response into list of supported countries with is_strictly_latin', () => {
+    const supportedDocumentsResponse = new SupportedDocumentsResponse({
+      supported_countries: [
+        {
+          code: SOME_COUNTRY_CODE,
+          supported_documents: [
+            {
+              type: SOME_DOCUMENT_TYPE,
+              is_strictly_latin: true,
+            },
+          ],
+        },
+        {
+          code: SOME_OTHER_COUNTRY_CODE,
+          supported_documents: [
+            {
+              type: SOME_DOCUMENT_TYPE,
+              is_strictly_latin: true,
+            },
+            {
+              type: SOME_OTHER_DOCUMENT_TYPE,
+              is_strictly_latin: false,
+            },
+          ],
+        },
+      ],
+    });
+
+    const supportedCountries = supportedDocumentsResponse.getSupportedCountries();
+
+    expect(supportedCountries[0].getSupportedDocuments()[0].getIsStrictlyLatin()).toBe(true);
+    expect(supportedCountries[1].getSupportedDocuments()[0].getIsStrictlyLatin()).toBe(true);
+    expect(supportedCountries[1].getSupportedDocuments()[1].getIsStrictlyLatin()).toBe(false);
+  });
 });


### PR DESCRIPTION
Includes:
- [x] #400
- [x] #402
- [x] #401 
- [x] #414
