### PR TITLE
SDK-2417 advanced identity profile share v2

### DIFF
--- a/examples/digital-identity/controllers/profile.controller.js
+++ b/examples/digital-identity/controllers/profile.controller.js
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 const {
   constants: {
     ATTR_SELFIE,
@@ -178,32 +179,80 @@ function renderProfileWithIdentity(profile, res) {
   const identityProfile = profile.getIdentityProfileReport().getValue();
   let identityAssertion = null;
   let verificationReport = null;
+  let verificationReports = null;
   let authenticationReport = null;
+  let authenticationReports = null;
+  let identityAssertionProof = null;
   let documentImagesAttributes = [];
+  let selfieAttribute = null;
 
   const {
-    identity_assertion: assertion,
-    verification_report: verification,
-    authentication_report: authentication,
+    identity_assertion,
+    verification_report,
+    verification_reports,
+    authentication_report,
+    authentication_reports,
+    proof,
   } = identityProfile;
 
-  identityAssertion = assertion;
-  verificationReport = verification;
-  authenticationReport = authentication;
+  identityAssertion = identity_assertion;
+  verificationReport = verification_report;
+  verificationReports = verification_reports;
+  authenticationReport = authentication_report;
+  authenticationReports = authentication_reports;
+  identityAssertionProof = proof;
 
-  const { evidence } = verificationReport;
-  const { documents } = evidence;
-  documentImagesAttributes = documents
-  // eslint-disable-next-line camelcase
-    .map(({ document_images_attribute_id }) => (document_images_attribute_id
-      ? (profile && profile.getAttributeById(document_images_attribute_id)) : null))
-    .filter((documentImagesAttribute) => documentImagesAttribute);
+  if (verificationReport) {
+    const { evidence } = verificationReport;
+    const { face, documents } = evidence;
+
+    // Document images (if any)
+    documentImagesAttributes = documents
+      .map(({ document_images_attribute_id }) => (document_images_attribute_id
+        ? (profile && profile.getAttributeById(document_images_attribute_id)) : null))
+      .filter((documentImagesAttribute) => documentImagesAttribute);
+
+    // Selfie image (if any)
+    const { selfie_attribute_id } = face;
+    selfieAttribute = selfie_attribute_id
+      ? (profile && profile.getAttributeById(selfie_attribute_id))
+      : null;
+  } else if (verificationReports.length > 0) {
+    // Document images (if any)
+    const documentImagesAttributesArray = verificationReports.map((report) => {
+      const { evidence } = report;
+      const { documents } = evidence;
+
+      return documents
+        .map(({ document_images_attribute_id }) => (document_images_attribute_id
+          ? (profile && profile.getAttributeById(document_images_attribute_id)) : null))
+        .filter((documentImagesAttribute) => documentImagesAttribute);
+    });
+    documentImagesAttributes = documentImagesAttributesArray.flat();
+
+    // Selfie image (if any)
+    const selfieAttributeArray = verificationReports.map((report) => {
+      const { evidence } = report;
+      const { face } = evidence;
+      const { selfie_attribute_id } = face;
+
+      return selfie_attribute_id
+        ? (profile && profile.getAttributeById(selfie_attribute_id))
+        : null;
+    });
+    // eslint-disable-next-line prefer-destructuring
+    selfieAttribute = selfieAttributeArray.filter((selfie) => selfie)[0];
+  }
 
   res.render('pages/profile-with-identity', {
     identityAssertion,
     verificationReport,
+    verificationReports,
     authenticationReport,
+    authenticationReports,
+    identityAssertionProof,
     documentImagesAttributes,
+    selfieAttribute,
   });
 }
 

--- a/examples/digital-identity/controllers/profile.controller.js
+++ b/examples/digital-identity/controllers/profile.controller.js
@@ -1,4 +1,3 @@
-/* eslint-disable camelcase */
 const {
   constants: {
     ATTR_SELFIE,
@@ -177,30 +176,17 @@ function renderProfile(profile, res) {
 
 function renderProfileWithIdentity(profile, res) {
   const identityProfile = profile.getIdentityProfileReport().getValue();
-  let identityAssertion = null;
-  let verificationReport = null;
-  let verificationReports = null;
-  let authenticationReport = null;
-  let authenticationReports = null;
-  let identityAssertionProof = null;
   let documentImagesAttributes = [];
   let selfieAttribute = null;
 
   const {
-    identity_assertion,
-    verification_report,
-    verification_reports,
-    authentication_report,
-    authentication_reports,
-    proof,
+    identity_assertion: identityAssertion,
+    verification_report: verificationReport,
+    verification_reports: verificationReports,
+    authentication_report: authenticationReport,
+    authentication_reports: authenticationReports,
+    proof: identityAssertionProof,
   } = identityProfile;
-
-  identityAssertion = identity_assertion;
-  verificationReport = verification_report;
-  verificationReports = verification_reports;
-  authenticationReport = authentication_report;
-  authenticationReports = authentication_reports;
-  identityAssertionProof = proof;
 
   if (verificationReport) {
     const { evidence } = verificationReport;
@@ -208,14 +194,16 @@ function renderProfileWithIdentity(profile, res) {
 
     // Document images (if any)
     documentImagesAttributes = documents
-      .map(({ document_images_attribute_id }) => (document_images_attribute_id
-        ? (profile && profile.getAttributeById(document_images_attribute_id)) : null))
+    // eslint-disable-next-line max-len
+      .map(({ document_images_attribute_id: documentImagesAttributeId }) => (documentImagesAttributeId
+        ? (profile && profile.getAttributeById(documentImagesAttributeId))
+        : null))
       .filter((documentImagesAttribute) => documentImagesAttribute);
 
     // Selfie image (if any)
-    const { selfie_attribute_id } = face;
-    selfieAttribute = selfie_attribute_id
-      ? (profile && profile.getAttributeById(selfie_attribute_id))
+    const { selfie_attribute_id: selfieAttributeId } = face;
+    selfieAttribute = selfieAttributeId
+      ? (profile && profile.getAttributeById(selfieAttributeId))
       : null;
   } else if (verificationReports.length > 0) {
     // Document images (if any)
@@ -224,8 +212,9 @@ function renderProfileWithIdentity(profile, res) {
       const { documents } = evidence;
 
       return documents
-        .map(({ document_images_attribute_id }) => (document_images_attribute_id
-          ? (profile && profile.getAttributeById(document_images_attribute_id)) : null))
+      // eslint-disable-next-line max-len
+        .map(({ document_images_attribute_id: documentImagesAttributeId }) => (documentImagesAttributeId
+          ? (profile && profile.getAttributeById(documentImagesAttributeId)) : null))
         .filter((documentImagesAttribute) => documentImagesAttribute);
     });
     documentImagesAttributes = documentImagesAttributesArray.flat();
@@ -234,10 +223,10 @@ function renderProfileWithIdentity(profile, res) {
     const selfieAttributeArray = verificationReports.map((report) => {
       const { evidence } = report;
       const { face } = evidence;
-      const { selfie_attribute_id } = face;
+      const { selfie_attribute_id: selfieAttributeId } = face;
 
-      return selfie_attribute_id
-        ? (profile && profile.getAttributeById(selfie_attribute_id))
+      return selfieAttributeId
+        ? (profile && profile.getAttributeById(selfieAttributeId))
         : null;
     });
     // eslint-disable-next-line prefer-destructuring

--- a/examples/digital-identity/controllers/share.controller.js
+++ b/examples/digital-identity/controllers/share.controller.js
@@ -9,60 +9,49 @@ const {
 const config = require('../config');
 const sdkDigitalIdentityClient = require('./sdk.digital.identity.client');
 
-const identityProfileRequirementsDescriptors = {
-  RTW: {
-    trust_framework: 'UK_TFIDA',
-    scheme: {
-      type: 'RTW',
+const SIMPLE_CASE_IDENTIFIER = 'simple-identity-case';
+const ADVANCED_CASE_IDENTIFIER = 'advanced-identity-case';
+
+const simpleIdentityRequirement = {
+  trust_framework: 'UK_TFIDA',
+  scheme: {
+    type: 'RTW',
+  },
+};
+
+const advancedIdentityRequirement = {
+  profiles: [
+    {
+      trust_framework: 'UK_TFIDA',
+      schemes: [
+        {
+          type: 'DBS',
+          objective: 'STANDARD',
+          label: 'dbs-standard',
+        },
+        {
+          type: 'RTW',
+          objective: '',
+          label: 'rtw',
+        },
+      ],
     },
-  },
-  RTR: {
-    trust_framework: 'UK_TFIDA',
-    scheme: {
-      type: 'RTR',
+    {
+      trust_framework: 'YOTI_GLOBAL',
+      schemes: [
+        {
+          type: 'IDENTITY',
+          objective: 'AL_L1',
+          label: 'identity-AL-L1',
+        },
+        {
+          type: 'IDENTITY',
+          objective: 'AL_M1',
+          label: 'identity-AL-M1',
+        },
+      ],
     },
-  },
-  DBS_BASIC: {
-    trust_framework: 'UK_TFIDA',
-    scheme: {
-      type: 'DBS',
-      objective: 'BASIC',
-    },
-  },
-  MTF_BASE: {
-    profiles: [
-      {
-        trust_framework: 'UK_TFIDA',
-        schemes: [
-          {
-            type: 'DBS',
-            objective: 'STANDARD',
-            label: 'dbs-standard',
-          },
-          {
-            type: 'RTW',
-            objective: '',
-            label: 'rtw',
-          },
-        ],
-      },
-      {
-        trust_framework: 'YOTI_GLOBAL',
-        schemes: [
-          {
-            type: 'IDENTITY',
-            objective: 'AL_L1',
-            label: 'identity-AL-L1',
-          },
-          {
-            type: 'IDENTITY',
-            objective: 'AL_M1',
-            label: 'identity-AL-M1',
-          },
-        ],
-      },
-    ],
-  },
+  ],
 };
 
 const router = Router();
@@ -78,25 +67,31 @@ router.get('/get-new-session-id', async (req, res) => {
   const { policyType } = query;
 
   const policyBuilder = new PolicyBuilder();
-  if (policyType === 'MTF_BASE') {
-    const identityProfileRequirementsDescriptor = identityProfileRequirementsDescriptors.MTF_BASE;
-    policyBuilder
-      .withAdvancedIdentityProfileRequirements(identityProfileRequirementsDescriptor);
-  } else if (Object.keys(identityProfileRequirementsDescriptors).includes(policyType)) {
-    policyBuilder
-      .withIdentityProfileRequirements(identityProfileRequirementsDescriptors[policyType]);
-  } else {
-    policyBuilder.withFullName()
-      .withEmail()
-      .withPhoneNumber()
-      .withSelfie()
-      .withStructuredPostalAddress()
-      .withAgeOver(18)
-      .withNationality()
-      .withGender()
-      .withDocumentDetails()
-      .withDocumentImages()
-      .withWantedRememberMe();
+
+  switch (policyType) {
+    case SIMPLE_CASE_IDENTIFIER:
+      policyBuilder
+        .withIdentityProfileRequirements(simpleIdentityRequirement);
+      break;
+
+    case ADVANCED_CASE_IDENTIFIER:
+      policyBuilder
+        .withAdvancedIdentityProfileRequirements(advancedIdentityRequirement);
+      break;
+
+    default:
+      policyBuilder.withFullName()
+        .withEmail()
+        .withPhoneNumber()
+        .withSelfie()
+        .withStructuredPostalAddress()
+        .withAgeOver(18)
+        .withNationality()
+        .withGender()
+        .withDocumentDetails()
+        .withDocumentImages()
+        .withWantedRememberMe();
+      break;
   }
 
   const policy = policyBuilder.build();
@@ -144,18 +139,48 @@ router.get('/get-receipt', async (req, res) => {
         error: receiptError,
       };
     } else if (hasIdentityProfile) {
-      const { verification_report: verificationReport } = profile.getIdentityProfileReport().value;
+      const identityProfileReport = profile.getIdentityProfileReport().getValue();
       const {
-        trust_framework: trustFramework,
-        schemes_compliance: schemesCompliance,
-      } = verificationReport;
+        verification_report: verificationReport,
+        verification_reports: verificationReports,
+      } = identityProfileReport;
 
-      receiptData = {
-        ...receiptData,
-        hasIdentityProfile: true,
-        trustFramework,
-        schemesCount: schemesCompliance.length,
-      };
+      const isAdvancedIdentityProfile = verificationReports && verificationReports.length;
+
+      if (isAdvancedIdentityProfile) {
+        let schemesCount = 0;
+        const trustFrameworks = [];
+
+        verificationReports.forEach((report) => {
+          const {
+            schemes_compliance: schemesCompliance,
+            trust_framework: trustFramework,
+          } = report;
+          trustFrameworks.push(trustFramework);
+          schemesCount += schemesCompliance.length;
+        });
+
+        receiptData = {
+          ...receiptData,
+          hasIdentityProfile: true,
+          isAdvanced: true,
+          trustFrameworks,
+          schemesCount,
+        };
+      } else {
+        const {
+          trust_framework: trustFramework,
+          schemes_compliance: schemesCompliance,
+        } = verificationReport;
+
+        receiptData = {
+          ...receiptData,
+          hasIdentityProfile: true,
+          isAdvanced: false,
+          trustFramework,
+          schemesCount: schemesCompliance.length,
+        };
+      }
     } else {
       receiptData = {
         ...receiptData,

--- a/examples/digital-identity/controllers/share.controller.js
+++ b/examples/digital-identity/controllers/share.controller.js
@@ -9,6 +9,62 @@ const {
 const config = require('../config');
 const sdkDigitalIdentityClient = require('./sdk.digital.identity.client');
 
+const identityProfileRequirementsDescriptors = {
+  RTW: {
+    trust_framework: 'UK_TFIDA',
+    scheme: {
+      type: 'RTW',
+    },
+  },
+  RTR: {
+    trust_framework: 'UK_TFIDA',
+    scheme: {
+      type: 'RTR',
+    },
+  },
+  DBS_BASIC: {
+    trust_framework: 'UK_TFIDA',
+    scheme: {
+      type: 'DBS',
+      objective: 'BASIC',
+    },
+  },
+  MTF_BASE: {
+    profiles: [
+      {
+        trust_framework: 'UK_TFIDA',
+        schemes: [
+          {
+            type: 'DBS',
+            objective: 'STANDARD',
+            label: 'dbs-standard',
+          },
+          {
+            type: 'RTW',
+            objective: '',
+            label: 'rtw',
+          },
+        ],
+      },
+      {
+        trust_framework: 'YOTI_GLOBAL',
+        schemes: [
+          {
+            type: 'IDENTITY',
+            objective: 'AL_L1',
+            label: 'identity-AL-L1',
+          },
+          {
+            type: 'IDENTITY',
+            objective: 'AL_M1',
+            label: 'identity-AL-M1',
+          },
+        ],
+      },
+    ],
+  },
+};
+
 const router = Router();
 
 router.get('/', (req, res) => {
@@ -22,14 +78,13 @@ router.get('/get-new-session-id', async (req, res) => {
   const { policyType } = query;
 
   const policyBuilder = new PolicyBuilder();
-
-  if (policyType === 'RTW') {
-    policyBuilder.withIdentityProfileRequirements({
-      trust_framework: 'UK_TFIDA',
-      scheme: {
-        type: 'RTW',
-      },
-    });
+  if (policyType === 'MTF_BASE') {
+    const identityProfileRequirementsDescriptor = identityProfileRequirementsDescriptors.MTF_BASE;
+    policyBuilder
+      .withAdvancedIdentityProfileRequirements(identityProfileRequirementsDescriptor);
+  } else if (Object.keys(identityProfileRequirementsDescriptors).includes(policyType)) {
+    policyBuilder
+      .withIdentityProfileRequirements(identityProfileRequirementsDescriptors[policyType]);
   } else {
     policyBuilder.withFullName()
       .withEmail()

--- a/examples/digital-identity/static/index.css
+++ b/examples/digital-identity/static/index.css
@@ -45,18 +45,21 @@
 
 .yoti-share-buttons-section {
     display: flex;
-    gap: 1em
+    gap: 1em;
+    flex-wrap: wrap;
+    align-items: stretch;
+    justify-content: center;
 }
 
 .yoti-share-button-container {
     background: rgba(211, 211, 211, 0.5);
     padding: 1em;
-}
-
-
-#yoti-share-button2 {
-    width: fit-content;
-    height: 45px;
+    flex-basis: 335px;
+    max-width: fit-content;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    justify-content: space-between;
 }
 
 #yoti-share-completion {

--- a/examples/digital-identity/views/pages/profile-with-identity.ejs
+++ b/examples/digital-identity/views/pages/profile-with-identity.ejs
@@ -15,38 +15,79 @@
                 <div class="yoti-logo-section">
                     <a href="/">
                         <img class="yoti-logo-image"
-                                src="/static/assets/logo.png"
-                                srcset="/static/assets/logo@2x.png 2x"
-                                alt="Yoti"/>
+                             src="/static/assets/logo.png"
+                             srcset="/static/assets/logo@2x.png 2x"
+                             alt="Yoti"/>
                     </a>
                 </div>
             </section>
 
-            <section class="yoti-report-section">
-                <h1 class="yoti-main-title">Identity profile report</h1>
-                <div>
-                    <h4>Identity assertion:</h4>
-                    <pre><%= JSON.stringify(identityAssertion, null, 2) %></pre>
-                </div>
-                <div>
-                    <h4>Verification report:</h4>
-                    <pre><%= JSON.stringify(verificationReport, null, 2) %></pre>
-                </div>
-                <div>
-                    <h4>Authentication report:</h4>
-                    <pre><%= JSON.stringify(authenticationReport, null, 2) %></pre>
-                </div>
-                <div>
-                    <h4>Documents images attributes:</h4>
-                    <% documentImagesAttributes.forEach((docImgAttr) => { %>
-                        <span>Document image ID: </span>
-                        <span><%= docImgAttr.getId() %></span>
-                        <br>
-                        <br>
-                        <% docImgAttr.getValue().forEach((image) => { %>
-                            <img src="<%= image.getBase64Content() %>" alt="Document image"/>
-                        <% }) %>
-                    <% }) %>
+            <section>
+                <div class="yoti-report-section">
+                    <% if (identityAssertion ) { %>
+                        <div>
+                            <h4>Identity assertion:</h4>
+                            <pre><%= JSON.stringify(identityAssertion, null, 2) %></pre>
+                        </div>
+                    <% } %>
+                    <% if (verificationReport ) { %>
+                        <div>
+                            <h4>Verification report:</h4>
+                            <pre><%= JSON.stringify(verificationReport, null, 2) %></pre>
+                        </div>
+                    <% } %>
+                    <% if (authenticationReport ) { %>
+                        <div>
+                            <h4>Authentication report:</h4>
+                            <pre><%= JSON.stringify(authenticationReport, null, 2) %></pre>
+                        </div>
+                    <% } %>
+                    <% if (verificationReports && verificationReports.length !== 0 ) { %>
+                        <div>
+                            <h4>Verification reports:</h4>
+                            <pre><%= JSON.stringify(verificationReports, null, 2) %></pre>
+                        </div>
+                    <% } %>
+                    <% if (authenticationReports && authenticationReports.length !== 0 ) { %>
+                        <div>
+                            <h4>Authentication reports:</h4>
+                            <pre><%= JSON.stringify(authenticationReports, null, 2) %></pre>
+                        </div>
+                    <% } %>
+                    <% if (identityAssertionProof ) { %>
+                        <div>
+                            <h4>Proof:</h4>
+                            <pre><%= JSON.stringify(identityAssertionProof, null, 2) %></pre>
+                        </div>
+                    <% } %>
+                    <% if (documentImagesAttributes && documentImagesAttributes.length !== 0 ) { %>
+                        <div>
+                            <h4>Documents images attributes:</h4>
+                            <% documentImagesAttributes.forEach((docImgAttr) => { %>
+                                <span>Document image ID: </span>
+                                <span><%= docImgAttr.getId() %></span>
+                                <br>
+                                <br>
+                                <% docImgAttr.getValue().forEach((image) => { %>
+                                    <img src="<%= image.getBase64Content() %>" alt="Document image"/>
+                                <% }) %>
+                                <br>
+                                <br>
+                            <% }) %>
+                        </div>
+                    <% } %>
+                    <% if (selfieAttribute ) { %>
+                        <div>
+                            <h4>Selfie:</h4>
+                            <span>Selfie ID: </span>
+                            <span><%= selfieAttribute.getId() %></span>
+                            <br>
+                            <br>
+                            <img src="<%= selfieAttribute.getValue().getBase64Content() %>" alt="Selfie"/>
+                            <br>
+                            <br>
+                        </div>
+                    <% } %>
                 </div>
             </section>
         </main>

--- a/examples/digital-identity/views/pages/share.ejs
+++ b/examples/digital-identity/views/pages/share.ejs
@@ -31,8 +31,16 @@
         <div class="yoti-share-button-container">
           <p>
             Start the flow to assert Right To Work
+            <br/><small>(using just UK Identity Trust Framework)</small>
           </p>
-          <div id="yoti-share-button-right-to-work"></div>
+          <div id="yoti-share-button-simple-rtw"></div>
+        </div>
+        <div class="yoti-share-button-container">
+          <p>
+            Start the flow to assert Right To Work and DBS
+            <br/><small>(with Yoti Identity Trust Framework as fallback)</small>
+          </p>
+          <div id="yoti-share-button-advanced-rtw"></div>
         </div>
 
       </div>
@@ -140,18 +148,29 @@
               domId: 'yoti-share-button-basic-attributes',
               sdkId: "<%= yotiClientSdkId %>",
               hooks: {
-                sessionIdResolver,
+                sessionIdResolver: ()=>sessionIdResolver('attributes-case'),
                 completionHandler,
                 errorListener,
               },
             })
 
             await Yoti.createWebShare({
-              name: 'share example RTW',
-              domId: 'yoti-share-button-right-to-work',
+              name: 'share example simple RTW',
+              domId: 'yoti-share-button-simple-rtw',
               sdkId: "<%= yotiClientSdkId %>",
               hooks: {
-                sessionIdResolver: ()=>sessionIdResolver('RTW'),
+                sessionIdResolver: ()=>sessionIdResolver('simple-identity-case'),
+                completionHandler,
+                errorListener,
+              },
+            })
+
+            await Yoti.createWebShare({
+              name: 'share example advanced RTW (with extra DBS and Yoti Identity fallback)',
+              domId: 'yoti-share-button-advanced-rtw',
+              sdkId: "<%= yotiClientSdkId %>",
+              hooks: {
+                sessionIdResolver: ()=>sessionIdResolver('advanced-identity-case'),
                 completionHandler,
                 errorListener,
               },

--- a/src/digital_identity_service/policy/policy.builder.js
+++ b/src/digital_identity_service/policy/policy.builder.js
@@ -336,11 +336,34 @@ module.exports = class PolicyBuilder {
   }
 
   /**
-   * @param {object} identityProfileRequirements
-   * @returns this
+   * @typedef {Object} SimpleScheme
+   * @property {string} type
+   * @property {string} [objective]
+   *
+   * @param {Object} identityProfileRequirements
+   * @param {string} identityProfileRequirements.trust_framework
+   * @param {SimpleScheme} identityProfileRequirements.scheme
    */
   withIdentityProfileRequirements(identityProfileRequirements) {
     this.identityProfileRequirements = identityProfileRequirements;
+    return this;
+  }
+
+  /**
+   * @typedef {Object} AdvancedScheme
+   * @property {string} type
+   * @property {string} objective
+   * @property {string} label
+   *
+   * @typedef {Object} AdvancedProfileRequirements
+   * @property {string} trust_framework - Expected: 'UK_TFIDA' | 'YOTI_GLOBAL'
+   * @property {Array<AdvancedScheme>} schemes
+   *
+   * @param {Object} advancedIdentityProfileRequirements
+   * @param {Array<AdvancedProfileRequirements>} advancedIdentityProfileRequirements.profiles
+   */
+  withAdvancedIdentityProfileRequirements(advancedIdentityProfileRequirements) {
+    this.advancedIdentityProfileRequirements = advancedIdentityProfileRequirements;
     return this;
   }
 
@@ -352,7 +375,8 @@ module.exports = class PolicyBuilder {
       Object.keys(this.wantedAttributes).map((k) => this.wantedAttributes[k]),
       this.wantedAuthTypes.filter((value, index, self) => self.indexOf(value) === index),
       this.wantedRememberMe,
-      this.identityProfileRequirements
+      this.identityProfileRequirements,
+      this.advancedIdentityProfileRequirements
     );
   }
 };

--- a/src/digital_identity_service/policy/policy.js
+++ b/src/digital_identity_service/policy/policy.js
@@ -14,12 +14,14 @@ module.exports = class Policy {
    * @param {number[]} wantedAuthTypes - auth types represents the authentication type to be used.
    * @param {boolean} wantedRememberMe
    * @param {object} identityProfileRequirements
+   * @param {object} advancedIdentityProfileRequirements
    */
   constructor(
     wantedAttributes,
     wantedAuthTypes,
     wantedRememberMe = false,
-    identityProfileRequirements = null
+    identityProfileRequirements = null,
+    advancedIdentityProfileRequirements = null
   ) {
     Validation.isArrayOfType(wantedAttributes, WantedAttribute, 'wantedAttribute');
     /** @private */
@@ -42,6 +44,11 @@ module.exports = class Policy {
       Validation.isPlainObject(identityProfileRequirements, 'identityProfileRequirements');
       /** @private */
       this.identityProfileRequirements = identityProfileRequirements;
+    }
+
+    if (advancedIdentityProfileRequirements) {
+      Validation.isPlainObject(advancedIdentityProfileRequirements, 'advancedIdentityProfileRequirements');
+      this.advancedIdentityProfileRequirements = advancedIdentityProfileRequirements;
     }
   }
 
@@ -74,6 +81,13 @@ module.exports = class Policy {
   }
 
   /**
+   * @return {Object}
+   */
+  getAdvancedIdentityProfileRequirements() {
+    return this.advancedIdentityProfileRequirements;
+  }
+
+  /**
    * @returns {Object} data for JSON.stringify()
    */
   toJSON() {
@@ -84,6 +98,12 @@ module.exports = class Policy {
       wanted_remember_me_optional: false,
     };
     const identityProfileRequirements = this.getIdentityProfileRequirements();
+    const advancedIdentityProfileRequirements = this.getAdvancedIdentityProfileRequirements();
+    if (advancedIdentityProfileRequirements) {
+      return Object.assign(base, {
+        advanced_identity_profile_requirements: advancedIdentityProfileRequirements,
+      });
+    }
     if (identityProfileRequirements) {
       return Object.assign(base, { identity_profile_requirements: identityProfileRequirements });
     }

--- a/tests/digital_identity_service/policy/policy.builder.spec.js
+++ b/tests/digital_identity_service/policy/policy.builder.spec.js
@@ -453,4 +453,78 @@ describe('PolicyBuilder', () => {
       });
     });
   });
+
+  describe('when using with advanced identity profile requirements', () => {
+    const advancedIdentityProfileRequirementsDescriptor = {
+      profiles: [
+        {
+          trust_framework: 'UK_TFIDA',
+          schemes: [
+            {
+              label: 'LB912',
+              type: 'RTW',
+            },
+            {
+              label: 'LB777',
+              type: 'DBS',
+              objective: 'BASIC',
+            },
+          ],
+        },
+        {
+          trust_framework: 'YOTI_GLOBAL',
+          schemes: [
+            {
+              label: 'LB321',
+              type: 'IDENTITY',
+              objective: 'AL_L1',
+            },
+          ],
+        },
+      ],
+    };
+
+    it('should build with identity profile requirements only', () => {
+      const policy = new PolicyBuilder()
+        .withAdvancedIdentityProfileRequirements(advancedIdentityProfileRequirementsDescriptor)
+        .build();
+
+      expect(policy.getAdvancedIdentityProfileRequirements())
+        .toEqual(advancedIdentityProfileRequirementsDescriptor);
+
+      expectPolicyJson(policy, {
+        wanted: [],
+        wanted_auth_types: [],
+        wanted_remember_me: false,
+        wanted_remember_me_optional: false,
+        advanced_identity_profile_requirements: advancedIdentityProfileRequirementsDescriptor,
+      });
+    });
+
+    it('should build with identity profile requirements alongside other wanted attributes', () => {
+      const policy = new PolicyBuilder()
+        .withGender()
+        .withNationality()
+        .withAdvancedIdentityProfileRequirements(advancedIdentityProfileRequirementsDescriptor)
+        .build();
+
+      const expectedWantedAttributeData = [
+        { name: 'gender', optional: false },
+        { name: 'nationality', optional: false },
+      ];
+
+      expectPolicyAttributes(policy, expectedWantedAttributeData);
+
+      expect(policy.getAdvancedIdentityProfileRequirements())
+        .toEqual(advancedIdentityProfileRequirementsDescriptor);
+
+      expectPolicyJson(policy, {
+        wanted: expectedWantedAttributeData,
+        wanted_auth_types: [],
+        wanted_remember_me: false,
+        wanted_remember_me_optional: false,
+        advanced_identity_profile_requirements: advancedIdentityProfileRequirementsDescriptor,
+      });
+    });
+  });
 });

--- a/types/src/digital_identity_service/policy/policy.builder.d.ts
+++ b/types/src/digital_identity_service/policy/policy.builder.d.ts
@@ -138,11 +138,67 @@ declare class PolicyBuilder {
     withWantedRememberMe(wantedRememberMe?: boolean): this;
     wantedRememberMe: boolean;
     /**
-     * @param {object} identityProfileRequirements
-     * @returns this
+     * @typedef {Object} SimpleScheme
+     * @property {string} type
+     * @property {string} [objective]
+     *
+     * @param {Object} identityProfileRequirements
+     * @param {string} identityProfileRequirements.trust_framework
+     * @param {SimpleScheme} identityProfileRequirements.scheme
      */
-    withIdentityProfileRequirements(identityProfileRequirements: object): this;
-    identityProfileRequirements: any;
+    withIdentityProfileRequirements(identityProfileRequirements: {
+        trust_framework: string;
+        scheme: {
+            type: string;
+            objective?: string;
+        };
+    }): this;
+    identityProfileRequirements: {
+        trust_framework: string;
+        scheme: {
+            type: string;
+            objective?: string;
+        };
+    };
+    /**
+     * @typedef {Object} AdvancedScheme
+     * @property {string} type
+     * @property {string} objective
+     * @property {string} label
+     *
+     * @typedef {Object} AdvancedProfileRequirements
+     * @property {string} trust_framework - Expected: 'UK_TFIDA' | 'YOTI_GLOBAL'
+     * @property {Array<AdvancedScheme>} schemes
+     *
+     * @param {Object} advancedIdentityProfileRequirements
+     * @param {Array<AdvancedProfileRequirements>} advancedIdentityProfileRequirements.profiles
+     */
+    withAdvancedIdentityProfileRequirements(advancedIdentityProfileRequirements: {
+        profiles: {
+            /**
+             * - Expected: 'UK_TFIDA' | 'YOTI_GLOBAL'
+             */
+            trust_framework: string;
+            schemes: {
+                type: string;
+                objective: string;
+                label: string;
+            }[];
+        }[];
+    }): this;
+    advancedIdentityProfileRequirements: {
+        profiles: {
+            /**
+             * - Expected: 'UK_TFIDA' | 'YOTI_GLOBAL'
+             */
+            trust_framework: string;
+            schemes: {
+                type: string;
+                objective: string;
+                label: string;
+            }[];
+        }[];
+    };
     /**
      * @returns {Policy}
      */

--- a/types/src/digital_identity_service/policy/policy.d.ts
+++ b/types/src/digital_identity_service/policy/policy.d.ts
@@ -5,8 +5,9 @@ declare class Policy {
      * @param {number[]} wantedAuthTypes - auth types represents the authentication type to be used.
      * @param {boolean} wantedRememberMe
      * @param {object} identityProfileRequirements
+     * @param {object} advancedIdentityProfileRequirements
      */
-    constructor(wantedAttributes: WantedAttribute[], wantedAuthTypes: number[], wantedRememberMe?: boolean, identityProfileRequirements?: object);
+    constructor(wantedAttributes: WantedAttribute[], wantedAuthTypes: number[], wantedRememberMe?: boolean, identityProfileRequirements?: object, advancedIdentityProfileRequirements?: object);
     /** @private */
     private wantedAttributes;
     /** @private */
@@ -15,6 +16,7 @@ declare class Policy {
     private wantedRememberMe;
     /** @private */
     private identityProfileRequirements;
+    advancedIdentityProfileRequirements: any;
     /**
      * @returns {WantedAttribute[]} array of attributes to be requested.
      */
@@ -31,6 +33,10 @@ declare class Policy {
      * @return {Object}
      */
     getIdentityProfileRequirements(): any;
+    /**
+     * @return {Object}
+     */
+    getAdvancedIdentityProfileRequirements(): any;
     /**
      * @returns {Object} data for JSON.stringify()
      */


### PR DESCRIPTION
Modified src/digital_identity_service:

added to PolicyBuilder the method .withAdvancedIdentityProfileRequirements()
updated Policy constructor to accept an additional parameter (advancedIdentityProfileRequirements) and to include it in the payload as 'advanced_identity_profile_requirements'.