### PR TITLE
SDK-2372 - IDV: surface identity profile failure reason details

### DIFF
--- a/src/idv_service/session/retrieve/identity.profile.failure.reason.response.js
+++ b/src/idv_service/session/retrieve/identity.profile.failure.reason.response.js
@@ -2,15 +2,59 @@
 
 const Validation = require('../../../yoti_common/validation');
 
+/**
+ * @typedef {Object} RequirementsNotMetDetail
+ * @property {string} [failureType]
+ * @property {string} [documentType]
+ * @property {string} [documentCountryIsoCode]
+ * @property {string} [auditId]
+ * @property {string} [details]
+ */
+
 class IdentityProfileFailureReasonResponse {
   constructor(failureReason) {
     Validation.isString(failureReason.reason_code, 'reason code');
     /** @private */
     this.reasonCode = failureReason.reason_code;
+
+    /** @private  */
+    this.requirementsNotMetDetails = [];
+
+    // eslint-disable-next-line camelcase
+    const { requirements_not_met_details: requirementsNotMetDetails } = failureReason;
+    if (requirementsNotMetDetails) {
+      Validation.isArray(requirementsNotMetDetails, 'requirements not met details');
+
+      this.requirementsNotMetDetails = requirementsNotMetDetails.map((detail) => {
+        const {
+          failure_type: failureType,
+          document_type: documentType,
+          document_country_iso_code: documentCountryIsoCode,
+          audit_id: auditId,
+          details,
+        } = detail;
+
+        return ({
+          failureType,
+          documentType,
+          documentCountryIsoCode,
+          auditId,
+          details,
+        });
+      });
+    }
+    /** @private */
   }
 
   getReasonCode() {
     return this.reasonCode;
+  }
+
+  /**
+   * @returns {RequirementsNotMetDetail[]}
+   */
+  getRequirementsNotMetDetails() {
+    return this.requirementsNotMetDetails;
   }
 }
 

--- a/src/idv_service/session/retrieve/identity.profile.failure.reason.response.js
+++ b/src/idv_service/session/retrieve/identity.profile.failure.reason.response.js
@@ -46,6 +46,9 @@ class IdentityProfileFailureReasonResponse {
     /** @private */
   }
 
+  /**
+   * @returns {string}
+   */
   getReasonCode() {
     return this.reasonCode;
   }

--- a/src/idv_service/session/retrieve/identity.profile.response.js
+++ b/src/idv_service/session/retrieve/identity.profile.response.js
@@ -44,7 +44,7 @@ class IdentityProfileResponse {
   }
 
   /**
-   * @returns {object}
+   * @returns {IdentityProfileFailureReasonResponse}
    */
   getFailureReason() {
     return this.failureReason;

--- a/tests/idv_service/session/retrieve/identity.profile.response.spec.js
+++ b/tests/idv_service/session/retrieve/identity.profile.response.spec.js
@@ -10,7 +10,23 @@ describe('IdentityProfileResponse', () => {
       subject_id: 'someStringHere',
       result: 'DONE',
       failure_reason: {
-        reason_code: 'MANDATORY_DOCUMENT_COULD_NOT_BE_PROVIDED',
+        reason_code: 'MANDATORY_DOCUMENT_NOT_PROVIDED',
+        requirements_not_met_details: [
+          {
+            failure_type: 'ID_DOCUMENT_EXTRACTION',
+            document_type: 'PASSPORT',
+            document_country_iso_code: 'GBR',
+            audit_id: 'audit-123',
+            details: 'something not right',
+          },
+          {
+            failure_type: 'ID_DOCUMENT_AUTHENTICITY',
+            document_type: 'PASSPORT',
+            document_country_iso_code: 'GBR',
+            audit_id: 'audit-456',
+            details: 'something still not right',
+          },
+        ],
       },
       identity_profile_report: {
         trust_framework: 'UK_TFIDA',
@@ -52,7 +68,23 @@ describe('IdentityProfileResponse', () => {
       expect(failureReason)
         .toBeInstanceOf(IdentityProfileFailureReasonResponse);
 
-      expect(failureReason.getReasonCode()).toBe('MANDATORY_DOCUMENT_COULD_NOT_BE_PROVIDED');
+      expect(failureReason.getReasonCode()).toBe('MANDATORY_DOCUMENT_NOT_PROVIDED');
+      expect(failureReason.getRequirementsNotMetDetails()).toHaveLength(2);
+      const [firstDetail, secondDetail] = failureReason.getRequirementsNotMetDetails();
+      expect(firstDetail).toEqual(expect.objectContaining({
+        failureType: 'ID_DOCUMENT_EXTRACTION',
+        documentType: 'PASSPORT',
+        documentCountryIsoCode: 'GBR',
+        auditId: 'audit-123',
+        details: 'something not right',
+      }));
+      expect(secondDetail).toEqual(expect.objectContaining({
+        failureType: 'ID_DOCUMENT_AUTHENTICITY',
+        documentType: 'PASSPORT',
+        documentCountryIsoCode: 'GBR',
+        auditId: 'audit-456',
+        details: 'something still not right',
+      }));
     });
   });
 

--- a/types/src/idv_service/session/retrieve/identity.profile.failure.reason.response.d.ts
+++ b/types/src/idv_service/session/retrieve/identity.profile.failure.reason.response.d.ts
@@ -1,7 +1,31 @@
 export = IdentityProfileFailureReasonResponse;
+/**
+ * @typedef {Object} RequirementsNotMetDetail
+ * @property {string} [failureType]
+ * @property {string} [documentType]
+ * @property {string} [documentCountryIsoCode]
+ * @property {string} [auditId]
+ * @property {string} [details]
+ */
 declare class IdentityProfileFailureReasonResponse {
     constructor(failureReason: any);
     /** @private */
     private reasonCode;
+    /** @private  */
+    private requirementsNotMetDetails;
     getReasonCode(): any;
+    /**
+     * @returns {RequirementsNotMetDetail[]}
+     */
+    getRequirementsNotMetDetails(): RequirementsNotMetDetail[];
 }
+declare namespace IdentityProfileFailureReasonResponse {
+    export { RequirementsNotMetDetail };
+}
+type RequirementsNotMetDetail = {
+    failureType?: string;
+    documentType?: string;
+    documentCountryIsoCode?: string;
+    auditId?: string;
+    details?: string;
+};

--- a/types/src/idv_service/session/retrieve/identity.profile.failure.reason.response.d.ts
+++ b/types/src/idv_service/session/retrieve/identity.profile.failure.reason.response.d.ts
@@ -13,7 +13,10 @@ declare class IdentityProfileFailureReasonResponse {
     private reasonCode;
     /** @private  */
     private requirementsNotMetDetails;
-    getReasonCode(): any;
+    /**
+     * @returns {string}
+     */
+    getReasonCode(): string;
     /**
      * @returns {RequirementsNotMetDetail[]}
      */

--- a/types/src/idv_service/session/retrieve/identity.profile.response.d.ts
+++ b/types/src/idv_service/session/retrieve/identity.profile.response.d.ts
@@ -18,12 +18,13 @@ declare class IdentityProfileResponse {
      */
     getResult(): string;
     /**
-     * @returns {object}
+     * @returns {IdentityProfileFailureReasonResponse}
      */
-    getFailureReason(): object;
+    getFailureReason(): IdentityProfileFailureReasonResponse;
     /**
      * @returns {IdentityProfileReportResponse}
      */
     getIdentityProfileReport(): IdentityProfileReportResponse;
 }
+import IdentityProfileFailureReasonResponse = require("./identity.profile.failure.reason.response");
 import IdentityProfileReportResponse = require("./identity.profile.report.response");


### PR DESCRIPTION
Surface the 'requirements not met details' within the IdentityProfile FailureReasonResponse.


#### Usage

Given a session (with identity profile requirement) is completed and retrieved:

```ts
const sessionResult = await idvClient.getSession(sessionId);
const identityProfile = sessionResult.getIdentityProfile();
if (identityProfile) {
  const failureReason = identityProfile.getFailureReason();

  if (failureReason) {
    const reasonCode = failureReason.getReasonCode(); // string
    const requirementsNotMetDetails = failureReason.getRequirementsNotMetDetails(); // Array of RequirementsNotMetDetail
    /*
    RequirementsNotMetDetail shape as follows:
    {
      failureType, //string
      documentType, //string
      documentCountryIsoCode, //string
      auditId, //string
      details, //string
    }
    */
  }
}
```
