### PR TITLE
SDK-2366 Advanced Identity Profile in share v1

### DIFF
--- a/examples/profile-identity-checks/controllers/report.controller.js
+++ b/examples/profile-identity-checks/controllers/report.controller.js
@@ -72,7 +72,7 @@ module.exports = async (req, res) => {
               ? (profile && profile.getAttributeById(document_images_attribute_id)) : null))
             .filter((documentImagesAttribute) => documentImagesAttribute);
         });
-        documentImagesAttributes = [].concat(...documentImagesAttributesArray);
+        documentImagesAttributes = documentImagesAttributesArray.flat();
 
         // Selfie image (if any)
         const selfieAttributeArray = verificationReports.map((report) => {

--- a/examples/profile-identity-checks/controllers/report.controller.js
+++ b/examples/profile-identity-checks/controllers/report.controller.js
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 const Yoti = require('yoti');
 const config = require('../config');
 
@@ -14,8 +15,12 @@ module.exports = async (req, res) => {
 
   let identityAssertion = null;
   let verificationReport = null;
+  let verificationReports = null;
   let authenticationReport = null;
+  let authenticationReports = null;
+  let identityAssertionProof = null;
   let documentImagesAttributes = [];
+  let selfieAttribute = null;
   let errorDetails = null;
 
   try {
@@ -26,22 +31,62 @@ module.exports = async (req, res) => {
       const profile = activityDetails.getProfile();
       const identityProfile = profile.getIdentityProfileReport().getValue();
       const {
-        identity_assertion: assertion,
-        verification_report: verification,
-        authentication_report: authentication,
+        identity_assertion,
+        verification_report,
+        verification_reports,
+        authentication_report,
+        authentication_reports,
+        proof,
       } = identityProfile;
 
-      identityAssertion = assertion;
-      verificationReport = verification;
-      authenticationReport = authentication;
+      identityAssertion = identity_assertion;
+      verificationReport = verification_report;
+      verificationReports = verification_reports;
+      authenticationReport = authentication_report;
+      authenticationReports = authentication_reports;
+      identityAssertionProof = proof;
 
-      const { evidence } = verificationReport;
-      const { documents } = evidence;
-      documentImagesAttributes = documents
-      // eslint-disable-next-line camelcase
-        .map(({ document_images_attribute_id }) => (document_images_attribute_id
-          ? (profile && profile.getAttributeById(document_images_attribute_id)) : null))
-        .filter((documentImagesAttribute) => documentImagesAttribute);
+      if (verificationReport) {
+        const { evidence } = verificationReport;
+        const { face, documents } = evidence;
+
+        // Document images (if any)
+        documentImagesAttributes = documents
+          .map(({ document_images_attribute_id }) => (document_images_attribute_id
+            ? (profile && profile.getAttributeById(document_images_attribute_id)) : null))
+          .filter((documentImagesAttribute) => documentImagesAttribute);
+
+        // Selfie image (if any)
+        const { selfie_attribute_id } = face;
+        selfieAttribute = selfie_attribute_id
+          ? (profile && profile.getAttributeById(selfie_attribute_id))
+          : null;
+      } else if (verificationReports.length > 0) {
+        // Document images (if any)
+        const documentImagesAttributesArray = verificationReports.map((report) => {
+          const { evidence } = report;
+          const { documents } = evidence;
+
+          return documents
+            .map(({ document_images_attribute_id }) => (document_images_attribute_id
+              ? (profile && profile.getAttributeById(document_images_attribute_id)) : null))
+            .filter((documentImagesAttribute) => documentImagesAttribute);
+        });
+        documentImagesAttributes = [].concat(...documentImagesAttributesArray);
+
+        // Selfie image (if any)
+        const selfieAttributeArray = verificationReports.map((report) => {
+          const { evidence } = report;
+          const { face } = evidence;
+          const { selfie_attribute_id } = face;
+
+          return selfie_attribute_id
+            ? (profile && profile.getAttributeById(selfie_attribute_id))
+            : null;
+        });
+        // eslint-disable-next-line prefer-destructuring
+        selfieAttribute = selfieAttributeArray.filter((selfie) => selfie)[0];
+      }
     } else {
       errorDetails = activityDetails.getErrorDetails();
     }
@@ -50,8 +95,12 @@ module.exports = async (req, res) => {
       outcome,
       identityAssertion,
       verificationReport,
+      verificationReports,
       authenticationReport,
+      authenticationReports,
+      identityAssertionProof,
       documentImagesAttributes,
+      selfieAttribute,
       errorDetails,
     });
   } catch (err) {

--- a/examples/profile-identity-checks/controllers/share.url.controller.js
+++ b/examples/profile-identity-checks/controllers/share.url.controller.js
@@ -23,20 +23,60 @@ const identityProfileRequirementsDescriptors = {
       objective: 'BASIC',
     },
   },
+  MTF_BASE: {
+    profiles: [
+      {
+        trust_framework: 'UK_TFIDA',
+        schemes: [
+          {
+            type: 'DBS',
+            objective: 'STANDARD',
+            label: 'dbs-standard',
+          },
+          {
+            type: 'RTW',
+            objective: '',
+            label: 'rtw',
+          },
+        ],
+      },
+      {
+        trust_framework: 'YOTI_GLOBAL',
+        schemes: [
+          {
+            type: 'IDENTITY',
+            objective: 'AL_L1',
+            label: 'identity-AL-L1',
+          },
+          {
+            type: 'IDENTITY',
+            objective: 'AL_M1',
+            label: 'identity-AL-M1',
+          },
+        ],
+      },
+    ],
+  },
 };
 
 module.exports = async (req, res) => {
   const { scheme } = req.query;
+  const dynamicPolicyBuilder = new Yoti.DynamicPolicyBuilder();
 
-  const identityProfileRequirementsDescriptor = identityProfileRequirementsDescriptors[scheme];
+  if (scheme === 'MTF_BASE') {
+    const identityProfileRequirementsDescriptor = identityProfileRequirementsDescriptors.MTF_BASE;
+    dynamicPolicyBuilder
+      .withAdvancedIdentityProfileRequirements(identityProfileRequirementsDescriptor);
+  } else {
+    dynamicPolicyBuilder
+      .withIdentityProfileRequirements(identityProfileRequirementsDescriptors[scheme]);
+  }
+
+  const dynamicPolicy = dynamicPolicyBuilder.build();
 
   const subject = {
     subject_id: 'subject_id_string',
   };
-
-  const dynamicPolicy = new Yoti.DynamicPolicyBuilder()
-    .withIdentityProfileRequirements(identityProfileRequirementsDescriptor)
-    .build();
 
   const dynamicScenario = new Yoti.DynamicScenarioBuilder()
     .withCallbackEndpoint('/identity-profile-report')

--- a/examples/profile-identity-checks/views/pages/identity-profile-report.ejs
+++ b/examples/profile-identity-checks/views/pages/identity-profile-report.ejs
@@ -26,30 +26,70 @@
     <section>
       <div class="yoti-report-section">
         <% if (outcome === 'SUCCESS' ) { %>
-          <div>
-            <h4>Identity assertion:</h4>
-            <pre><%= JSON.stringify(identityAssertion, null, 2) %></pre>
-          </div>
-          <div>
-            <h4>Verification report:</h4>
-            <pre><%= JSON.stringify(verificationReport, null, 2) %></pre>
-          </div>
-          <div>
-            <h4>Authentication report:</h4>
-            <pre><%= JSON.stringify(authenticationReport, null, 2) %></pre>
-          </div>
-          <div>
-            <h4>Documents images attributes:</h4>
-            <% documentImagesAttributes.forEach((docImgAttr) => { %>
-              <span>Document image ID: </span>
-              <span><%= docImgAttr.getId() %></span>
-              <br>
-              <br>
-              <% docImgAttr.getValue().forEach((image) => { %>
-                <img src="<%= image.getBase64Content() %>"  alt="Document image"/>
+          <% if (identityAssertion ) { %>
+            <div>
+              <h4>Identity assertion:</h4>
+              <pre><%= JSON.stringify(identityAssertion, null, 2) %></pre>
+            </div>
+          <% } %>
+          <% if (verificationReport ) { %>
+            <div>
+              <h4>Verification report:</h4>
+              <pre><%= JSON.stringify(verificationReport, null, 2) %></pre>
+            </div>
+          <% } %>
+          <% if (authenticationReport ) { %>
+            <div>
+              <h4>Authentication report:</h4>
+              <pre><%= JSON.stringify(authenticationReport, null, 2) %></pre>
+            </div>
+          <% } %>
+          <% if (verificationReports && verificationReports.length !== 0 ) { %>
+            <div>
+              <h4>Verification reports:</h4>
+              <pre><%= JSON.stringify(verificationReports, null, 2) %></pre>
+            </div>
+          <% } %>
+          <% if (authenticationReports && authenticationReports.length !== 0 ) { %>
+            <div>
+              <h4>Authentication reports:</h4>
+              <pre><%= JSON.stringify(authenticationReports, null, 2) %></pre>
+            </div>
+          <% } %>
+          <% if (identityAssertionProof ) { %>
+            <div>
+              <h4>Proof:</h4>
+              <pre><%= JSON.stringify(identityAssertionProof, null, 2) %></pre>
+            </div>
+          <% } %>
+          <% if (documentImagesAttributes && documentImagesAttributes.length !== 0 ) { %>
+            <div>
+              <h4>Documents images attributes:</h4>
+              <% documentImagesAttributes.forEach((docImgAttr) => { %>
+                <span>Document image ID: </span>
+                <span><%= docImgAttr.getId() %></span>
+                <br>
+                <br>
+                <% docImgAttr.getValue().forEach((image) => { %>
+                  <img src="<%= image.getBase64Content() %>"  alt="Document image"/>
+                <% }) %>
+                <br>
+                <br>
               <% }) %>
-            <% }) %>
-          </div>
+            </div>
+          <% } %>
+          <% if (selfieAttribute ) { %>
+            <div>
+              <h4>Selfie:</h4>
+              <span>Selfie ID: </span>
+              <span><%= selfieAttribute.getId() %></span>
+              <br>
+              <br>
+              <img src="<%= selfieAttribute.getValue().getBase64Content() %>"  alt="Selfie"/>
+              <br>
+              <br>
+            </div>
+          <% } %>
         <% } else { %>
           <div>
             <h4>Sorry, the check was not successful</h4>

--- a/examples/profile-identity-checks/views/pages/index.ejs
+++ b/examples/profile-identity-checks/views/pages/index.ejs
@@ -28,9 +28,10 @@
         <div>
           <label for="selectedScheme" class="yoti-checks-scheme">Select identity check scheme: </label>
           <select id="selectedScheme">
-            <option value="DBS_BASIC">DBS_BASIC</option>
+            <option value="DBS_BASIC">DBS-BASIC</option>
             <option value="RTW">RTW</option>
             <option value="RTR">RTR</option>
+            <option value="MTF_BASE">Advanced - UK_TFIDA(DBS-STANDARD & RTW) + YOTI_GLOBAL(IDENTITY-AL_M1 & IDENTITY-AL_L1)</option>
           </select>
         </div>
         <div class="yoti-sdk-integration-section">

--- a/src/dynamic_sharing_service/policy/dynamic.policy.builder.js
+++ b/src/dynamic_sharing_service/policy/dynamic.policy.builder.js
@@ -311,10 +311,34 @@ module.exports = class DynamicPolicyBuilder {
   }
 
   /**
-   * @param {object} identityProfileRequirements
+   * @typedef {Object} SimpleScheme
+   * @property {string} type
+   * @property {string} [objective]
+   *
+   * @param {Object} identityProfileRequirements
+   * @param {string} identityProfileRequirements.trust_framework
+   * @param {SimpleScheme} identityProfileRequirements.scheme
    */
   withIdentityProfileRequirements(identityProfileRequirements) {
     this.identityProfileRequirements = identityProfileRequirements;
+    return this;
+  }
+
+  /**
+   * @typedef {Object} AdvancedScheme
+   * @property {string} type
+   * @property {string} objective
+   * @property {string} label
+   *
+   * @typedef {Object} AdvancedProfileRequirements
+   * @property {string} trust_framework - Expected: 'UK_TFIDA' | 'YOTI_GLOBAL'
+   * @property {Array<AdvancedScheme>} schemes
+   *
+   * @param {Object} advancedIdentityProfileRequirements
+   * @param {Array<AdvancedProfileRequirements>} advancedIdentityProfileRequirements.profiles
+   */
+  withAdvancedIdentityProfileRequirements(advancedIdentityProfileRequirements) {
+    this.advancedIdentityProfileRequirements = advancedIdentityProfileRequirements;
     return this;
   }
 
@@ -326,7 +350,8 @@ module.exports = class DynamicPolicyBuilder {
       Object.keys(this.wantedAttributes).map((k) => this.wantedAttributes[k]),
       this.wantedAuthTypes.filter((value, index, self) => self.indexOf(value) === index),
       this.wantedRememberMe,
-      this.identityProfileRequirements
+      this.identityProfileRequirements,
+      this.advancedIdentityProfileRequirements
     );
   }
 };

--- a/src/dynamic_sharing_service/policy/dynamic.policy.js
+++ b/src/dynamic_sharing_service/policy/dynamic.policy.js
@@ -14,12 +14,14 @@ module.exports = class DynamicPolicy {
    * @param {number[]} wantedAuthTypes - auth types represents the authentication type to be used.
    * @param {boolean} wantedRememberMe
    * @param {object} identityProfileRequirements
+   * @param {object} advancedIdentityProfileRequirements
    */
   constructor(
     wantedAttributes,
     wantedAuthTypes,
     wantedRememberMe = false,
-    identityProfileRequirements = null
+    identityProfileRequirements = null,
+    advancedIdentityProfileRequirements = null
   ) {
     Validation.isArrayOfType(wantedAttributes, WantedAttribute, 'wantedAttribute');
     /** @private */
@@ -42,6 +44,11 @@ module.exports = class DynamicPolicy {
       Validation.isPlainObject(identityProfileRequirements, 'identityProfileRequirements');
       /** @private */
       this.identityProfileRequirements = identityProfileRequirements;
+    }
+
+    if (advancedIdentityProfileRequirements) {
+      Validation.isPlainObject(advancedIdentityProfileRequirements, 'advancedIdentityProfileRequirements');
+      this.advancedIdentityProfileRequirements = advancedIdentityProfileRequirements;
     }
   }
 
@@ -74,6 +81,13 @@ module.exports = class DynamicPolicy {
   }
 
   /**
+   * @return {Object}
+   */
+  getAdvancedIdentityProfileRequirements() {
+    return this.advancedIdentityProfileRequirements;
+  }
+
+  /**
    * @returns {Object} data for JSON.stringify()
    */
   toJSON() {
@@ -84,6 +98,12 @@ module.exports = class DynamicPolicy {
       wanted_remember_me_optional: false,
     };
     const identityProfileRequirements = this.getIdentityProfileRequirements();
+    const advancedIdentityProfileRequirements = this.getAdvancedIdentityProfileRequirements();
+    if (advancedIdentityProfileRequirements) {
+      return Object.assign(base, {
+        advanced_identity_profile_requirements: advancedIdentityProfileRequirements,
+      });
+    }
     if (identityProfileRequirements) {
       return Object.assign(base, { identity_profile_requirements: identityProfileRequirements });
     }

--- a/tests/dynamic_sharing_service/policy/dynamic.policy.builder.spec.js
+++ b/tests/dynamic_sharing_service/policy/dynamic.policy.builder.spec.js
@@ -451,4 +451,78 @@ describe('DynamicPolicyBuilder', () => {
       });
     });
   });
+
+  describe('when using with advanced identity profile requirements', () => {
+    const advancedIdentityProfileRequirementsDescriptor = {
+      profiles: [
+        {
+          trust_framework: 'UK_TFIDA',
+          schemes: [
+            {
+              label: 'LB912',
+              type: 'RTW',
+            },
+            {
+              label: 'LB777',
+              type: 'DBS',
+              objective: 'BASIC',
+            },
+          ],
+        },
+        {
+          trust_framework: 'YOTI_GLOBAL',
+          schemes: [
+            {
+              label: 'LB321',
+              type: 'IDENTITY',
+              objective: 'AL_L1',
+            },
+          ],
+        },
+      ],
+    };
+
+    it('should build with identity profile requirements only', () => {
+      const dynamicPolicy = new DynamicPolicyBuilder()
+        .withAdvancedIdentityProfileRequirements(advancedIdentityProfileRequirementsDescriptor)
+        .build();
+
+      expect(dynamicPolicy.getAdvancedIdentityProfileRequirements())
+        .toEqual(advancedIdentityProfileRequirementsDescriptor);
+
+      expectDynamicPolicyJson(dynamicPolicy, {
+        wanted: [],
+        wanted_auth_types: [],
+        wanted_remember_me: false,
+        wanted_remember_me_optional: false,
+        advanced_identity_profile_requirements: advancedIdentityProfileRequirementsDescriptor,
+      });
+    });
+
+    it('should build with identity profile requirements alongside other wanted attributes', () => {
+      const dynamicPolicy = new DynamicPolicyBuilder()
+        .withGender()
+        .withNationality()
+        .withAdvancedIdentityProfileRequirements(advancedIdentityProfileRequirementsDescriptor)
+        .build();
+
+      const expectedWantedAttributeData = [
+        { name: 'gender', optional: false },
+        { name: 'nationality', optional: false },
+      ];
+
+      expectDynamicPolicyAttributes(dynamicPolicy, expectedWantedAttributeData);
+
+      expect(dynamicPolicy.getAdvancedIdentityProfileRequirements())
+        .toEqual(advancedIdentityProfileRequirementsDescriptor);
+
+      expectDynamicPolicyJson(dynamicPolicy, {
+        wanted: expectedWantedAttributeData,
+        wanted_auth_types: [],
+        wanted_remember_me: false,
+        wanted_remember_me_optional: false,
+        advanced_identity_profile_requirements: advancedIdentityProfileRequirementsDescriptor,
+      });
+    });
+  });
 });

--- a/types/src/dynamic_sharing_service/policy/dynamic.policy.builder.d.ts
+++ b/types/src/dynamic_sharing_service/policy/dynamic.policy.builder.d.ts
@@ -116,10 +116,67 @@ declare class DynamicPolicyBuilder {
     withWantedRememberMe(wantedRememberMe: boolean): this;
     wantedRememberMe: boolean;
     /**
-     * @param {object} identityProfileRequirements
+     * @typedef {Object} SimpleScheme
+     * @property {string} type
+     * @property {string} [objective]
+     *
+     * @param {Object} identityProfileRequirements
+     * @param {string} identityProfileRequirements.trust_framework
+     * @param {SimpleScheme} identityProfileRequirements.scheme
      */
-    withIdentityProfileRequirements(identityProfileRequirements: object): this;
-    identityProfileRequirements: any;
+    withIdentityProfileRequirements(identityProfileRequirements: {
+        trust_framework: string;
+        scheme: {
+            type: string;
+            objective?: string;
+        };
+    }): this;
+    identityProfileRequirements: {
+        trust_framework: string;
+        scheme: {
+            type: string;
+            objective?: string;
+        };
+    };
+    /**
+     * @typedef {Object} AdvancedScheme
+     * @property {string} type
+     * @property {string} objective
+     * @property {string} label
+     *
+     * @typedef {Object} AdvancedProfileRequirements
+     * @property {string} trust_framework - Expected: 'UK_TFIDA' | 'YOTI_GLOBAL'
+     * @property {Array<AdvancedScheme>} schemes
+     *
+     * @param {Object} advancedIdentityProfileRequirements
+     * @param {Array<AdvancedProfileRequirements>} advancedIdentityProfileRequirements.profiles
+     */
+    withAdvancedIdentityProfileRequirements(advancedIdentityProfileRequirements: {
+        profiles: {
+            /**
+             * - Expected: 'UK_TFIDA' | 'YOTI_GLOBAL'
+             */
+            trust_framework: string;
+            schemes: {
+                type: string;
+                objective: string;
+                label: string;
+            }[];
+        }[];
+    }): this;
+    advancedIdentityProfileRequirements: {
+        profiles: {
+            /**
+             * - Expected: 'UK_TFIDA' | 'YOTI_GLOBAL'
+             */
+            trust_framework: string;
+            schemes: {
+                type: string;
+                objective: string;
+                label: string;
+            }[];
+        }[];
+    };
     /**
      * @returns {DynamicPolicy}
      */

--- a/types/src/dynamic_sharing_service/policy/dynamic.policy.d.ts
+++ b/types/src/dynamic_sharing_service/policy/dynamic.policy.d.ts
@@ -5,8 +5,9 @@ declare class DynamicPolicy {
      * @param {number[]} wantedAuthTypes - auth types represents the authentication type to be used.
      * @param {boolean} wantedRememberMe
      * @param {object} identityProfileRequirements
+     * @param {object} advancedIdentityProfileRequirements
      */
-    constructor(wantedAttributes: WantedAttribute[], wantedAuthTypes: number[], wantedRememberMe?: boolean, identityProfileRequirements?: object);
+    constructor(wantedAttributes: WantedAttribute[], wantedAuthTypes: number[], wantedRememberMe?: boolean, identityProfileRequirements?: object, advancedIdentityProfileRequirements?: object);
     /** @private */
     private wantedAttributes;
     /** @private */
@@ -15,6 +16,7 @@ declare class DynamicPolicy {
     private wantedRememberMe;
     /** @private */
     private identityProfileRequirements;
+    advancedIdentityProfileRequirements: any;
     /**
      * @returns {WantedAttribute[]} array of attributes to be requested.
      */
@@ -31,6 +33,10 @@ declare class DynamicPolicy {
      * @return {Object}
      */
     getIdentityProfileRequirements(): any;
+    /**
+     * @return {Object}
+     */
+    getAdvancedIdentityProfileRequirements(): any;
     /**
      * @returns {Object} data for JSON.stringify()
      */


### PR DESCRIPTION
Modified src/dynamic_sharing_service:
- added to DynamicPolicyBuilder the method .withAdvancedIdentityProfileRequirements()
- updated DynamicPolicy constructor to accept an additional parameter (advancedIdentityProfileRequirements) and to include it in the payload as 'advanced_identity_profile_requirements'.

Updated examples/profile-identity-checks:
- added an new case to demo the advanced identity profile requirements
- added extraction/display of 'verification_reports' and 'authentication_reports' 