### PR TITLE
Release/4.5.0

### DIFF
--- a/examples/aml-check/package-lock.json
+++ b/examples/aml-check/package-lock.json
@@ -25,13 +25,13 @@
     },
     "../..": {
       "name": "yoti",
-      "version": "4.4.0",
+      "version": "4.5.0",
       "license": "MIT",
       "dependencies": {
         "form-data": "4.0.0",
         "node-forge": "1.3.1",
-        "protobufjs": "7.2.4",
-        "superagent": "8.0.9",
+        "protobufjs": "7.2.5",
+        "superagent": "8.1.2",
         "uuid": "9.0.0"
       },
       "devDependencies": {
@@ -2374,6 +2374,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/typescript": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
@@ -2658,7 +2672,8 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ajv": {
       "version": "6.12.6",
@@ -4103,6 +4118,13 @@
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
       "dev": true
     },
+    "typescript": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "dev": true,
+      "peer": true
+    },
     "unbox-primitive": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
@@ -4179,8 +4201,8 @@
         "jest": "29.5.0",
         "nock": "13.2.9",
         "node-forge": "1.3.1",
-        "protobufjs": "7.2.4",
-        "superagent": "8.0.9",
+        "protobufjs": "7.2.5",
+        "superagent": "8.1.2",
         "uuid": "9.0.0"
       }
     }

--- a/examples/digital-identity/package-lock.json
+++ b/examples/digital-identity/package-lock.json
@@ -28,13 +28,13 @@
     },
     "../..": {
       "name": "yoti",
-      "version": "4.4.0",
+      "version": "4.5.0",
       "license": "MIT",
       "dependencies": {
         "form-data": "4.0.0",
         "node-forge": "1.3.1",
-        "protobufjs": "7.2.4",
-        "superagent": "8.0.9",
+        "protobufjs": "7.2.5",
+        "superagent": "8.1.2",
         "uuid": "9.0.0"
       },
       "devDependencies": {
@@ -2962,6 +2962,20 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typescript": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
@@ -3328,7 +3342,8 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ajv": {
       "version": "6.12.6",
@@ -5147,6 +5162,13 @@
         "mime-types": "~2.1.24"
       }
     },
+    "typescript": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "dev": true,
+      "peer": true
+    },
     "unbox-primitive": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
@@ -5238,8 +5260,8 @@
         "jest": "29.5.0",
         "nock": "13.2.9",
         "node-forge": "1.3.1",
-        "protobufjs": "7.2.4",
-        "superagent": "8.0.9",
+        "protobufjs": "7.2.5",
+        "superagent": "8.1.2",
         "uuid": "9.0.0"
       }
     }

--- a/examples/idv-identity-checks/package-lock.json
+++ b/examples/idv-identity-checks/package-lock.json
@@ -27,13 +27,13 @@
     },
     "../..": {
       "name": "yoti",
-      "version": "4.4.0",
+      "version": "4.5.0",
       "license": "MIT",
       "dependencies": {
         "form-data": "4.0.0",
         "node-forge": "1.3.1",
-        "protobufjs": "7.2.4",
-        "superagent": "8.0.9",
+        "protobufjs": "7.2.5",
+        "superagent": "8.1.2",
         "uuid": "9.0.0"
       },
       "devDependencies": {
@@ -3003,6 +3003,20 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typescript": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/uid-safe": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
@@ -3380,7 +3394,8 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ajv": {
       "version": "6.12.6",
@@ -5231,6 +5246,13 @@
         "mime-types": "~2.1.24"
       }
     },
+    "typescript": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "dev": true,
+      "peer": true
+    },
     "uid-safe": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
@@ -5330,8 +5352,8 @@
         "jest": "29.5.0",
         "nock": "13.2.9",
         "node-forge": "1.3.1",
-        "protobufjs": "7.2.4",
-        "superagent": "8.0.9",
+        "protobufjs": "7.2.5",
+        "superagent": "8.1.2",
         "uuid": "9.0.0"
       }
     }

--- a/examples/idv/package-lock.json
+++ b/examples/idv/package-lock.json
@@ -28,13 +28,13 @@
     },
     "../..": {
       "name": "yoti",
-      "version": "4.4.0",
+      "version": "4.5.0",
       "license": "MIT",
       "dependencies": {
         "form-data": "4.0.0",
         "node-forge": "1.3.1",
-        "protobufjs": "7.2.4",
-        "superagent": "8.0.9",
+        "protobufjs": "7.2.5",
+        "superagent": "8.1.2",
         "uuid": "9.0.0"
       },
       "devDependencies": {
@@ -3004,6 +3004,20 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typescript": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/uid-safe": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
@@ -3381,7 +3395,8 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ajv": {
       "version": "6.12.6",
@@ -5232,6 +5247,13 @@
         "mime-types": "~2.1.24"
       }
     },
+    "typescript": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "dev": true,
+      "peer": true
+    },
     "uid-safe": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
@@ -5331,8 +5353,8 @@
         "jest": "29.5.0",
         "nock": "13.2.9",
         "node-forge": "1.3.1",
-        "protobufjs": "7.2.4",
-        "superagent": "8.0.9",
+        "protobufjs": "7.2.5",
+        "superagent": "8.1.2",
         "uuid": "9.0.0"
       }
     }

--- a/examples/idv/src/controllers/use-cases/allow.non.latin.document.check.controller.js
+++ b/examples/idv/src/controllers/use-cases/allow.non.latin.document.check.controller.js
@@ -39,8 +39,8 @@ async function createSession() {
       (new RequiredIdDocumentBuilder())
         .withFilter(
           (new OrthogonalRestrictionsFilterBuilder())
-            .withWhitelistedDocumentTypes(['PASSPORT'])
-            .withAllowExpiredDocuments(true)
+            .withWhitelistedDocumentTypes(['DRIVING_LICENCE'])
+            .withAllowNonLatinDocuments(true)
             .build()
         )
         .build()
@@ -51,10 +51,10 @@ async function createSession() {
     //     .withFilter(
     //       (new DocumentRestrictionsFilterBuilder())
     //         .withDocumentRestriction((new DocumentRestrictionBuilder())
-    //           .withDocumentTypes(['PASSPORT'])
+    //           .withDocumentTypes(['DRIVING_LICENCE'])
     //           .build())
     //         .forWhitelist()
-    //         .withAllowExpiredDocuments(true)
+    //         .withAllowNonLatinDocuments(true)
     //         .build()
     //     )
     //     .build()
@@ -72,6 +72,34 @@ async function createSession() {
 
   return idvClient.createSession(sessionSpec);
 }
+
+// async function getListOfAllowedNonLatinDocuments() {
+//   const idvClient = new IDVClient(config.YOTI_CLIENT_SDK_ID, config.YOTI_PEM);
+//   const supportedDocumentsResponse = await idvClient.getSupportedDocuments(true);
+//
+//   console.log('\nThe list of allowed non Latin documents: \n');
+//   supportedDocumentsResponse.getSupportedCountries().forEach((supportedCountry) => {
+//     supportedCountry.getSupportedDocuments()
+//       .filter((supportedDoc) => !supportedDoc.getIsStrictlyLatin())
+//       .forEach((supportedDoc) => {
+//         console.log(`${supportedDoc.getType()} of ${supportedCountry.getCode()}`);
+//       });
+//   });
+// }
+//
+// async function getListOfStrictlyLatinDocuments() {
+//   const idvClient = new IDVClient(config.YOTI_CLIENT_SDK_ID, config.YOTI_PEM);
+//   const supportedDocumentsResponse = await idvClient.getSupportedDocuments(true);
+//
+//   console.log('\nThe list of strictly Latin documents: \n');
+//   supportedDocumentsResponse.getSupportedCountries().forEach((supportedCountry) => {
+//     supportedCountry.getSupportedDocuments()
+//       .filter((supportedDoc) => supportedDoc.getIsStrictlyLatin())
+//       .forEach((supportedDoc) => {
+//         console.log(`${supportedDoc.getType()} of ${supportedCountry.getCode()}`);
+//       });
+//   });
+// }
 
 module.exports = async (req, res) => {
   try {

--- a/examples/idv/src/controllers/use-cases/index.js
+++ b/examples/idv/src/controllers/use-cases/index.js
@@ -1,5 +1,6 @@
 const authenticityAndIdentityCheckController = require('./authenticity.and.identity.check.controller');
 const documentComparisonCheckController = require('./document.comparison.check.controller');
+const allowNonLatinDocumentCheckController = require('./allow.non.latin.document.check.controller');
 const allowExpiredDocumentCheckController = require('./allow.expired.document.check.controller');
 const faceComparisonCheckController = require('./face.comparison.check.controller');
 const faceMatchCheckController = require('./face.match.check.controller');
@@ -8,6 +9,7 @@ const watchlistCheckController = require('./watchlist.check.controller');
 module.exports = {
   authenticityAndIdentityCheckController,
   documentComparisonCheckController,
+  allowNonLatinDocumentCheckController,
   allowExpiredDocumentCheckController,
   faceComparisonCheckController,
   faceMatchCheckController,

--- a/examples/idv/src/routes/use-cases-router.js
+++ b/examples/idv/src/routes/use-cases-router.js
@@ -10,6 +10,7 @@ const {
   authenticityAndIdentityCheckController,
   documentComparisonCheckController,
   allowExpiredDocumentCheckController,
+  allowNonLatinDocumentCheckController,
   faceComparisonCheckController,
   faceMatchCheckController,
   watchlistCheckController,
@@ -18,6 +19,7 @@ const {
 const caseIdToControllerMapping = {
   [Cases.DOCUMENT_AUTHENTICITY_AND_IDENTITY]: authenticityAndIdentityCheckController,
   [Cases.DOCUMENT_COMPARISON]: documentComparisonCheckController,
+  [Cases.AllOW_NON_LATIN_DOCUMENT]: allowNonLatinDocumentCheckController,
   [Cases.AllOW_EXPIRED_DOCUMENT]: allowExpiredDocumentCheckController,
   [Cases.FACE_COMPARISON]: faceComparisonCheckController,
   [Cases.FACE_MATCH]: faceMatchCheckController,

--- a/examples/idv/src/useCases.js
+++ b/examples/idv/src/useCases.js
@@ -1,6 +1,7 @@
 const Cases = {
   DOCUMENT_AUTHENTICITY_AND_IDENTITY: 'documentAuthenticityAndIdentity',
   DOCUMENT_COMPARISON: 'documentComparison',
+  AllOW_NON_LATIN_DOCUMENT: 'allowNonLatinDocument',
   AllOW_EXPIRED_DOCUMENT: 'allowExpiredDocument',
   FACE_COMPARISON: 'faceComparison',
   FACE_MATCH: 'faceMatch',
@@ -15,6 +16,10 @@ const CasesMap = new Map([
   [Cases.DOCUMENT_COMPARISON, {
     name: 'Document comparison check',
     path: '/document-comparison-check',
+  }],
+  [Cases.AllOW_NON_LATIN_DOCUMENT, {
+    name: 'Allow non Latin document',
+    path: '/allow-non-latin-document',
   }],
   [Cases.AllOW_EXPIRED_DOCUMENT, {
     name: 'Allow expired document',

--- a/examples/profile-identity-checks/package-lock.json
+++ b/examples/profile-identity-checks/package-lock.json
@@ -28,13 +28,13 @@
     },
     "../..": {
       "name": "yoti",
-      "version": "4.4.0",
+      "version": "4.5.0",
       "license": "MIT",
       "dependencies": {
         "form-data": "4.0.0",
         "node-forge": "1.3.1",
-        "protobufjs": "7.2.4",
-        "superagent": "8.0.9",
+        "protobufjs": "7.2.5",
+        "superagent": "8.1.2",
         "uuid": "9.0.0"
       },
       "devDependencies": {
@@ -2962,6 +2962,20 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typescript": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
@@ -3328,7 +3342,8 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ajv": {
       "version": "6.12.6",
@@ -5147,6 +5162,13 @@
         "mime-types": "~2.1.24"
       }
     },
+    "typescript": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "dev": true,
+      "peer": true
+    },
     "unbox-primitive": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
@@ -5238,8 +5260,8 @@
         "jest": "29.5.0",
         "nock": "13.2.9",
         "node-forge": "1.3.1",
-        "protobufjs": "7.2.4",
-        "superagent": "8.0.9",
+        "protobufjs": "7.2.5",
+        "superagent": "8.1.2",
         "uuid": "9.0.0"
       }
     }

--- a/examples/profile/package-lock.json
+++ b/examples/profile/package-lock.json
@@ -28,13 +28,13 @@
     },
     "../..": {
       "name": "yoti",
-      "version": "4.4.0",
+      "version": "4.5.0",
       "license": "MIT",
       "dependencies": {
         "form-data": "4.0.0",
         "node-forge": "1.3.1",
-        "protobufjs": "7.2.4",
-        "superagent": "8.0.9",
+        "protobufjs": "7.2.5",
+        "superagent": "8.1.2",
         "uuid": "9.0.0"
       },
       "devDependencies": {
@@ -2962,6 +2962,20 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typescript": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
@@ -3328,7 +3342,8 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ajv": {
       "version": "6.12.6",
@@ -5147,6 +5162,13 @@
         "mime-types": "~2.1.24"
       }
     },
+    "typescript": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "dev": true,
+      "peer": true
+    },
     "unbox-primitive": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
@@ -5238,8 +5260,8 @@
         "jest": "29.5.0",
         "nock": "13.2.9",
         "node-forge": "1.3.1",
-        "protobufjs": "7.2.4",
-        "superagent": "8.0.9",
+        "protobufjs": "7.2.5",
+        "superagent": "8.1.2",
         "uuid": "9.0.0"
       }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "form-data": "4.0.0",
         "node-forge": "1.3.1",
-        "protobufjs": "7.2.4",
+        "protobufjs": "7.2.5",
         "superagent": "8.0.9",
         "uuid": "9.0.0"
       },
@@ -5222,9 +5222,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.4.tgz",
-      "integrity": "sha512-AT+RJgD2sH8phPmCf7OUZR8xGdcJRga4+1cOaXJ64hvcSkVhNcRHOwIxUatPH15+nj59WAGTDv3LSGZPEQbJaQ==",
+      "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.5.tgz",
+      "integrity": "sha512-gGXRSXvxQ7UiPgfw8gevrfRWcTlSbOFg+p/N+JVJEK5VhueL2miT6qTymqAmjr1Q5WbOCyJbyrk6JfWKwlFn6A==",
       "hasInstallScript": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
@@ -5896,6 +5896,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/unbox-primitive": {
@@ -7317,7 +7331,8 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ajv": {
       "version": "6.12.6",
@@ -9267,7 +9282,8 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
       "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "jest-regex-util": {
       "version": "29.4.3",
@@ -10018,9 +10034,9 @@
       "dev": true
     },
     "protobufjs": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.4.tgz",
-      "integrity": "sha512-AT+RJgD2sH8phPmCf7OUZR8xGdcJRga4+1cOaXJ64hvcSkVhNcRHOwIxUatPH15+nj59WAGTDv3LSGZPEQbJaQ==",
+      "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.5.tgz",
+      "integrity": "sha512-gGXRSXvxQ7UiPgfw8gevrfRWcTlSbOFg+p/N+JVJEK5VhueL2miT6qTymqAmjr1Q5WbOCyJbyrk6JfWKwlFn6A==",
       "requires": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -10495,6 +10511,13 @@
         "for-each": "^0.3.3",
         "is-typed-array": "^1.1.9"
       }
+    },
+    "typescript": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+      "dev": true,
+      "peer": true
     },
     "unbox-primitive": {
       "version": "1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "form-data": "4.0.0",
         "node-forge": "1.3.1",
         "protobufjs": "7.2.5",
-        "superagent": "8.0.9",
+        "superagent": "8.1.2",
         "uuid": "9.0.0"
       },
       "devDependencies": {
@@ -5722,9 +5722,9 @@
       }
     },
     "node_modules/superagent": {
-      "version": "8.0.9",
-      "resolved": "https://registry.npmjs.org/superagent/-/superagent-8.0.9.tgz",
-      "integrity": "sha512-4C7Bh5pyHTvU33KpZgwrNKh/VQnvgtCSqPRfJAUdmrtSYePVzVg4E4OzsrbkhJj9O7SO6Bnv75K/F8XVZT8YHA==",
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-8.1.2.tgz",
+      "integrity": "sha512-6WTxW1EB6yCxV5VFOIPQruWGHqc3yI7hEmZK6h+pyk69Lk/Ut7rLUY6W/ONF2MjBuGjvmMiIpsrVJ2vjrHlslA==",
       "dependencies": {
         "component-emitter": "^1.3.0",
         "cookiejar": "^2.1.4",
@@ -10378,9 +10378,9 @@
       "dev": true
     },
     "superagent": {
-      "version": "8.0.9",
-      "resolved": "https://registry.npmjs.org/superagent/-/superagent-8.0.9.tgz",
-      "integrity": "sha512-4C7Bh5pyHTvU33KpZgwrNKh/VQnvgtCSqPRfJAUdmrtSYePVzVg4E4OzsrbkhJj9O7SO6Bnv75K/F8XVZT8YHA==",
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-8.1.2.tgz",
+      "integrity": "sha512-6WTxW1EB6yCxV5VFOIPQruWGHqc3yI7hEmZK6h+pyk69Lk/Ut7rLUY6W/ONF2MjBuGjvmMiIpsrVJ2vjrHlslA==",
       "requires": {
         "component-emitter": "^1.3.0",
         "cookiejar": "^2.1.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "yoti",
-  "version": "4.4.0",
+  "version": "4.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "yoti",
-      "version": "4.4.0",
+      "version": "4.5.0",
       "license": "MIT",
       "dependencies": {
         "form-data": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yoti",
-  "version": "4.4.0",
+  "version": "4.5.0",
   "description": "Yoti NodeJS SDK for back-end integration",
   "author": "Yoti LTD <tech@yoti.com> (https://www.yoti.com/developers)",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "form-data": "4.0.0",
     "node-forge": "1.3.1",
-    "protobufjs": "7.2.4",
+    "protobufjs": "7.2.5",
     "superagent": "8.0.9",
     "uuid": "9.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "form-data": "4.0.0",
     "node-forge": "1.3.1",
     "protobufjs": "7.2.5",
-    "superagent": "8.0.9",
+    "superagent": "8.1.2",
     "uuid": "9.0.0"
   },
   "devDependencies": {

--- a/src/client/idv.client.js
+++ b/src/client/idv.client.js
@@ -87,10 +87,12 @@ class IDVClient {
   /**
    * Gets a list of supported documents.
    *
+   * @param {boolean} includeNonLatin
+   *
    * @returns {Promise<SupportedDocumentsResponse>}
    */
-  getSupportedDocuments() {
-    return this.idvService.getSupportedDocuments();
+  getSupportedDocuments(includeNonLatin) {
+    return this.idvService.getSupportedDocuments(includeNonLatin);
   }
 
   /**

--- a/src/idv_service/idv.service.js
+++ b/src/idv_service/idv.service.js
@@ -216,15 +216,22 @@ class IDVService {
   /**
    * Gets a list of supported documents.
    *
+   * @param {boolean} includeNonLatin
+   *
    * @returns {Promise<SupportedDocumentsResponse>}
    */
-  getSupportedDocuments() {
-    const request = new RequestBuilder()
+  getSupportedDocuments(includeNonLatin) {
+    const requestBuilder = new RequestBuilder()
       .withPemString(this.pem)
       .withBaseUrl(this.apiUrl)
       .withEndpoint('/supported-documents')
-      .withGet()
-      .build();
+      .withGet();
+
+    if (includeNonLatin) {
+      requestBuilder.withQueryParam('includeNonLatin', true);
+    }
+
+    const request = requestBuilder.build();
 
     return new Promise((resolve, reject) => {
       request.execute()

--- a/src/idv_service/session/create/filters/document/document.restrictions.filter.builder.js
+++ b/src/idv_service/session/create/filters/document/document.restrictions.filter.builder.js
@@ -49,13 +49,24 @@ class DocumentRestrictionsFilterBuilder {
   }
 
   /**
+   * @param {Boolean} allowNonLatinDocuments
+   *
+   * @returns {this}
+   */
+  withAllowNonLatinDocuments(allowNonLatinDocuments) {
+    this.allowNonLatinDocuments = allowNonLatinDocuments;
+    return this;
+  }
+
+  /**
    * @returns {DocumentRestrictionsFilter}
    */
   build() {
     return new DocumentRestrictionsFilter(
       this.inclusion,
       this.documents,
-      this.allowExpiredDocuments
+      this.allowExpiredDocuments,
+      this.allowNonLatinDocuments
     );
   }
 }

--- a/src/idv_service/session/create/filters/document/document.restrictions.filter.js
+++ b/src/idv_service/session/create/filters/document/document.restrictions.filter.js
@@ -10,8 +10,9 @@ class DocumentRestrictionsFilter extends DocumentFilter {
    * @param {string} inclusion
    * @param {DocumentRestriction[]} documents
    * @param {Boolean} allowExpiredDocuments
+   * @param {Boolean} allowNonLatinDocuments
    */
-  constructor(inclusion, documents, allowExpiredDocuments) {
+  constructor(inclusion, documents, allowExpiredDocuments, allowNonLatinDocuments) {
     super(IDVConstants.DOCUMENT_RESTRICTIONS);
 
     Validation.isString(inclusion, 'inclusion');
@@ -22,6 +23,9 @@ class DocumentRestrictionsFilter extends DocumentFilter {
 
     Validation.isBoolean(allowExpiredDocuments, 'allowExpiredDocuments', true);
     this.allowExpiredDocuments = allowExpiredDocuments;
+
+    Validation.isBoolean(allowNonLatinDocuments, 'allowNonLatinDocuments', true);
+    this.allowNonLatinDocuments = allowNonLatinDocuments;
   }
 
   toJSON() {
@@ -30,6 +34,7 @@ class DocumentRestrictionsFilter extends DocumentFilter {
     json.inclusion = this.inclusion;
     json.documents = this.documents;
     json.allow_expired_documents = this.allowExpiredDocuments;
+    json.allow_non_latin_documents = this.allowNonLatinDocuments;
 
     return json;
   }

--- a/src/idv_service/session/create/filters/orthogonal/orthogonal.restrictions.filter.builder.js
+++ b/src/idv_service/session/create/filters/orthogonal/orthogonal.restrictions.filter.builder.js
@@ -8,6 +8,8 @@ const IDVConstants = require('../../../../idv.constants');
 class OrthogonalRestrictionsFilterBuilder {
   /**
    * @param {string[]} countryCodes
+   *
+   * @returns {this}
    */
   withWhitelistedCountries(countryCodes) {
     this.countryRestriction = new CountryRestriction(
@@ -19,6 +21,8 @@ class OrthogonalRestrictionsFilterBuilder {
 
   /**
    * @param {string[]} countryCodes
+   *
+   * @returns {this}
    */
   withBlacklistedCountries(countryCodes) {
     this.countryRestriction = new CountryRestriction(
@@ -30,6 +34,8 @@ class OrthogonalRestrictionsFilterBuilder {
 
   /**
    * @param {string[]} documentTypes
+   *
+   * @returns {this}
    */
   withWhitelistedDocumentTypes(documentTypes) {
     this.typeRestriction = new TypeRestriction(
@@ -41,6 +47,8 @@ class OrthogonalRestrictionsFilterBuilder {
 
   /**
    * @param {string[]} documentTypes
+   *
+   * @returns {this}
    */
   withBlacklistedDocumentTypes(documentTypes) {
     this.typeRestriction = new TypeRestriction(
@@ -61,13 +69,24 @@ class OrthogonalRestrictionsFilterBuilder {
   }
 
   /**
+   * @param {Boolean} allowNonLatinDocuments
+   *
+   * @returns {this}
+   */
+  withAllowNonLatinDocuments(allowNonLatinDocuments) {
+    this.allowNonLatinDocuments = allowNonLatinDocuments;
+    return this;
+  }
+
+  /**
    * @returns {OrthogonalRestrictionsFilter}
    */
   build() {
     return new OrthogonalRestrictionsFilter(
       this.countryRestriction,
       this.typeRestriction,
-      this.allowExpiredDocuments
+      this.allowExpiredDocuments,
+      this.allowNonLatinDocuments
     );
   }
 }

--- a/src/idv_service/session/create/filters/orthogonal/orthogonal.restrictions.filter.js
+++ b/src/idv_service/session/create/filters/orthogonal/orthogonal.restrictions.filter.js
@@ -11,8 +11,9 @@ class OrthogonalRestrictionsFilter extends DocumentFilter {
    * @param {CountryRestriction} countryRestriction
    * @param {TypeRestriction} typeRestriction
    * @param {Boolean} allowExpiredDocuments
+   * @param {Boolean} allowNonLatinDocuments
    */
-  constructor(countryRestriction, typeRestriction, allowExpiredDocuments) {
+  constructor(countryRestriction, typeRestriction, allowExpiredDocuments, allowNonLatinDocuments) {
     super(IDVConstants.ORTHOGONAL_RESTRICTIONS);
 
     if (countryRestriction) {
@@ -27,6 +28,9 @@ class OrthogonalRestrictionsFilter extends DocumentFilter {
 
     Validation.isBoolean(allowExpiredDocuments, 'allowExpiredDocuments', true);
     this.allowExpiredDocuments = allowExpiredDocuments;
+
+    Validation.isBoolean(allowNonLatinDocuments, 'allowNonLatinDocuments', true);
+    this.allowNonLatinDocuments = allowNonLatinDocuments;
   }
 
   toJSON() {
@@ -35,6 +39,7 @@ class OrthogonalRestrictionsFilter extends DocumentFilter {
     json.country_restriction = this.countryRestriction;
     json.type_restriction = this.typeRestriction;
     json.allow_expired_documents = this.allowExpiredDocuments;
+    json.allow_non_latin_documents = this.allowNonLatinDocuments;
 
     return json;
   }

--- a/src/idv_service/support/supported.document.js
+++ b/src/idv_service/support/supported.document.js
@@ -6,10 +6,25 @@ class SupportedDocument {
   constructor(document) {
     Validation.isString(document.type, 'type', true);
     this.type = document.type;
+
+    Validation.isBoolean(document.is_strictly_latin, 'is_strictly_latin', true);
+    this.isStrictlyLatin = document.is_strictly_latin;
   }
 
+  /**
+   *
+   * @return {string|undefined}
+   */
   getType() {
     return this.type;
+  }
+
+  /**
+   *
+   * @return {boolean|undefined}
+   */
+  getIsStrictlyLatin() {
+    return this.isStrictlyLatin;
   }
 }
 

--- a/tests/client/idv.client.spec.js
+++ b/tests/client/idv.client.spec.js
@@ -11,6 +11,7 @@ const {
   UploadFaceCaptureImagePayloadBuilder,
 } = require('../..');
 
+const { IDVService } = require('../../src/idv_service');
 const CreateSessionResult = require('../../src/idv_service/session/create/create.session.result');
 const GetSessionResult = require('../../src/idv_service/session/retrieve/get.session.result');
 const Media = require('../../src/data_type/media');
@@ -191,11 +192,18 @@ describe.each([
         .reply(responseStatusCode, responseBody);
     };
 
-    describe('when a valid response is returned', () => {
-      beforeEach(() => {
-        setupResponse(JSON.stringify({}));
-      });
+    let spyOnIDVServiceRelatedMethod;
 
+    beforeEach(() => {
+      setupResponse(JSON.stringify({}));
+      spyOnIDVServiceRelatedMethod = jest.spyOn(IDVService.prototype, 'getSupportedDocuments');
+    });
+
+    afterEach(() => {
+      spyOnIDVServiceRelatedMethod.mockRestore();
+    });
+
+    describe('when a valid response is returned', () => {
       it('should return SupportedDocumentResponse', (done) => {
         idvClient
           .getSupportedDocuments()
@@ -204,6 +212,22 @@ describe.each([
             done();
           })
           .catch(done);
+        expect(spyOnIDVServiceRelatedMethod).toHaveBeenCalledTimes(1);
+        expect(spyOnIDVServiceRelatedMethod).not.toHaveBeenCalledWith(true);
+      });
+    });
+
+    describe('when includeNonLatin is passed', () => {
+      it('should return SupportedDocumentResponse', (done) => {
+        idvClient
+          .getSupportedDocuments(true)
+          .then((result) => {
+            expect(result).toBeInstanceOf(SupportedDocumentResponse);
+            done();
+          })
+          .catch(done);
+        expect(spyOnIDVServiceRelatedMethod).toHaveBeenCalledTimes(1);
+        expect(spyOnIDVServiceRelatedMethod).toHaveBeenCalledWith(true);
       });
     });
   });

--- a/tests/idv_service/idv.service.spec.js
+++ b/tests/idv_service/idv.service.spec.js
@@ -419,6 +419,22 @@ describe('IDVService', () => {
           .catch(done);
       });
     });
+    describe('when includeNonLatin is passed', () => {
+      it('should return SupportedDocumentResponse', (done) => {
+        nock(config.yoti.idvApi)
+          .get(SUPPORTED_DOCUMENTS_URI)
+          .query((queryParams) => queryParams.includeNonLatin === 'true')
+          .reply(200, '{}');
+
+        idvService
+          .getSupportedDocuments(true)
+          .then((result) => {
+            expect(result).toBeInstanceOf(SupportedDocumentResponse);
+            done();
+          })
+          .catch(done);
+      });
+    });
     describe('when response code is invalid', () => {
       it('should reject', (done) => {
         nock(config.yoti.idvApi)

--- a/tests/idv_service/session/create/filters/document/document.restrictions.filter.builder.spec.js
+++ b/tests/idv_service/session/create/filters/document/document.restrictions.filter.builder.spec.js
@@ -104,7 +104,7 @@ describe('DocumentRestrictionsFilterBuilder', () => {
   it('should build DocumentRestrictionsFilter with expired documents not allowed', () => {
     const documentRestrictionsFilter = new DocumentRestrictionsFilterBuilder()
       .forWhitelist()
-      .withAllowExpiredDocuments(false)
+      .withAllowExpiredDocuments(true)
       .build();
 
     expect(JSON.stringify(documentRestrictionsFilter))
@@ -112,7 +112,22 @@ describe('DocumentRestrictionsFilterBuilder', () => {
         type: 'DOCUMENT_RESTRICTIONS',
         inclusion: 'WHITELIST',
         documents: [],
-        allow_expired_documents: false,
+        allow_expired_documents: true,
+      }));
+  });
+
+  it('should build DocumentRestrictionsFilter with non latin documents allowed', () => {
+    const documentRestrictionsFilter = new DocumentRestrictionsFilterBuilder()
+      .forWhitelist()
+      .withAllowNonLatinDocuments(true)
+      .build();
+
+    expect(JSON.stringify(documentRestrictionsFilter))
+      .toBe(JSON.stringify({
+        type: 'DOCUMENT_RESTRICTIONS',
+        inclusion: 'WHITELIST',
+        documents: [],
+        allow_non_latin_documents: true,
       }));
   });
 });

--- a/tests/idv_service/session/create/filters/orthogonal/orthogonal.restrictions.filter.builder.spec.js
+++ b/tests/idv_service/session/create/filters/orthogonal/orthogonal.restrictions.filter.builder.spec.js
@@ -134,4 +134,16 @@ describe('OrthogonalRestrictionsFilterBuilder', () => {
         allow_expired_documents: false,
       }));
   });
+
+  it('should build OrthogonalRestrictionsFilter with allow non latin documents', () => {
+    const orthogonalRestrictionsFilter = new OrthogonalRestrictionsFilterBuilder()
+      .withAllowNonLatinDocuments(true)
+      .build();
+
+    expect(JSON.stringify(orthogonalRestrictionsFilter))
+      .toBe(JSON.stringify({
+        type: 'ORTHOGONAL_RESTRICTIONS',
+        allow_non_latin_documents: true,
+      }));
+  });
 });

--- a/tests/idv_service/session/retrieve/configuration/capture/document/supported.country.response.spec.js
+++ b/tests/idv_service/session/retrieve/configuration/capture/document/supported.country.response.spec.js
@@ -27,9 +27,14 @@ describe('SupportedCountryResponse', () => {
   describe('#getSupportedDocuments', () => {
     it('should return requested tasks', () => {
       expect(supportedCountryResponse.getSupportedDocuments()).toHaveLength(2);
-      expect(
-        supportedCountryResponse.getSupportedDocuments()[0]
-      ).toBeInstanceOf(SupportedDocumentResponse);
+
+      const [firstResponse, secondResponse] = supportedCountryResponse.getSupportedDocuments();
+
+      expect(firstResponse).toBeInstanceOf(SupportedDocumentResponse);
+      expect(firstResponse.getType()).toBe('DRIVING_LICENCE');
+
+      expect(secondResponse).toBeInstanceOf(SupportedDocumentResponse);
+      expect(secondResponse.getType()).toBe('PASSPORT');
     });
   });
 });

--- a/tests/idv_service/support/supported.documents.response.spec.js
+++ b/tests/idv_service/support/supported.documents.response.spec.js
@@ -66,4 +66,39 @@ describe('SupportedDocumentsResponse', () => {
 
     expect(supportedCountries).toHaveLength(0);
   });
+
+  it('parses response into list of supported countries with is_strictly_latin', () => {
+    const supportedDocumentsResponse = new SupportedDocumentsResponse({
+      supported_countries: [
+        {
+          code: SOME_COUNTRY_CODE,
+          supported_documents: [
+            {
+              type: SOME_DOCUMENT_TYPE,
+              is_strictly_latin: true,
+            },
+          ],
+        },
+        {
+          code: SOME_OTHER_COUNTRY_CODE,
+          supported_documents: [
+            {
+              type: SOME_DOCUMENT_TYPE,
+              is_strictly_latin: true,
+            },
+            {
+              type: SOME_OTHER_DOCUMENT_TYPE,
+              is_strictly_latin: false,
+            },
+          ],
+        },
+      ],
+    });
+
+    const supportedCountries = supportedDocumentsResponse.getSupportedCountries();
+
+    expect(supportedCountries[0].getSupportedDocuments()[0].getIsStrictlyLatin()).toBe(true);
+    expect(supportedCountries[1].getSupportedDocuments()[0].getIsStrictlyLatin()).toBe(true);
+    expect(supportedCountries[1].getSupportedDocuments()[1].getIsStrictlyLatin()).toBe(false);
+  });
 });


### PR DESCRIPTION
### New Identity Verification Features

#### Allowing non-latin documents
A new method `withAllowNonLatinDocuments(value: Boolean)` on both `OrthogonalRestrictionsFilterBuilder` and `DocumentRestrictionsFilterBuilder` filter builders is now available.

###### with `OrthogonalRestrictionsFilterBuilder`
```js
  const orthogonalRestrictionsFilter = new OrthogonalRestrictionsFilterBuilder()
    .withWhitelistedDocumentTypes(['PASSPORT'])
    .withAllowNonLatinDocuments(true)
    .build();
     
  const requiredIdDocument = new RequiredIdDocumentBuilder()
    .withFilter(orthogonalRestrictionsFilter)
    .build();
```
or 
###### with`DocumentRestrictionsFilterBuilder`
```js
  const documentRestriction = new DocumentRestrictionBuilder()
    .withDocumentTypes(['PASSPORT'])
    .build();

  const documentRestrictionsFilter = new DocumentRestrictionsFilterBuilder()
    .withDocumentRestriction(documentRestriction)
    .forWhitelist()
    .withAllowNonLatinDocuments(true)
    .build();

  const requiredIdDocument = new RequiredIdDocumentBuilder()
    .withFilter(documentRestrictionsFilter)
    .build();
```
#### Getting the list of documents supported, including non-latin or not
This is generic feature related to the API capabilities (ie, not bound to any specific session).
One can call the method `getSupportedDocuments(includeNonLatin: Boolean)`, the `includeNonLatin` is new.
```js
const supportedDocumentsResponse = await idvClient.getSupportedDocuments(true);
```


