### PR TITLE
SDK-2455 remove extraneous query params "appId" in share v2 requests

### DIFF
--- a/src/digital_identity_service/index.js
+++ b/src/digital_identity_service/index.js
@@ -68,7 +68,6 @@ class DigitalIdentityService {
       .withHeader('X-Yoti-Auth-Id', this.sdkId)
       .withPemString(this.pem.toString())
       .withEndpoint('/v2/sessions')
-      .withQueryParam('appId', this.sdkId)
       .withMethod('POST')
       .withPayload(payload);
 
@@ -107,7 +106,6 @@ class DigitalIdentityService {
       .withHeader('X-Yoti-Auth-Id', this.sdkId)
       .withPemString(this.pem.toString())
       .withEndpoint(`/v2/sessions/${sessionId}`)
-      .withQueryParam('appId', this.sdkId)
       .withMethod('GET');
 
     const request = requestBuilder.build();
@@ -148,7 +146,6 @@ class DigitalIdentityService {
       .withHeader('X-Yoti-Auth-Id', this.sdkId)
       .withPemString(this.pem.toString())
       .withEndpoint(`/v2/sessions/${sessionId}/qr-codes`)
-      .withQueryParam('appId', this.sdkId)
       .withMethod('POST')
       .withPayload(payload);
 
@@ -187,7 +184,6 @@ class DigitalIdentityService {
       .withHeader('X-Yoti-Auth-Id', this.sdkId)
       .withPemString(this.pem.toString())
       .withEndpoint(`/v2/qr-codes/${qrCodeId}`)
-      .withQueryParam('appId', this.sdkId)
       .withMethod('GET');
 
     const request = requestBuilder.build();
@@ -225,7 +221,6 @@ class DigitalIdentityService {
       .withHeader('X-Yoti-Auth-Id', this.sdkId)
       .withPemString(this.pem.toString())
       .withEndpoint(`/v2/receipts/${receiptIdUrl}`)
-      .withQueryParam('appId', this.sdkId)
       .withMethod('GET')
       .build();
 
@@ -250,7 +245,6 @@ class DigitalIdentityService {
       .withHeader('X-Yoti-Auth-Id', this.sdkId)
       .withPemString(this.pem.toString())
       .withEndpoint(`/v2/wrapped-item-keys/${receiptItemKeyId}`)
-      .withQueryParam('appId', this.sdkId)
       .withMethod('GET')
       .build();
 


### PR DESCRIPTION
Removed extraneous query params "appId" in requests made by digital_identity_service