### PR TITLE
SDK-2470 add brand_id to IDV SDK config

### DIFF
--- a/src/idv_service/session/create/sdk.config.builder.js
+++ b/src/idv_service/session/create/sdk.config.builder.js
@@ -252,6 +252,19 @@ class SdkConfigBuilder {
   }
 
   /**
+   * Sets the brandID on the builder
+   *
+   * @param {string} brandId
+   *
+   * @returns {this}
+   */
+  withBrandId(brandId) {
+    Validation.isString(brandId, 'brandId');
+    this.brandId = brandId;
+    return this;
+  }
+
+  /**
    * Builds the {@link SdkConfig} using the values supplied to the builder
    *
    * @returns {SdkConfig}
@@ -269,7 +282,8 @@ class SdkConfigBuilder {
       this.privacyPolicyUrl,
       this.biometricConsentFlow,
       this.allowHandoff,
-      this.attemptsConfiguration
+      this.attemptsConfiguration,
+      this.brandId
     );
   }
 }

--- a/src/idv_service/session/create/sdk.config.js
+++ b/src/idv_service/session/create/sdk.config.js
@@ -28,6 +28,8 @@ class SdkConfig {
    *   Allows user to handoff to mobile during session
    * @param {object} attemptsConfiguration
    *   The attempts configuration
+   * @param {string} brandId
+   *   The brandID for the client
    */
   constructor(
     allowedCaptureMethods,
@@ -41,7 +43,8 @@ class SdkConfig {
     privacyPolicyUrl,
     biometricConsentFlow,
     allowHandoff,
-    attemptsConfiguration
+    attemptsConfiguration,
+    brandId
   ) {
     Validation.isString(allowedCaptureMethods, 'allowedCaptureMethods', true);
     /** @private */
@@ -92,6 +95,10 @@ class SdkConfig {
       /** @private */
       this.attemptsConfiguration = attemptsConfiguration;
     }
+
+    Validation.isString(brandId, 'brandId', true);
+    /** @private */
+    this.brandId = brandId;
   }
 
   /**
@@ -111,6 +118,7 @@ class SdkConfig {
       biometric_consent_flow: this.biometricConsentFlow,
       allow_handoff: this.allowHandoff,
       attempts_configuration: this.attemptsConfiguration,
+      brand_id: this.brandId,
     };
   }
 }

--- a/tests/idv_service/session/create/sdk.config.builder.test.js
+++ b/tests/idv_service/session/create/sdk.config.builder.test.js
@@ -16,6 +16,7 @@ describe('SdkConfigBuilder', () => {
       .withPrivacyPolicyUrl('some-privacy-policy-url')
       .withBiometricConsentFlow('some-flow')
       .withAllowHandoff(true)
+      .withBrandId('some-brand-identifier')
       .build();
 
     const expectedJson = JSON.stringify({
@@ -30,6 +31,7 @@ describe('SdkConfigBuilder', () => {
       privacy_policy_url: 'some-privacy-policy-url',
       biometric_consent_flow: 'some-flow',
       allow_handoff: true,
+      brand_id: 'some-brand-identifier',
     });
 
     expect(JSON.stringify(sdkConfig)).toBe(expectedJson);

--- a/types/src/idv_service/session/create/sdk.config.builder.d.ts
+++ b/types/src/idv_service/session/create/sdk.config.builder.d.ts
@@ -164,6 +164,15 @@ declare class SdkConfigBuilder {
      */
     withIdDocumentTextExtractionGenericRetries(retries: number): this;
     /**
+     * Sets the brandID on the builder
+     *
+     * @param {string} brandId
+     *
+     * @returns {this}
+     */
+    withBrandId(brandId: string): this;
+    brandId: string;
+    /**
      * Builds the {@link SdkConfig} using the values supplied to the builder
      *
      * @returns {SdkConfig}

--- a/types/src/idv_service/session/create/sdk.config.d.ts
+++ b/types/src/idv_service/session/create/sdk.config.d.ts
@@ -25,8 +25,10 @@ declare class SdkConfig {
      *   Allows user to handoff to mobile during session
      * @param {object} attemptsConfiguration
      *   The attempts configuration
+     * @param {string} brandId
+     *   The brandID for the client
      */
-    constructor(allowedCaptureMethods: string, primaryColour: string, secondaryColour: string, fontColour: string, locale: string, presetIssuingCountry: string, successUrl: string, errorUrl: string, privacyPolicyUrl: string, biometricConsentFlow: string, allowHandoff: boolean, attemptsConfiguration: object);
+    constructor(allowedCaptureMethods: string, primaryColour: string, secondaryColour: string, fontColour: string, locale: string, presetIssuingCountry: string, successUrl: string, errorUrl: string, privacyPolicyUrl: string, biometricConsentFlow: string, allowHandoff: boolean, attemptsConfiguration: object, brandId: string);
     /** @private */
     private allowedCaptureMethods;
     /** @private */
@@ -51,6 +53,8 @@ declare class SdkConfig {
     private allowHandoff;
     /** @private */
     private attemptsConfiguration;
+    /** @private */
+    private brandId;
     /**
      * Returns serialized data for JSON.stringify()
      */
@@ -67,5 +71,6 @@ declare class SdkConfig {
         biometric_consent_flow: string;
         allow_handoff: boolean;
         attempts_configuration: any;
+        brand_id: string;
     };
 }


### PR DESCRIPTION
Update idv_service to expose a `withBrandId` in the SDK config builder.