### PR TITLE
SDK-2453 include requirements_not_met_details in scheme compliance

### DIFF
--- a/src/idv_service/session/retrieve/identity.profile.failure.reason.response.js
+++ b/src/idv_service/session/retrieve/identity.profile.failure.reason.response.js
@@ -1,23 +1,15 @@
 'use strict';
 
 const Validation = require('../../../yoti_common/validation');
-
-/**
- * @typedef {Object} RequirementsNotMetDetail
- * @property {string} [failureType]
- * @property {string} [documentType]
- * @property {string} [documentCountryIsoCode]
- * @property {string} [auditId]
- * @property {string} [details]
- */
+const IdentityProfileRequirementsNotMetDetailResponse = require('./identity.profile.requirements.not.met.detail.response');
 
 class IdentityProfileFailureReasonResponse {
   constructor(failureReason) {
     Validation.isString(failureReason.reason_code, 'reason code');
-    /** @private */
+    /** @private string */
     this.reasonCode = failureReason.reason_code;
 
-    /** @private  */
+    /** @private {IdentityProfileRequirementsNotMetDetailResponse[]} */
     this.requirementsNotMetDetails = [];
 
     // eslint-disable-next-line camelcase
@@ -25,37 +17,16 @@ class IdentityProfileFailureReasonResponse {
     if (requirementsNotMetDetails) {
       Validation.isArray(requirementsNotMetDetails, 'requirements not met details');
 
-      this.requirementsNotMetDetails = requirementsNotMetDetails.map((detail) => {
-        const {
-          failure_type: failureType,
-          document_type: documentType,
-          document_country_iso_code: documentCountryIsoCode,
-          audit_id: auditId,
-          details,
-        } = detail;
-
-        return ({
-          failureType,
-          documentType,
-          documentCountryIsoCode,
-          auditId,
-          details,
-        });
-      });
+      this.requirementsNotMetDetails = requirementsNotMetDetails
+        // eslint-disable-next-line max-len
+        .map((requirementsNotMetDetail) => new IdentityProfileRequirementsNotMetDetailResponse(requirementsNotMetDetail));
     }
-    /** @private */
   }
 
-  /**
-   * @returns {string}
-   */
   getReasonCode() {
     return this.reasonCode;
   }
 
-  /**
-   * @returns {RequirementsNotMetDetail[]}
-   */
   getRequirementsNotMetDetails() {
     return this.requirementsNotMetDetails;
   }

--- a/src/idv_service/session/retrieve/identity.profile.failure.reason.response.js
+++ b/src/idv_service/session/retrieve/identity.profile.failure.reason.response.js
@@ -6,10 +6,10 @@ const IdentityProfileRequirementsNotMetDetailResponse = require('./identity.prof
 class IdentityProfileFailureReasonResponse {
   constructor(failureReason) {
     Validation.isString(failureReason.reason_code, 'reason code');
-    /** @private string */
+    /** @private @type {string} */
     this.reasonCode = failureReason.reason_code;
 
-    /** @private {IdentityProfileRequirementsNotMetDetailResponse[]} */
+    /** @private @type {IdentityProfileRequirementsNotMetDetailResponse[]} */
     this.requirementsNotMetDetails = [];
 
     // eslint-disable-next-line camelcase

--- a/src/idv_service/session/retrieve/identity.profile.report.schemes.compliance.response.js
+++ b/src/idv_service/session/retrieve/identity.profile.report.schemes.compliance.response.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const Validation = require('../../../yoti_common/validation');
+const IdentityProfileRequirementsNotMetDetailResponse = require('./identity.profile.requirements.not.met.detail.response');
 
 class IdentityProfileReportSchemesComplianceResponse {
   constructor(schemesCompliance) {
@@ -9,13 +10,24 @@ class IdentityProfileReportSchemesComplianceResponse {
     this.scheme = schemesCompliance.scheme;
 
     Validation.isBoolean(schemesCompliance.requirements_met, 'requirements_met');
-    /** @private */
+    /** @private boolean */
     this.requirementsMet = schemesCompliance.requirements_met;
 
     if (schemesCompliance.requirements_not_met_info) {
       Validation.isString(schemesCompliance.requirements_not_met_info, 'requirements_not_met_info');
-      /** @private */
+      /** @private string|undefined */
       this.requirementsNotMetInfo = schemesCompliance.requirements_not_met_info;
+
+      /** @private {IdentityProfileRequirementsNotMetDetailResponse[]}|undefined */
+      this.requirementsNotMetDetails = [];
+
+      if (schemesCompliance.requirements_not_met_details) {
+        Validation.isArray(schemesCompliance.requirements_not_met_details, 'requirements not met details');
+
+        this.requirementsNotMetDetails = schemesCompliance.requirements_not_met_details
+        // eslint-disable-next-line max-len
+          .map((requirementsNotMetDetail) => new IdentityProfileRequirementsNotMetDetailResponse(requirementsNotMetDetail));
+      }
     }
   }
 
@@ -26,18 +38,16 @@ class IdentityProfileReportSchemesComplianceResponse {
     return this.scheme;
   }
 
-  /**
-   * @returns {boolean}
-   */
   isRequirementsMet() {
     return this.requirementsMet;
   }
 
-  /**
-   * @returns {string}
-   */
   getRequirementsNotMetInfo() {
     return this.requirementsNotMetInfo;
+  }
+
+  getRequirementsNotMetDetails() {
+    return this.requirementsNotMetDetails;
   }
 }
 

--- a/src/idv_service/session/retrieve/identity.profile.report.schemes.compliance.response.js
+++ b/src/idv_service/session/retrieve/identity.profile.report.schemes.compliance.response.js
@@ -10,15 +10,15 @@ class IdentityProfileReportSchemesComplianceResponse {
     this.scheme = schemesCompliance.scheme;
 
     Validation.isBoolean(schemesCompliance.requirements_met, 'requirements_met');
-    /** @private boolean */
+    /** @private @type {boolean} */
     this.requirementsMet = schemesCompliance.requirements_met;
 
     if (schemesCompliance.requirements_not_met_info) {
       Validation.isString(schemesCompliance.requirements_not_met_info, 'requirements_not_met_info');
-      /** @private string|undefined */
+      /** @private @type {string|undefined} */
       this.requirementsNotMetInfo = schemesCompliance.requirements_not_met_info;
 
-      /** @private {IdentityProfileRequirementsNotMetDetailResponse[]}|undefined */
+      /** @private @type {IdentityProfileRequirementsNotMetDetailResponse[]|undefined} */
       this.requirementsNotMetDetails = [];
 
       if (schemesCompliance.requirements_not_met_details) {

--- a/src/idv_service/session/retrieve/identity.profile.requirements.not.met.detail.response.js
+++ b/src/idv_service/session/retrieve/identity.profile.requirements.not.met.detail.response.js
@@ -5,24 +5,23 @@ const Validation = require('../../../yoti_common/validation');
 class IdentityProfileRequirementsNotMetDetailResponse {
   constructor(requirementsNotMetDetail) {
     Validation.isString(requirementsNotMetDetail.failure_type, 'failure_type');
-    /** @private string */
+    /** @private @type {string} */
     this.failureType = requirementsNotMetDetail.failure_type;
 
     Validation.isString(requirementsNotMetDetail.document_type, 'document_type');
-    /** @private string */
+    /** @private @type {string} */
     this.documentType = requirementsNotMetDetail.document_type;
 
     Validation.isString(requirementsNotMetDetail.document_country_iso_code, 'document_country_iso_code');
-    /** @private string */
+    /** @private @type {string} */
     this.documentCountryIsoCode = requirementsNotMetDetail.document_country_iso_code;
 
     Validation.isString(requirementsNotMetDetail.audit_id, 'audit_id', true);
-    /** @private string|undefined */
+    /** @private @type {string|undefined} */
     this.auditId = requirementsNotMetDetail.audit_id;
 
-    /** @private string */
     Validation.isString(requirementsNotMetDetail.details, 'details');
-    /** @private */
+    /** @private @type {string} */
     this.details = requirementsNotMetDetail.details;
   }
 

--- a/src/idv_service/session/retrieve/identity.profile.requirements.not.met.detail.response.js
+++ b/src/idv_service/session/retrieve/identity.profile.requirements.not.met.detail.response.js
@@ -1,0 +1,50 @@
+'use strict';
+
+const Validation = require('../../../yoti_common/validation');
+
+class IdentityProfileRequirementsNotMetDetailResponse {
+  constructor(requirementsNotMetDetail) {
+    Validation.isString(requirementsNotMetDetail.failure_type, 'failure_type');
+    /** @private string */
+    this.failureType = requirementsNotMetDetail.failure_type;
+
+    Validation.isString(requirementsNotMetDetail.document_type, 'document_type');
+    /** @private string */
+    this.documentType = requirementsNotMetDetail.document_type;
+
+    Validation.isString(requirementsNotMetDetail.document_country_iso_code, 'document_country_iso_code');
+    /** @private string */
+    this.documentCountryIsoCode = requirementsNotMetDetail.document_country_iso_code;
+
+    Validation.isString(requirementsNotMetDetail.audit_id, 'audit_id', true);
+    /** @private string|undefined */
+    this.auditId = requirementsNotMetDetail.audit_id;
+
+    /** @private string */
+    Validation.isString(requirementsNotMetDetail.details, 'details');
+    /** @private */
+    this.details = requirementsNotMetDetail.details;
+  }
+
+  getFailureType() {
+    return this.failureType;
+  }
+
+  getDocumentType() {
+    return this.documentType;
+  }
+
+  getDocumentCountryIsoCode() {
+    return this.documentCountryIsoCode;
+  }
+
+  getAuditId() {
+    return this.auditId;
+  }
+
+  getDetails() {
+    return this.details;
+  }
+}
+
+module.exports = IdentityProfileRequirementsNotMetDetailResponse;

--- a/tests/idv_service/session/retrieve/identity.profile.report.schemes.compliance.response.spec.js
+++ b/tests/idv_service/session/retrieve/identity.profile.report.schemes.compliance.response.spec.js
@@ -1,4 +1,5 @@
 const IdentityProfileReportSchemesComplianceResponse = require('../../../../src/idv_service/session/retrieve/identity.profile.report.schemes.compliance.response');
+const IdentityProfileRequirementsNotMetDetailResponse = require('../../../../src/idv_service/session/retrieve/identity.profile.requirements.not.met.detail.response');
 
 describe('IdentityProfileReportSchemesComplianceResponse', () => {
   let identityProfileReportSchemesComplianceResponse;
@@ -11,7 +12,6 @@ describe('IdentityProfileReportSchemesComplianceResponse', () => {
         objective: 'STANDARD',
       },
       requirements_met: true,
-      requirements_not_met_info: 'some string here',
     });
   });
 
@@ -30,9 +30,63 @@ describe('IdentityProfileReportSchemesComplianceResponse', () => {
     });
   });
 
-  describe('#getRequirementsNotMetInfo', () => {
-    it('Should return requirements_not_met_info string', () => {
-      expect(identityProfileReportSchemesComplianceResponse.getRequirementsNotMetInfo()).toBe('some string here');
+  describe('with requirements not met', () => {
+    beforeAll(() => {
+      identityProfileReportSchemesComplianceResponse = new
+      IdentityProfileReportSchemesComplianceResponse({
+        scheme: {
+          type: 'DBS',
+          objective: 'STANDARD',
+        },
+        requirements_met: false,
+        requirements_not_met_info: 'some string here',
+        requirements_not_met_details: [
+          {
+            failure_type: 'ID_DOCUMENT_EXTRACTION',
+            document_type: 'PASSPORT',
+            document_country_iso_code: 'GBR',
+            audit_id: 'audit-123',
+            details: 'something not right',
+          },
+          {
+            failure_type: 'ID_DOCUMENT_AUTHENTICITY',
+            document_type: 'PASSPORT',
+            document_country_iso_code: 'GBR',
+            audit_id: 'audit-456',
+            details: 'something still not right',
+          },
+        ],
+      });
+    });
+    describe('#getRequirementsNotMetInfo', () => {
+      it('Should return requirements_not_met_info string', () => {
+        expect(identityProfileReportSchemesComplianceResponse.getRequirementsNotMetInfo()).toBe('some string here');
+      });
+    });
+
+    describe('#getRequirementsNotMetDetails', () => {
+      it('Should return the list of RequirementsNotMetDetail', () => {
+        // eslint-disable-next-line max-len
+        const requirementsNotMetDetails = identityProfileReportSchemesComplianceResponse.getRequirementsNotMetDetails();
+        expect(requirementsNotMetDetails).toHaveLength(2);
+        const [firstDetail, secondDetail] = requirementsNotMetDetails;
+        expect(firstDetail).toBeInstanceOf(IdentityProfileRequirementsNotMetDetailResponse);
+        expect(firstDetail).toEqual(expect.objectContaining({
+          failureType: 'ID_DOCUMENT_EXTRACTION',
+          documentType: 'PASSPORT',
+          documentCountryIsoCode: 'GBR',
+          auditId: 'audit-123',
+          details: 'something not right',
+        }));
+        expect(firstDetail).toBeInstanceOf(IdentityProfileRequirementsNotMetDetailResponse);
+        expect(secondDetail).toEqual(expect.objectContaining({
+          failureType: 'ID_DOCUMENT_AUTHENTICITY',
+          documentType: 'PASSPORT',
+          documentCountryIsoCode: 'GBR',
+          auditId: 'audit-456',
+          details: 'something still not right',
+        }));
+      });
     });
   });
 });

--- a/tests/idv_service/session/retrieve/identity.profile.requirement.not.met.detail.response.spec.js
+++ b/tests/idv_service/session/retrieve/identity.profile.requirement.not.met.detail.response.spec.js
@@ -1,0 +1,57 @@
+const IdentityProfileRequirementsNotMetDetailResponse = require('../../../../src/idv_service/session/retrieve/identity.profile.requirements.not.met.detail.response');
+
+describe('IdentityProfileRequirementsNotMetDetailResponse', () => {
+  let requirementsNotMetDetailResponse;
+
+  beforeEach(() => {
+    requirementsNotMetDetailResponse = new IdentityProfileRequirementsNotMetDetailResponse({
+      failure_type: 'ID_DOCUMENT_EXTRACTION',
+      document_type: 'PASSPORT',
+      document_country_iso_code: 'GBR',
+      audit_id: 'audit-123',
+      details: 'something not right',
+    });
+  });
+
+  describe('#getFailureType', () => {
+    it('Should return the failure type', () => {
+      expect(requirementsNotMetDetailResponse.getFailureType()).toBe('ID_DOCUMENT_EXTRACTION');
+    });
+  });
+
+  describe('#getDocumentType', () => {
+    it('Should return the document type', () => {
+      expect(requirementsNotMetDetailResponse.getDocumentType()).toBe('PASSPORT');
+    });
+  });
+
+  describe('#getDocumentCountryIsoCode', () => {
+    it('Should return the document country iso code', () => {
+      expect(requirementsNotMetDetailResponse.getDocumentCountryIsoCode()).toBe('GBR');
+    });
+  });
+
+  describe('#getAuditId', () => {
+    it('Should return the audit ID', () => {
+      expect(requirementsNotMetDetailResponse.getAuditId()).toBe('audit-123');
+    });
+  });
+
+  describe('#getDetails', () => {
+    it('Should return the details', () => {
+      expect(requirementsNotMetDetailResponse.getDetails()).toBe('something not right');
+    });
+  });
+
+  describe('default instance object', () => {
+    it('Should return an object with all the fields', () => {
+      expect(requirementsNotMetDetailResponse).toEqual(expect.objectContaining({
+        failureType: 'ID_DOCUMENT_EXTRACTION',
+        documentType: 'PASSPORT',
+        documentCountryIsoCode: 'GBR',
+        auditId: 'audit-123',
+        details: 'something not right',
+      }));
+    });
+  });
+});

--- a/tests/idv_service/session/retrieve/identity.profile.response.spec.js
+++ b/tests/idv_service/session/retrieve/identity.profile.response.spec.js
@@ -1,6 +1,7 @@
 const IdentityProfileResponse = require('../../../../src/idv_service/session/retrieve/identity.profile.response');
 const IdentityProfileReportResponse = require('../../../../src/idv_service/session/retrieve/identity.profile.report.response');
 const IdentityProfileFailureReasonResponse = require('../../../../src/idv_service/session/retrieve/identity.profile.failure.reason.response');
+const IdentityProfileRequirementsNotMetDetailResponse = require('../../../../src/idv_service/session/retrieve/identity.profile.requirements.not.met.detail.response');
 
 describe('IdentityProfileResponse', () => {
   let identityProfileResponse;
@@ -71,6 +72,7 @@ describe('IdentityProfileResponse', () => {
       expect(failureReason.getReasonCode()).toBe('MANDATORY_DOCUMENT_NOT_PROVIDED');
       expect(failureReason.getRequirementsNotMetDetails()).toHaveLength(2);
       const [firstDetail, secondDetail] = failureReason.getRequirementsNotMetDetails();
+      expect(firstDetail).toBeInstanceOf(IdentityProfileRequirementsNotMetDetailResponse);
       expect(firstDetail).toEqual(expect.objectContaining({
         failureType: 'ID_DOCUMENT_EXTRACTION',
         documentType: 'PASSPORT',
@@ -78,6 +80,7 @@ describe('IdentityProfileResponse', () => {
         auditId: 'audit-123',
         details: 'something not right',
       }));
+      expect(firstDetail).toBeInstanceOf(IdentityProfileRequirementsNotMetDetailResponse);
       expect(secondDetail).toEqual(expect.objectContaining({
         failureType: 'ID_DOCUMENT_AUTHENTICITY',
         documentType: 'PASSPORT',

--- a/types/src/idv_service/session/retrieve/identity.profile.failure.reason.response.d.ts
+++ b/types/src/idv_service/session/retrieve/identity.profile.failure.reason.response.d.ts
@@ -1,10 +1,11 @@
 export = IdentityProfileFailureReasonResponse;
 declare class IdentityProfileFailureReasonResponse {
     constructor(failureReason: any);
-    /** @private string */
+    /** @private @type {string} */
     private reasonCode;
-    /** @private {IdentityProfileRequirementsNotMetDetailResponse[]} */
+    /** @private @type {IdentityProfileRequirementsNotMetDetailResponse[]} */
     private requirementsNotMetDetails;
-    getReasonCode(): any;
-    getRequirementsNotMetDetails(): any;
+    getReasonCode(): string;
+    getRequirementsNotMetDetails(): IdentityProfileRequirementsNotMetDetailResponse[];
 }
+import IdentityProfileRequirementsNotMetDetailResponse = require("./identity.profile.requirements.not.met.detail.response");

--- a/types/src/idv_service/session/retrieve/identity.profile.failure.reason.response.d.ts
+++ b/types/src/idv_service/session/retrieve/identity.profile.failure.reason.response.d.ts
@@ -1,34 +1,10 @@
 export = IdentityProfileFailureReasonResponse;
-/**
- * @typedef {Object} RequirementsNotMetDetail
- * @property {string} [failureType]
- * @property {string} [documentType]
- * @property {string} [documentCountryIsoCode]
- * @property {string} [auditId]
- * @property {string} [details]
- */
 declare class IdentityProfileFailureReasonResponse {
     constructor(failureReason: any);
-    /** @private */
+    /** @private string */
     private reasonCode;
-    /** @private  */
+    /** @private {IdentityProfileRequirementsNotMetDetailResponse[]} */
     private requirementsNotMetDetails;
-    /**
-     * @returns {string}
-     */
-    getReasonCode(): string;
-    /**
-     * @returns {RequirementsNotMetDetail[]}
-     */
-    getRequirementsNotMetDetails(): RequirementsNotMetDetail[];
+    getReasonCode(): any;
+    getRequirementsNotMetDetails(): any;
 }
-declare namespace IdentityProfileFailureReasonResponse {
-    export { RequirementsNotMetDetail };
-}
-type RequirementsNotMetDetail = {
-    failureType?: string;
-    documentType?: string;
-    documentCountryIsoCode?: string;
-    auditId?: string;
-    details?: string;
-};

--- a/types/src/idv_service/session/retrieve/identity.profile.report.schemes.compliance.response.d.ts
+++ b/types/src/idv_service/session/retrieve/identity.profile.report.schemes.compliance.response.d.ts
@@ -3,20 +3,17 @@ declare class IdentityProfileReportSchemesComplianceResponse {
     constructor(schemesCompliance: any);
     /** @private */
     private scheme;
-    /** @private */
+    /** @private boolean */
     private requirementsMet;
-    /** @private */
+    /** @private string|undefined */
     private requirementsNotMetInfo;
+    /** @private {IdentityProfileRequirementsNotMetDetailResponse[]}|undefined */
+    private requirementsNotMetDetails;
     /**
      * @returns {object}
      */
     getScheme(): object;
-    /**
-     * @returns {boolean}
-     */
-    isRequirementsMet(): boolean;
-    /**
-     * @returns {string}
-     */
-    getRequirementsNotMetInfo(): string;
+    isRequirementsMet(): any;
+    getRequirementsNotMetInfo(): any;
+    getRequirementsNotMetDetails(): any;
 }

--- a/types/src/idv_service/session/retrieve/identity.profile.report.schemes.compliance.response.d.ts
+++ b/types/src/idv_service/session/retrieve/identity.profile.report.schemes.compliance.response.d.ts
@@ -3,17 +3,18 @@ declare class IdentityProfileReportSchemesComplianceResponse {
     constructor(schemesCompliance: any);
     /** @private */
     private scheme;
-    /** @private boolean */
+    /** @private @type {boolean} */
     private requirementsMet;
-    /** @private string|undefined */
+    /** @private @type {string|undefined} */
     private requirementsNotMetInfo;
-    /** @private {IdentityProfileRequirementsNotMetDetailResponse[]}|undefined */
+    /** @private @type {IdentityProfileRequirementsNotMetDetailResponse[]|undefined} */
     private requirementsNotMetDetails;
     /**
      * @returns {object}
      */
     getScheme(): object;
-    isRequirementsMet(): any;
-    getRequirementsNotMetInfo(): any;
-    getRequirementsNotMetDetails(): any;
+    isRequirementsMet(): boolean;
+    getRequirementsNotMetInfo(): string;
+    getRequirementsNotMetDetails(): IdentityProfileRequirementsNotMetDetailResponse[];
 }
+import IdentityProfileRequirementsNotMetDetailResponse = require("./identity.profile.requirements.not.met.detail.response");

--- a/types/src/idv_service/session/retrieve/identity.profile.requirements.not.met.detail.response.d.ts
+++ b/types/src/idv_service/session/retrieve/identity.profile.requirements.not.met.detail.response.d.ts
@@ -1,0 +1,19 @@
+export = IdentityProfileRequirementsNotMetDetailResponse;
+declare class IdentityProfileRequirementsNotMetDetailResponse {
+    constructor(requirementsNotMetDetail: any);
+    /** @private string */
+    private failureType;
+    /** @private string */
+    private documentType;
+    /** @private string */
+    private documentCountryIsoCode;
+    /** @private string|undefined */
+    private auditId;
+    /** @private */
+    private details;
+    getFailureType(): any;
+    getDocumentType(): any;
+    getDocumentCountryIsoCode(): any;
+    getAuditId(): any;
+    getDetails(): any;
+}

--- a/types/src/idv_service/session/retrieve/identity.profile.requirements.not.met.detail.response.d.ts
+++ b/types/src/idv_service/session/retrieve/identity.profile.requirements.not.met.detail.response.d.ts
@@ -1,19 +1,19 @@
 export = IdentityProfileRequirementsNotMetDetailResponse;
 declare class IdentityProfileRequirementsNotMetDetailResponse {
     constructor(requirementsNotMetDetail: any);
-    /** @private string */
+    /** @private @type {string} */
     private failureType;
-    /** @private string */
+    /** @private @type {string} */
     private documentType;
-    /** @private string */
+    /** @private @type {string} */
     private documentCountryIsoCode;
-    /** @private string|undefined */
+    /** @private @type {string|undefined} */
     private auditId;
-    /** @private */
+    /** @private @type {string} */
     private details;
-    getFailureType(): any;
-    getDocumentType(): any;
-    getDocumentCountryIsoCode(): any;
-    getAuditId(): any;
-    getDetails(): any;
+    getFailureType(): string;
+    getDocumentType(): string;
+    getDocumentCountryIsoCode(): string;
+    getAuditId(): string;
+    getDetails(): string;
 }


### PR DESCRIPTION
Created class `IdentityProfileRequirementsNotMetDetailResponse` to parse/expose the RequirementsNotMetDetail object.

Updated `IdentityProfileFailureReasonResponse` to use `IdentityProfileRequirementsNotMetDetailResponse`

Modified `IdentityProfileReportSchemesComplianceResponse` to include conditionally field _requirementsNotMetDetails_, as a list of `IdentityProfileRequirementsNotMetDetailResponse`