### PR TITLE
Release/4.7.1

### DIFF
--- a/examples/aml-check/package-lock.json
+++ b/examples/aml-check/package-lock.json
@@ -25,12 +25,12 @@
     },
     "../..": {
       "name": "yoti",
-      "version": "4.7.0",
+      "version": "4.7.1",
       "license": "MIT",
       "dependencies": {
         "form-data": "4.0.0",
         "node-forge": "1.3.1",
-        "protobufjs": "7.2.6",
+        "protobufjs": "7.3.0",
         "superagent": "9.0.2",
         "uuid": "9.0.1"
       },
@@ -4202,7 +4202,7 @@
         "jest": "29.5.0",
         "nock": "13.2.9",
         "node-forge": "1.3.1",
-        "protobufjs": "7.2.6",
+        "protobufjs": "7.3.0",
         "superagent": "9.0.2",
         "typescript": "5.3.3",
         "uuid": "9.0.1"

--- a/examples/digital-identity/package-lock.json
+++ b/examples/digital-identity/package-lock.json
@@ -28,12 +28,12 @@
     },
     "../..": {
       "name": "yoti",
-      "version": "4.7.0",
+      "version": "4.7.1",
       "license": "MIT",
       "dependencies": {
         "form-data": "4.0.0",
         "node-forge": "1.3.1",
-        "protobufjs": "7.2.6",
+        "protobufjs": "7.3.0",
         "superagent": "9.0.2",
         "uuid": "9.0.1"
       },
@@ -5352,7 +5352,7 @@
         "jest": "29.5.0",
         "nock": "13.2.9",
         "node-forge": "1.3.1",
-        "protobufjs": "7.2.6",
+        "protobufjs": "7.3.0",
         "superagent": "9.0.2",
         "typescript": "5.3.3",
         "uuid": "9.0.1"

--- a/examples/idv-identity-checks/package-lock.json
+++ b/examples/idv-identity-checks/package-lock.json
@@ -27,12 +27,12 @@
     },
     "../..": {
       "name": "yoti",
-      "version": "4.7.0",
+      "version": "4.7.1",
       "license": "MIT",
       "dependencies": {
         "form-data": "4.0.0",
         "node-forge": "1.3.1",
-        "protobufjs": "7.2.6",
+        "protobufjs": "7.3.0",
         "superagent": "9.0.2",
         "uuid": "9.0.1"
       },
@@ -5444,7 +5444,7 @@
         "jest": "29.5.0",
         "nock": "13.2.9",
         "node-forge": "1.3.1",
-        "protobufjs": "7.2.6",
+        "protobufjs": "7.3.0",
         "superagent": "9.0.2",
         "typescript": "5.3.3",
         "uuid": "9.0.1"

--- a/examples/idv/package-lock.json
+++ b/examples/idv/package-lock.json
@@ -28,12 +28,12 @@
     },
     "../..": {
       "name": "yoti",
-      "version": "4.7.0",
+      "version": "4.7.1",
       "license": "MIT",
       "dependencies": {
         "form-data": "4.0.0",
         "node-forge": "1.3.1",
-        "protobufjs": "7.2.6",
+        "protobufjs": "7.3.0",
         "superagent": "9.0.2",
         "uuid": "9.0.1"
       },
@@ -5445,7 +5445,7 @@
         "jest": "29.5.0",
         "nock": "13.2.9",
         "node-forge": "1.3.1",
-        "protobufjs": "7.2.6",
+        "protobufjs": "7.3.0",
         "superagent": "9.0.2",
         "typescript": "5.3.3",
         "uuid": "9.0.1"

--- a/examples/profile-identity-checks/package-lock.json
+++ b/examples/profile-identity-checks/package-lock.json
@@ -28,12 +28,12 @@
     },
     "../..": {
       "name": "yoti",
-      "version": "4.7.0",
+      "version": "4.7.1",
       "license": "MIT",
       "dependencies": {
         "form-data": "4.0.0",
         "node-forge": "1.3.1",
-        "protobufjs": "7.2.6",
+        "protobufjs": "7.3.0",
         "superagent": "9.0.2",
         "uuid": "9.0.1"
       },
@@ -5352,7 +5352,7 @@
         "jest": "29.5.0",
         "nock": "13.2.9",
         "node-forge": "1.3.1",
-        "protobufjs": "7.2.6",
+        "protobufjs": "7.3.0",
         "superagent": "9.0.2",
         "typescript": "5.3.3",
         "uuid": "9.0.1"

--- a/examples/profile/package-lock.json
+++ b/examples/profile/package-lock.json
@@ -28,12 +28,12 @@
     },
     "../..": {
       "name": "yoti",
-      "version": "4.7.0",
+      "version": "4.7.1",
       "license": "MIT",
       "dependencies": {
         "form-data": "4.0.0",
         "node-forge": "1.3.1",
-        "protobufjs": "7.2.6",
+        "protobufjs": "7.3.0",
         "superagent": "9.0.2",
         "uuid": "9.0.1"
       },
@@ -5352,7 +5352,7 @@
         "jest": "29.5.0",
         "nock": "13.2.9",
         "node-forge": "1.3.1",
-        "protobufjs": "7.2.6",
+        "protobufjs": "7.3.0",
         "superagent": "9.0.2",
         "typescript": "5.3.3",
         "uuid": "9.0.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "yoti",
-  "version": "4.7.0",
+  "version": "4.7.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "yoti",
-      "version": "4.7.0",
+      "version": "4.7.1",
       "license": "MIT",
       "dependencies": {
         "form-data": "4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "form-data": "4.0.0",
         "node-forge": "1.3.1",
-        "protobufjs": "7.2.6",
+        "protobufjs": "7.3.0",
         "superagent": "9.0.2",
         "uuid": "9.0.1"
       },
@@ -5366,9 +5366,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.2.6",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.6.tgz",
-      "integrity": "sha512-dgJaEDDL6x8ASUZ1YqWciTRrdOuYNzoOf27oHNfdyvKqHr5i0FV7FSLU+aIeFjyFgVxrpTOtQUi0BLLBymZaBw==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.3.0.tgz",
+      "integrity": "sha512-YWD03n3shzV9ImZRX3ccbjqLxj7NokGN0V/ESiBV5xWqrommYHYiihuIyavq03pWSGqlyvYUFmfoMKd+1rPA/g==",
       "hasInstallScript": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
@@ -10382,9 +10382,9 @@
       "dev": true
     },
     "protobufjs": {
-      "version": "7.2.6",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.6.tgz",
-      "integrity": "sha512-dgJaEDDL6x8ASUZ1YqWciTRrdOuYNzoOf27oHNfdyvKqHr5i0FV7FSLU+aIeFjyFgVxrpTOtQUi0BLLBymZaBw==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.3.0.tgz",
+      "integrity": "sha512-YWD03n3shzV9ImZRX3ccbjqLxj7NokGN0V/ESiBV5xWqrommYHYiihuIyavq03pWSGqlyvYUFmfoMKd+1rPA/g==",
       "requires": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yoti",
-  "version": "4.7.0",
+  "version": "4.7.1",
   "description": "Yoti NodeJS SDK for back-end integration",
   "author": "Yoti LTD <tech@yoti.com> (https://www.yoti.com/developers)",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "form-data": "4.0.0",
     "node-forge": "1.3.1",
-    "protobufjs": "7.2.6",
+    "protobufjs": "7.3.0",
     "superagent": "9.0.2",
     "uuid": "9.0.1"
   },

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,7 +3,7 @@ sonar.organization = getyoti
 
 sonar.projectKey = getyoti:node
 sonar.projectName = Node SDK
-sonar.projectVersion = 4.7.0
+sonar.projectVersion = 4.7.1
 sonar.exclusions=tests/**,examples/**,node_modules/**,coverage/**
 sonar.javascript.lcov.reportPaths=coverage/lcov.info
 sonar.verbose = true

--- a/src/digital_identity_service/index.js
+++ b/src/digital_identity_service/index.js
@@ -68,7 +68,6 @@ class DigitalIdentityService {
       .withHeader('X-Yoti-Auth-Id', this.sdkId)
       .withPemString(this.pem.toString())
       .withEndpoint('/v2/sessions')
-      .withQueryParam('appId', this.sdkId)
       .withMethod('POST')
       .withPayload(payload);
 
@@ -107,7 +106,6 @@ class DigitalIdentityService {
       .withHeader('X-Yoti-Auth-Id', this.sdkId)
       .withPemString(this.pem.toString())
       .withEndpoint(`/v2/sessions/${sessionId}`)
-      .withQueryParam('appId', this.sdkId)
       .withMethod('GET');
 
     const request = requestBuilder.build();
@@ -148,7 +146,6 @@ class DigitalIdentityService {
       .withHeader('X-Yoti-Auth-Id', this.sdkId)
       .withPemString(this.pem.toString())
       .withEndpoint(`/v2/sessions/${sessionId}/qr-codes`)
-      .withQueryParam('appId', this.sdkId)
       .withMethod('POST')
       .withPayload(payload);
 
@@ -187,7 +184,6 @@ class DigitalIdentityService {
       .withHeader('X-Yoti-Auth-Id', this.sdkId)
       .withPemString(this.pem.toString())
       .withEndpoint(`/v2/qr-codes/${qrCodeId}`)
-      .withQueryParam('appId', this.sdkId)
       .withMethod('GET');
 
     const request = requestBuilder.build();
@@ -225,7 +221,6 @@ class DigitalIdentityService {
       .withHeader('X-Yoti-Auth-Id', this.sdkId)
       .withPemString(this.pem.toString())
       .withEndpoint(`/v2/receipts/${receiptIdUrl}`)
-      .withQueryParam('appId', this.sdkId)
       .withMethod('GET')
       .build();
 
@@ -250,7 +245,6 @@ class DigitalIdentityService {
       .withHeader('X-Yoti-Auth-Id', this.sdkId)
       .withPemString(this.pem.toString())
       .withEndpoint(`/v2/wrapped-item-keys/${receiptItemKeyId}`)
-      .withQueryParam('appId', this.sdkId)
       .withMethod('GET')
       .build();
 

--- a/src/idv_service/session/retrieve/identity.profile.failure.reason.response.js
+++ b/src/idv_service/session/retrieve/identity.profile.failure.reason.response.js
@@ -1,23 +1,15 @@
 'use strict';
 
 const Validation = require('../../../yoti_common/validation');
-
-/**
- * @typedef {Object} RequirementsNotMetDetail
- * @property {string} [failureType]
- * @property {string} [documentType]
- * @property {string} [documentCountryIsoCode]
- * @property {string} [auditId]
- * @property {string} [details]
- */
+const IdentityProfileRequirementsNotMetDetailResponse = require('./identity.profile.requirements.not.met.detail.response');
 
 class IdentityProfileFailureReasonResponse {
   constructor(failureReason) {
     Validation.isString(failureReason.reason_code, 'reason code');
-    /** @private */
+    /** @private @type {string} */
     this.reasonCode = failureReason.reason_code;
 
-    /** @private  */
+    /** @private @type {IdentityProfileRequirementsNotMetDetailResponse[]} */
     this.requirementsNotMetDetails = [];
 
     // eslint-disable-next-line camelcase
@@ -25,37 +17,16 @@ class IdentityProfileFailureReasonResponse {
     if (requirementsNotMetDetails) {
       Validation.isArray(requirementsNotMetDetails, 'requirements not met details');
 
-      this.requirementsNotMetDetails = requirementsNotMetDetails.map((detail) => {
-        const {
-          failure_type: failureType,
-          document_type: documentType,
-          document_country_iso_code: documentCountryIsoCode,
-          audit_id: auditId,
-          details,
-        } = detail;
-
-        return ({
-          failureType,
-          documentType,
-          documentCountryIsoCode,
-          auditId,
-          details,
-        });
-      });
+      this.requirementsNotMetDetails = requirementsNotMetDetails
+        // eslint-disable-next-line max-len
+        .map((requirementsNotMetDetail) => new IdentityProfileRequirementsNotMetDetailResponse(requirementsNotMetDetail));
     }
-    /** @private */
   }
 
-  /**
-   * @returns {string}
-   */
   getReasonCode() {
     return this.reasonCode;
   }
 
-  /**
-   * @returns {RequirementsNotMetDetail[]}
-   */
   getRequirementsNotMetDetails() {
     return this.requirementsNotMetDetails;
   }

--- a/src/idv_service/session/retrieve/identity.profile.report.schemes.compliance.response.js
+++ b/src/idv_service/session/retrieve/identity.profile.report.schemes.compliance.response.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const Validation = require('../../../yoti_common/validation');
+const IdentityProfileRequirementsNotMetDetailResponse = require('./identity.profile.requirements.not.met.detail.response');
 
 class IdentityProfileReportSchemesComplianceResponse {
   constructor(schemesCompliance) {
@@ -9,13 +10,24 @@ class IdentityProfileReportSchemesComplianceResponse {
     this.scheme = schemesCompliance.scheme;
 
     Validation.isBoolean(schemesCompliance.requirements_met, 'requirements_met');
-    /** @private */
+    /** @private @type {boolean} */
     this.requirementsMet = schemesCompliance.requirements_met;
 
     if (schemesCompliance.requirements_not_met_info) {
       Validation.isString(schemesCompliance.requirements_not_met_info, 'requirements_not_met_info');
-      /** @private */
+      /** @private @type {string|undefined} */
       this.requirementsNotMetInfo = schemesCompliance.requirements_not_met_info;
+
+      /** @private @type {IdentityProfileRequirementsNotMetDetailResponse[]|undefined} */
+      this.requirementsNotMetDetails = [];
+
+      if (schemesCompliance.requirements_not_met_details) {
+        Validation.isArray(schemesCompliance.requirements_not_met_details, 'requirements not met details');
+
+        this.requirementsNotMetDetails = schemesCompliance.requirements_not_met_details
+        // eslint-disable-next-line max-len
+          .map((requirementsNotMetDetail) => new IdentityProfileRequirementsNotMetDetailResponse(requirementsNotMetDetail));
+      }
     }
   }
 
@@ -26,18 +38,16 @@ class IdentityProfileReportSchemesComplianceResponse {
     return this.scheme;
   }
 
-  /**
-   * @returns {boolean}
-   */
   isRequirementsMet() {
     return this.requirementsMet;
   }
 
-  /**
-   * @returns {string}
-   */
   getRequirementsNotMetInfo() {
     return this.requirementsNotMetInfo;
+  }
+
+  getRequirementsNotMetDetails() {
+    return this.requirementsNotMetDetails;
   }
 }
 

--- a/src/idv_service/session/retrieve/identity.profile.report.schemes.compliance.response.js
+++ b/src/idv_service/session/retrieve/identity.profile.report.schemes.compliance.response.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const Validation = require('../../../yoti_common/validation');
-const IdentityProfileRequirementsNotMetDetailResponse = require('./identity.profile.requirements.not.met.detail.response');
 
 class IdentityProfileReportSchemesComplianceResponse {
   constructor(schemesCompliance) {
@@ -17,17 +16,6 @@ class IdentityProfileReportSchemesComplianceResponse {
       Validation.isString(schemesCompliance.requirements_not_met_info, 'requirements_not_met_info');
       /** @private @type {string|undefined} */
       this.requirementsNotMetInfo = schemesCompliance.requirements_not_met_info;
-
-      /** @private @type {IdentityProfileRequirementsNotMetDetailResponse[]|undefined} */
-      this.requirementsNotMetDetails = [];
-
-      if (schemesCompliance.requirements_not_met_details) {
-        Validation.isArray(schemesCompliance.requirements_not_met_details, 'requirements not met details');
-
-        this.requirementsNotMetDetails = schemesCompliance.requirements_not_met_details
-        // eslint-disable-next-line max-len
-          .map((requirementsNotMetDetail) => new IdentityProfileRequirementsNotMetDetailResponse(requirementsNotMetDetail));
-      }
     }
   }
 
@@ -44,10 +32,6 @@ class IdentityProfileReportSchemesComplianceResponse {
 
   getRequirementsNotMetInfo() {
     return this.requirementsNotMetInfo;
-  }
-
-  getRequirementsNotMetDetails() {
-    return this.requirementsNotMetDetails;
   }
 }
 

--- a/src/idv_service/session/retrieve/identity.profile.requirements.not.met.detail.response.js
+++ b/src/idv_service/session/retrieve/identity.profile.requirements.not.met.detail.response.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const Validation = require('../../../yoti_common/validation');
+
+class IdentityProfileRequirementsNotMetDetailResponse {
+  constructor(requirementsNotMetDetail) {
+    Validation.isString(requirementsNotMetDetail.failure_type, 'failure_type');
+    /** @private @type {string} */
+    this.failureType = requirementsNotMetDetail.failure_type;
+
+    Validation.isString(requirementsNotMetDetail.document_type, 'document_type');
+    /** @private @type {string} */
+    this.documentType = requirementsNotMetDetail.document_type;
+
+    Validation.isString(requirementsNotMetDetail.document_country_iso_code, 'document_country_iso_code');
+    /** @private @type {string} */
+    this.documentCountryIsoCode = requirementsNotMetDetail.document_country_iso_code;
+
+    Validation.isString(requirementsNotMetDetail.audit_id, 'audit_id', true);
+    /** @private @type {string|undefined} */
+    this.auditId = requirementsNotMetDetail.audit_id;
+
+    Validation.isString(requirementsNotMetDetail.details, 'details');
+    /** @private @type {string} */
+    this.details = requirementsNotMetDetail.details;
+  }
+
+  getFailureType() {
+    return this.failureType;
+  }
+
+  getDocumentType() {
+    return this.documentType;
+  }
+
+  getDocumentCountryIsoCode() {
+    return this.documentCountryIsoCode;
+  }
+
+  getAuditId() {
+    return this.auditId;
+  }
+
+  getDetails() {
+    return this.details;
+  }
+}
+
+module.exports = IdentityProfileRequirementsNotMetDetailResponse;

--- a/tests/idv_service/session/retrieve/identity.profile.report.schemes.compliance.response.spec.js
+++ b/tests/idv_service/session/retrieve/identity.profile.report.schemes.compliance.response.spec.js
@@ -1,5 +1,4 @@
 const IdentityProfileReportSchemesComplianceResponse = require('../../../../src/idv_service/session/retrieve/identity.profile.report.schemes.compliance.response');
-const IdentityProfileRequirementsNotMetDetailResponse = require('../../../../src/idv_service/session/retrieve/identity.profile.requirements.not.met.detail.response');
 
 describe('IdentityProfileReportSchemesComplianceResponse', () => {
   let identityProfileReportSchemesComplianceResponse;
@@ -12,6 +11,7 @@ describe('IdentityProfileReportSchemesComplianceResponse', () => {
         objective: 'STANDARD',
       },
       requirements_met: true,
+      requirements_not_met_info: 'some string here',
     });
   });
 
@@ -30,63 +30,9 @@ describe('IdentityProfileReportSchemesComplianceResponse', () => {
     });
   });
 
-  describe('with requirements not met', () => {
-    beforeAll(() => {
-      identityProfileReportSchemesComplianceResponse = new
-      IdentityProfileReportSchemesComplianceResponse({
-        scheme: {
-          type: 'DBS',
-          objective: 'STANDARD',
-        },
-        requirements_met: false,
-        requirements_not_met_info: 'some string here',
-        requirements_not_met_details: [
-          {
-            failure_type: 'ID_DOCUMENT_EXTRACTION',
-            document_type: 'PASSPORT',
-            document_country_iso_code: 'GBR',
-            audit_id: 'audit-123',
-            details: 'something not right',
-          },
-          {
-            failure_type: 'ID_DOCUMENT_AUTHENTICITY',
-            document_type: 'PASSPORT',
-            document_country_iso_code: 'GBR',
-            audit_id: 'audit-456',
-            details: 'something still not right',
-          },
-        ],
-      });
-    });
-    describe('#getRequirementsNotMetInfo', () => {
-      it('Should return requirements_not_met_info string', () => {
-        expect(identityProfileReportSchemesComplianceResponse.getRequirementsNotMetInfo()).toBe('some string here');
-      });
-    });
-
-    describe('#getRequirementsNotMetDetails', () => {
-      it('Should return the list of RequirementsNotMetDetail', () => {
-        // eslint-disable-next-line max-len
-        const requirementsNotMetDetails = identityProfileReportSchemesComplianceResponse.getRequirementsNotMetDetails();
-        expect(requirementsNotMetDetails).toHaveLength(2);
-        const [firstDetail, secondDetail] = requirementsNotMetDetails;
-        expect(firstDetail).toBeInstanceOf(IdentityProfileRequirementsNotMetDetailResponse);
-        expect(firstDetail).toEqual(expect.objectContaining({
-          failureType: 'ID_DOCUMENT_EXTRACTION',
-          documentType: 'PASSPORT',
-          documentCountryIsoCode: 'GBR',
-          auditId: 'audit-123',
-          details: 'something not right',
-        }));
-        expect(firstDetail).toBeInstanceOf(IdentityProfileRequirementsNotMetDetailResponse);
-        expect(secondDetail).toEqual(expect.objectContaining({
-          failureType: 'ID_DOCUMENT_AUTHENTICITY',
-          documentType: 'PASSPORT',
-          documentCountryIsoCode: 'GBR',
-          auditId: 'audit-456',
-          details: 'something still not right',
-        }));
-      });
+  describe('#getRequirementsNotMetInfo', () => {
+    it('Should return requirements_not_met_info string', () => {
+      expect(identityProfileReportSchemesComplianceResponse.getRequirementsNotMetInfo()).toBe('some string here');
     });
   });
 });

--- a/tests/idv_service/session/retrieve/identity.profile.report.schemes.compliance.response.spec.js
+++ b/tests/idv_service/session/retrieve/identity.profile.report.schemes.compliance.response.spec.js
@@ -1,4 +1,5 @@
 const IdentityProfileReportSchemesComplianceResponse = require('../../../../src/idv_service/session/retrieve/identity.profile.report.schemes.compliance.response');
+const IdentityProfileRequirementsNotMetDetailResponse = require('../../../../src/idv_service/session/retrieve/identity.profile.requirements.not.met.detail.response');
 
 describe('IdentityProfileReportSchemesComplianceResponse', () => {
   let identityProfileReportSchemesComplianceResponse;
@@ -11,7 +12,6 @@ describe('IdentityProfileReportSchemesComplianceResponse', () => {
         objective: 'STANDARD',
       },
       requirements_met: true,
-      requirements_not_met_info: 'some string here',
     });
   });
 
@@ -30,9 +30,63 @@ describe('IdentityProfileReportSchemesComplianceResponse', () => {
     });
   });
 
-  describe('#getRequirementsNotMetInfo', () => {
-    it('Should return requirements_not_met_info string', () => {
-      expect(identityProfileReportSchemesComplianceResponse.getRequirementsNotMetInfo()).toBe('some string here');
+  describe('with requirements not met', () => {
+    beforeAll(() => {
+      identityProfileReportSchemesComplianceResponse = new
+      IdentityProfileReportSchemesComplianceResponse({
+        scheme: {
+          type: 'DBS',
+          objective: 'STANDARD',
+        },
+        requirements_met: false,
+        requirements_not_met_info: 'some string here',
+        requirements_not_met_details: [
+          {
+            failure_type: 'ID_DOCUMENT_EXTRACTION',
+            document_type: 'PASSPORT',
+            document_country_iso_code: 'GBR',
+            audit_id: 'audit-123',
+            details: 'something not right',
+          },
+          {
+            failure_type: 'ID_DOCUMENT_AUTHENTICITY',
+            document_type: 'PASSPORT',
+            document_country_iso_code: 'GBR',
+            audit_id: 'audit-456',
+            details: 'something still not right',
+          },
+        ],
+      });
+    });
+    describe('#getRequirementsNotMetInfo', () => {
+      it('Should return requirements_not_met_info string', () => {
+        expect(identityProfileReportSchemesComplianceResponse.getRequirementsNotMetInfo()).toBe('some string here');
+      });
+    });
+
+    describe('#getRequirementsNotMetDetails', () => {
+      it('Should return the list of RequirementsNotMetDetail', () => {
+        // eslint-disable-next-line max-len
+        const requirementsNotMetDetails = identityProfileReportSchemesComplianceResponse.getRequirementsNotMetDetails();
+        expect(requirementsNotMetDetails).toHaveLength(2);
+        const [firstDetail, secondDetail] = requirementsNotMetDetails;
+        expect(firstDetail).toBeInstanceOf(IdentityProfileRequirementsNotMetDetailResponse);
+        expect(firstDetail).toEqual(expect.objectContaining({
+          failureType: 'ID_DOCUMENT_EXTRACTION',
+          documentType: 'PASSPORT',
+          documentCountryIsoCode: 'GBR',
+          auditId: 'audit-123',
+          details: 'something not right',
+        }));
+        expect(firstDetail).toBeInstanceOf(IdentityProfileRequirementsNotMetDetailResponse);
+        expect(secondDetail).toEqual(expect.objectContaining({
+          failureType: 'ID_DOCUMENT_AUTHENTICITY',
+          documentType: 'PASSPORT',
+          documentCountryIsoCode: 'GBR',
+          auditId: 'audit-456',
+          details: 'something still not right',
+        }));
+      });
     });
   });
 });

--- a/tests/idv_service/session/retrieve/identity.profile.requirement.not.met.detail.response.spec.js
+++ b/tests/idv_service/session/retrieve/identity.profile.requirement.not.met.detail.response.spec.js
@@ -1,0 +1,57 @@
+const IdentityProfileRequirementsNotMetDetailResponse = require('../../../../src/idv_service/session/retrieve/identity.profile.requirements.not.met.detail.response');
+
+describe('IdentityProfileRequirementsNotMetDetailResponse', () => {
+  let requirementsNotMetDetailResponse;
+
+  beforeEach(() => {
+    requirementsNotMetDetailResponse = new IdentityProfileRequirementsNotMetDetailResponse({
+      failure_type: 'ID_DOCUMENT_EXTRACTION',
+      document_type: 'PASSPORT',
+      document_country_iso_code: 'GBR',
+      audit_id: 'audit-123',
+      details: 'something not right',
+    });
+  });
+
+  describe('#getFailureType', () => {
+    it('Should return the failure type', () => {
+      expect(requirementsNotMetDetailResponse.getFailureType()).toBe('ID_DOCUMENT_EXTRACTION');
+    });
+  });
+
+  describe('#getDocumentType', () => {
+    it('Should return the document type', () => {
+      expect(requirementsNotMetDetailResponse.getDocumentType()).toBe('PASSPORT');
+    });
+  });
+
+  describe('#getDocumentCountryIsoCode', () => {
+    it('Should return the document country iso code', () => {
+      expect(requirementsNotMetDetailResponse.getDocumentCountryIsoCode()).toBe('GBR');
+    });
+  });
+
+  describe('#getAuditId', () => {
+    it('Should return the audit ID', () => {
+      expect(requirementsNotMetDetailResponse.getAuditId()).toBe('audit-123');
+    });
+  });
+
+  describe('#getDetails', () => {
+    it('Should return the details', () => {
+      expect(requirementsNotMetDetailResponse.getDetails()).toBe('something not right');
+    });
+  });
+
+  describe('default instance object', () => {
+    it('Should return an object with all the fields', () => {
+      expect(requirementsNotMetDetailResponse).toEqual(expect.objectContaining({
+        failureType: 'ID_DOCUMENT_EXTRACTION',
+        documentType: 'PASSPORT',
+        documentCountryIsoCode: 'GBR',
+        auditId: 'audit-123',
+        details: 'something not right',
+      }));
+    });
+  });
+});

--- a/tests/idv_service/session/retrieve/identity.profile.response.spec.js
+++ b/tests/idv_service/session/retrieve/identity.profile.response.spec.js
@@ -1,6 +1,7 @@
 const IdentityProfileResponse = require('../../../../src/idv_service/session/retrieve/identity.profile.response');
 const IdentityProfileReportResponse = require('../../../../src/idv_service/session/retrieve/identity.profile.report.response');
 const IdentityProfileFailureReasonResponse = require('../../../../src/idv_service/session/retrieve/identity.profile.failure.reason.response');
+const IdentityProfileRequirementsNotMetDetailResponse = require('../../../../src/idv_service/session/retrieve/identity.profile.requirements.not.met.detail.response');
 
 describe('IdentityProfileResponse', () => {
   let identityProfileResponse;
@@ -71,6 +72,7 @@ describe('IdentityProfileResponse', () => {
       expect(failureReason.getReasonCode()).toBe('MANDATORY_DOCUMENT_NOT_PROVIDED');
       expect(failureReason.getRequirementsNotMetDetails()).toHaveLength(2);
       const [firstDetail, secondDetail] = failureReason.getRequirementsNotMetDetails();
+      expect(firstDetail).toBeInstanceOf(IdentityProfileRequirementsNotMetDetailResponse);
       expect(firstDetail).toEqual(expect.objectContaining({
         failureType: 'ID_DOCUMENT_EXTRACTION',
         documentType: 'PASSPORT',
@@ -78,6 +80,7 @@ describe('IdentityProfileResponse', () => {
         auditId: 'audit-123',
         details: 'something not right',
       }));
+      expect(firstDetail).toBeInstanceOf(IdentityProfileRequirementsNotMetDetailResponse);
       expect(secondDetail).toEqual(expect.objectContaining({
         failureType: 'ID_DOCUMENT_AUTHENTICITY',
         documentType: 'PASSPORT',

--- a/types/src/idv_service/session/retrieve/identity.profile.failure.reason.response.d.ts
+++ b/types/src/idv_service/session/retrieve/identity.profile.failure.reason.response.d.ts
@@ -1,34 +1,11 @@
 export = IdentityProfileFailureReasonResponse;
-/**
- * @typedef {Object} RequirementsNotMetDetail
- * @property {string} [failureType]
- * @property {string} [documentType]
- * @property {string} [documentCountryIsoCode]
- * @property {string} [auditId]
- * @property {string} [details]
- */
 declare class IdentityProfileFailureReasonResponse {
     constructor(failureReason: any);
-    /** @private */
+    /** @private @type {string} */
     private reasonCode;
-    /** @private  */
+    /** @private @type {IdentityProfileRequirementsNotMetDetailResponse[]} */
     private requirementsNotMetDetails;
-    /**
-     * @returns {string}
-     */
     getReasonCode(): string;
-    /**
-     * @returns {RequirementsNotMetDetail[]}
-     */
-    getRequirementsNotMetDetails(): RequirementsNotMetDetail[];
+    getRequirementsNotMetDetails(): IdentityProfileRequirementsNotMetDetailResponse[];
 }
-declare namespace IdentityProfileFailureReasonResponse {
-    export { RequirementsNotMetDetail };
-}
-type RequirementsNotMetDetail = {
-    failureType?: string;
-    documentType?: string;
-    documentCountryIsoCode?: string;
-    auditId?: string;
-    details?: string;
-};
+import IdentityProfileRequirementsNotMetDetailResponse = require("./identity.profile.requirements.not.met.detail.response");

--- a/types/src/idv_service/session/retrieve/identity.profile.report.schemes.compliance.response.d.ts
+++ b/types/src/idv_service/session/retrieve/identity.profile.report.schemes.compliance.response.d.ts
@@ -7,14 +7,10 @@ declare class IdentityProfileReportSchemesComplianceResponse {
     private requirementsMet;
     /** @private @type {string|undefined} */
     private requirementsNotMetInfo;
-    /** @private @type {IdentityProfileRequirementsNotMetDetailResponse[]|undefined} */
-    private requirementsNotMetDetails;
     /**
      * @returns {object}
      */
     getScheme(): object;
     isRequirementsMet(): boolean;
     getRequirementsNotMetInfo(): string;
-    getRequirementsNotMetDetails(): IdentityProfileRequirementsNotMetDetailResponse[];
 }
-import IdentityProfileRequirementsNotMetDetailResponse = require("./identity.profile.requirements.not.met.detail.response");

--- a/types/src/idv_service/session/retrieve/identity.profile.report.schemes.compliance.response.d.ts
+++ b/types/src/idv_service/session/retrieve/identity.profile.report.schemes.compliance.response.d.ts
@@ -3,20 +3,18 @@ declare class IdentityProfileReportSchemesComplianceResponse {
     constructor(schemesCompliance: any);
     /** @private */
     private scheme;
-    /** @private */
+    /** @private @type {boolean} */
     private requirementsMet;
-    /** @private */
+    /** @private @type {string|undefined} */
     private requirementsNotMetInfo;
+    /** @private @type {IdentityProfileRequirementsNotMetDetailResponse[]|undefined} */
+    private requirementsNotMetDetails;
     /**
      * @returns {object}
      */
     getScheme(): object;
-    /**
-     * @returns {boolean}
-     */
     isRequirementsMet(): boolean;
-    /**
-     * @returns {string}
-     */
     getRequirementsNotMetInfo(): string;
+    getRequirementsNotMetDetails(): IdentityProfileRequirementsNotMetDetailResponse[];
 }
+import IdentityProfileRequirementsNotMetDetailResponse = require("./identity.profile.requirements.not.met.detail.response");

--- a/types/src/idv_service/session/retrieve/identity.profile.requirements.not.met.detail.response.d.ts
+++ b/types/src/idv_service/session/retrieve/identity.profile.requirements.not.met.detail.response.d.ts
@@ -1,0 +1,19 @@
+export = IdentityProfileRequirementsNotMetDetailResponse;
+declare class IdentityProfileRequirementsNotMetDetailResponse {
+    constructor(requirementsNotMetDetail: any);
+    /** @private @type {string} */
+    private failureType;
+    /** @private @type {string} */
+    private documentType;
+    /** @private @type {string} */
+    private documentCountryIsoCode;
+    /** @private @type {string|undefined} */
+    private auditId;
+    /** @private @type {string} */
+    private details;
+    getFailureType(): string;
+    getDocumentType(): string;
+    getDocumentCountryIsoCode(): string;
+    getAuditId(): string;
+    getDetails(): string;
+}


### PR DESCRIPTION
## Minor updates

#### Update of type for the error details surfaced in Identity Verification service

The 'requirements not met details' within the `IdentityProfileRequirementsNotMetDetailResponse` are now parsed as a class

```ts

const sessionResult = await idvClient.getSession(sessionId);
const identityProfile = sessionResult.getIdentityProfile();
if (identityProfile) {
  const failureReason = identityProfile.getFailureReason();

  if (failureReason) {
    const reasonCode = failureReason.getReasonCode(); // string
     // Array of IdentityProfileRequirementsNotMetDetailResponse (NEW - class based)
    const requirementsNotMetDetails = failureReason.getRequirementsNotMetDetails();
    /*
    IdentityProfileRequirementsNotMetDetailResponse shape as follows:
    {
      failureType, //string
      documentType, //string
      documentCountryIsoCode, //string
      auditId, //string
      details, //string
    }

    // Getters (NEW):
    .getFailureType() 
    .getDocumentType() {
    .getDocumentCountryIsoCode() {
    .getAuditId() {
    .getDetails() {
    */
  }
}
```
