### PR TITLE
Release/4.9.0

### DIFF
--- a/examples/aml-check/package-lock.json
+++ b/examples/aml-check/package-lock.json
@@ -25,7 +25,7 @@
     },
     "../..": {
       "name": "yoti",
-      "version": "4.8.0",
+      "version": "4.9.0",
       "license": "MIT",
       "dependencies": {
         "form-data": "4.0.0",

--- a/examples/digital-identity/package-lock.json
+++ b/examples/digital-identity/package-lock.json
@@ -28,7 +28,7 @@
     },
     "../..": {
       "name": "yoti",
-      "version": "4.8.0",
+      "version": "4.9.0",
       "license": "MIT",
       "dependencies": {
         "form-data": "4.0.0",

--- a/examples/idv-identity-checks/package-lock.json
+++ b/examples/idv-identity-checks/package-lock.json
@@ -27,7 +27,7 @@
     },
     "../..": {
       "name": "yoti",
-      "version": "4.8.0",
+      "version": "4.9.0",
       "license": "MIT",
       "dependencies": {
         "form-data": "4.0.0",

--- a/examples/idv/package-lock.json
+++ b/examples/idv/package-lock.json
@@ -28,7 +28,7 @@
     },
     "../..": {
       "name": "yoti",
-      "version": "4.8.0",
+      "version": "4.9.0",
       "license": "MIT",
       "dependencies": {
         "form-data": "4.0.0",

--- a/examples/idv/package-lock.json
+++ b/examples/idv/package-lock.json
@@ -575,12 +575,12 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -1530,9 +1530,9 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -3557,12 +3557,12 @@
       }
     },
     "braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "requires": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       }
     },
     "bytes": {
@@ -4283,9 +4283,9 @@
       }
     },
     "fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "requires": {
         "to-regex-range": "^5.0.1"

--- a/examples/profile-identity-checks/package-lock.json
+++ b/examples/profile-identity-checks/package-lock.json
@@ -28,7 +28,7 @@
     },
     "../..": {
       "name": "yoti",
-      "version": "4.8.0",
+      "version": "4.9.0",
       "license": "MIT",
       "dependencies": {
         "form-data": "4.0.0",

--- a/examples/profile/package-lock.json
+++ b/examples/profile/package-lock.json
@@ -28,7 +28,7 @@
     },
     "../..": {
       "name": "yoti",
-      "version": "4.8.0",
+      "version": "4.9.0",
       "license": "MIT",
       "dependencies": {
         "form-data": "4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "yoti",
-  "version": "4.8.0",
+  "version": "4.9.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "yoti",
-      "version": "4.8.0",
+      "version": "4.9.0",
       "license": "MIT",
       "dependencies": {
         "form-data": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yoti",
-  "version": "4.8.0",
+  "version": "4.9.0",
   "description": "Yoti NodeJS SDK for back-end integration",
   "author": "Yoti LTD <tech@yoti.com> (https://www.yoti.com/developers)",
   "license": "MIT",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,7 +3,7 @@ sonar.organization = getyoti
 
 sonar.projectKey = getyoti:node
 sonar.projectName = Node SDK
-sonar.projectVersion = 4.8.0
+sonar.projectVersion = 4.9.0
 sonar.exclusions=tests/**,examples/**,node_modules/**,coverage/**
 sonar.javascript.lcov.reportPaths=coverage/lcov.info
 sonar.verbose = true

--- a/src/idv_service/session/create/sdk.config.builder.js
+++ b/src/idv_service/session/create/sdk.config.builder.js
@@ -252,6 +252,19 @@ class SdkConfigBuilder {
   }
 
   /**
+   * Sets the brandID on the builder
+   *
+   * @param {string} brandId
+   *
+   * @returns {this}
+   */
+  withBrandId(brandId) {
+    Validation.isString(brandId, 'brandId');
+    this.brandId = brandId;
+    return this;
+  }
+
+  /**
    * Builds the {@link SdkConfig} using the values supplied to the builder
    *
    * @returns {SdkConfig}
@@ -269,7 +282,8 @@ class SdkConfigBuilder {
       this.privacyPolicyUrl,
       this.biometricConsentFlow,
       this.allowHandoff,
-      this.attemptsConfiguration
+      this.attemptsConfiguration,
+      this.brandId
     );
   }
 }

--- a/src/idv_service/session/create/sdk.config.js
+++ b/src/idv_service/session/create/sdk.config.js
@@ -28,6 +28,8 @@ class SdkConfig {
    *   Allows user to handoff to mobile during session
    * @param {object} attemptsConfiguration
    *   The attempts configuration
+   * @param {string} brandId
+   *   The brandID for the client
    */
   constructor(
     allowedCaptureMethods,
@@ -41,7 +43,8 @@ class SdkConfig {
     privacyPolicyUrl,
     biometricConsentFlow,
     allowHandoff,
-    attemptsConfiguration
+    attemptsConfiguration,
+    brandId
   ) {
     Validation.isString(allowedCaptureMethods, 'allowedCaptureMethods', true);
     /** @private */
@@ -92,6 +95,10 @@ class SdkConfig {
       /** @private */
       this.attemptsConfiguration = attemptsConfiguration;
     }
+
+    Validation.isString(brandId, 'brandId', true);
+    /** @private */
+    this.brandId = brandId;
   }
 
   /**
@@ -111,6 +118,7 @@ class SdkConfig {
       biometric_consent_flow: this.biometricConsentFlow,
       allow_handoff: this.allowHandoff,
       attempts_configuration: this.attemptsConfiguration,
+      brand_id: this.brandId,
     };
   }
 }

--- a/tests/idv_service/session/create/sdk.config.builder.test.js
+++ b/tests/idv_service/session/create/sdk.config.builder.test.js
@@ -16,6 +16,7 @@ describe('SdkConfigBuilder', () => {
       .withPrivacyPolicyUrl('some-privacy-policy-url')
       .withBiometricConsentFlow('some-flow')
       .withAllowHandoff(true)
+      .withBrandId('some-brand-identifier')
       .build();
 
     const expectedJson = JSON.stringify({
@@ -30,6 +31,7 @@ describe('SdkConfigBuilder', () => {
       privacy_policy_url: 'some-privacy-policy-url',
       biometric_consent_flow: 'some-flow',
       allow_handoff: true,
+      brand_id: 'some-brand-identifier',
     });
 
     expect(JSON.stringify(sdkConfig)).toBe(expectedJson);

--- a/types/src/idv_service/session/create/sdk.config.builder.d.ts
+++ b/types/src/idv_service/session/create/sdk.config.builder.d.ts
@@ -164,6 +164,15 @@ declare class SdkConfigBuilder {
      */
     withIdDocumentTextExtractionGenericRetries(retries: number): this;
     /**
+     * Sets the brandID on the builder
+     *
+     * @param {string} brandId
+     *
+     * @returns {this}
+     */
+    withBrandId(brandId: string): this;
+    brandId: string;
+    /**
      * Builds the {@link SdkConfig} using the values supplied to the builder
      *
      * @returns {SdkConfig}

--- a/types/src/idv_service/session/create/sdk.config.d.ts
+++ b/types/src/idv_service/session/create/sdk.config.d.ts
@@ -25,8 +25,10 @@ declare class SdkConfig {
      *   Allows user to handoff to mobile during session
      * @param {object} attemptsConfiguration
      *   The attempts configuration
+     * @param {string} brandId
+     *   The brandID for the client
      */
-    constructor(allowedCaptureMethods: string, primaryColour: string, secondaryColour: string, fontColour: string, locale: string, presetIssuingCountry: string, successUrl: string, errorUrl: string, privacyPolicyUrl: string, biometricConsentFlow: string, allowHandoff: boolean, attemptsConfiguration: object);
+    constructor(allowedCaptureMethods: string, primaryColour: string, secondaryColour: string, fontColour: string, locale: string, presetIssuingCountry: string, successUrl: string, errorUrl: string, privacyPolicyUrl: string, biometricConsentFlow: string, allowHandoff: boolean, attemptsConfiguration: object, brandId: string);
     /** @private */
     private allowedCaptureMethods;
     /** @private */
@@ -51,6 +53,8 @@ declare class SdkConfig {
     private allowHandoff;
     /** @private */
     private attemptsConfiguration;
+    /** @private */
+    private brandId;
     /**
      * Returns serialized data for JSON.stringify()
      */
@@ -67,5 +71,6 @@ declare class SdkConfig {
         biometric_consent_flow: string;
         allow_handoff: boolean;
         attempts_configuration: any;
+        brand_id: string;
     };
 }


### PR DESCRIPTION
## NEW
#### Identity Verification service
When configuring a session, one can now specify the **brand identifier** for the IDV client, via the `SdkConfigBuilder` new method `withBrandId(string)`.

##### Example
```ts
const {
  SdkConfigBuilder,
} = require('yoti');

// Using the SessionSpecificationBuilder
const sdkConfig = new SdkConfigBuilder()
  .withAllowsCameraAndUpload()
  // .... more options
  .withBrandId('some-brand-identifier')  // NEW
  .build();
```