### PR TITLE
SDK-2359 Digital Identity - support wanted attributes extra options

### DIFF
--- a/src/digital_identity_service/policy/wanted.attribute.builder.js
+++ b/src/digital_identity_service/policy/wanted.attribute.builder.js
@@ -46,6 +46,33 @@ module.exports = class WantedAttributeBuilder {
   }
 
   /**
+   * @param {string} alternativeName
+   * @returns this
+   */
+  withAlternativeName(alternativeName) {
+    this.alternativeNames = [...(this.alternativeNames || []), alternativeName];
+    return this;
+  }
+
+  /**
+   * @param {string[]} alternativeNames
+   * @returns this
+   */
+  withAlternativeNames(alternativeNames) {
+    this.alternativeNames = alternativeNames;
+    return this;
+  }
+
+  /**
+   * @param {boolean} [optional=true]
+   * @returns this
+   */
+  withOptional(optional = true) {
+    this.optional = optional;
+    return this;
+  }
+
+  /**
    * @returns {WantedAttribute}
    */
   build() {
@@ -53,7 +80,9 @@ module.exports = class WantedAttributeBuilder {
       this.name,
       this.derivation,
       this.acceptSelfAsserted,
-      this.constraints
+      this.constraints,
+      this.alternativeNames,
+      this.optional
     );
   }
 };

--- a/src/digital_identity_service/policy/wanted.attribute.js
+++ b/src/digital_identity_service/policy/wanted.attribute.js
@@ -14,8 +14,11 @@ module.exports = class WantedAttribute {
    * @param {string|null} derivation
    * @param {boolean|null} acceptSelfAsserted
    * @param {Constraints|null} constraints
+   * @param {string[]|null} alternativeNames
+   * @param {boolean|null} optional
    */
-  constructor(name, derivation = null, acceptSelfAsserted = null, constraints = null) {
+  // eslint-disable-next-line max-len
+  constructor(name, derivation = null, acceptSelfAsserted = null, constraints = null, alternativeNames = null, optional = null) {
     Validation.isString(name, 'name');
     Validation.notNullOrEmpty(name, 'name');
     /** @private */
@@ -38,6 +41,18 @@ module.exports = class WantedAttribute {
     }
     /** @private */
     this.constraints = constraints;
+
+    if (alternativeNames !== null) {
+      Validation.isArrayOfStrings(alternativeNames, 'alternativeNames');
+    }
+    /** @private */
+    this.alternativeNames = alternativeNames;
+
+    if (optional !== null) {
+      Validation.isBoolean(optional, 'optional');
+    }
+    /** @private */
+    this.optional = optional;
   }
 
   /**
@@ -82,6 +97,26 @@ module.exports = class WantedAttribute {
   }
 
   /**
+   * Accept alternative names.
+   *
+   * These are names of attributes that can be used as fallback
+   *
+   * @returns {string[]}
+   */
+  getAlternativeNames() {
+    return this.alternativeNames;
+  }
+
+  /**
+   * Whether the attribute is wanted optionally
+   *
+   * @returns {boolean}
+   */
+  getOptional() {
+    return this.optional;
+  }
+
+  /**
    * Returns serialized data for JSON.stringify()
    */
   toJSON() {
@@ -100,6 +135,14 @@ module.exports = class WantedAttribute {
 
     if ((typeof this.getAcceptSelfAsserted()) === 'boolean') {
       json.accept_self_asserted = this.getAcceptSelfAsserted();
+    }
+
+    if (this.getAlternativeNames() !== null) {
+      json.alternative_names = this.getAlternativeNames();
+    }
+
+    if (this.getOptional() !== null) {
+      json.optional = this.getOptional();
     }
 
     return json;

--- a/tests/digital_identity_service/policy/wanted.attribute.builder.spec.js
+++ b/tests/digital_identity_service/policy/wanted.attribute.builder.spec.js
@@ -131,4 +131,48 @@ describe('WantedAttributeBuilder', () => {
     expect(wantedAttribute).toBeInstanceOf(WantedAttribute);
     expect(JSON.stringify(wantedAttribute)).toBe(expectedJson);
   });
+
+  it('should build a wanted attribute with alternative name', () => {
+    const wantedAttribute = new WantedAttributeBuilder()
+      .withName(TEST_NAME)
+      .withAlternativeName(`alt-${TEST_NAME}`)
+      .build();
+
+    const expectedJson = JSON.stringify({
+      name: TEST_NAME,
+      optional: false,
+      alternative_names: [`alt-${TEST_NAME}`],
+    });
+    expect(wantedAttribute).toBeInstanceOf(WantedAttribute);
+    expect(JSON.stringify(wantedAttribute)).toBe(expectedJson);
+  });
+
+  it('should build a wanted attribute with alternative names', () => {
+    const wantedAttribute = new WantedAttributeBuilder()
+      .withName(TEST_NAME)
+      .withAlternativeNames([`${TEST_NAME}-alt1`, `${TEST_NAME}-alt2`])
+      .build();
+
+    const expectedJson = JSON.stringify({
+      name: TEST_NAME,
+      optional: false,
+      alternative_names: [`${TEST_NAME}-alt1`, `${TEST_NAME}-alt2`],
+    });
+    expect(wantedAttribute).toBeInstanceOf(WantedAttribute);
+    expect(JSON.stringify(wantedAttribute)).toBe(expectedJson);
+  });
+
+  it('should build a wanted attribute with optional behaviour', () => {
+    const wantedAttribute = new WantedAttributeBuilder()
+      .withName(TEST_NAME)
+      .withOptional(true)
+      .build();
+
+    const expectedJson = JSON.stringify({
+      name: TEST_NAME,
+      optional: true,
+    });
+    expect(wantedAttribute).toBeInstanceOf(WantedAttribute);
+    expect(JSON.stringify(wantedAttribute)).toBe(expectedJson);
+  });
 });

--- a/tests/digital_identity_service/policy/wanted.attribute.builder.spec.js
+++ b/tests/digital_identity_service/policy/wanted.attribute.builder.spec.js
@@ -162,6 +162,22 @@ describe('WantedAttributeBuilder', () => {
     expect(JSON.stringify(wantedAttribute)).toBe(expectedJson);
   });
 
+  it('should build a wanted attribute with alternative names using both methods', () => {
+    const wantedAttribute = new WantedAttributeBuilder()
+      .withName(TEST_NAME)
+      .withAlternativeNames([`${TEST_NAME}-alt1`, `${TEST_NAME}-alt2`])
+      .withAlternativeName(`${TEST_NAME}-extra`)
+      .build();
+
+    const expectedJson = JSON.stringify({
+      name: TEST_NAME,
+      optional: false,
+      alternative_names: [`${TEST_NAME}-alt1`, `${TEST_NAME}-alt2`, `${TEST_NAME}-extra`],
+    });
+    expect(wantedAttribute).toBeInstanceOf(WantedAttribute);
+    expect(JSON.stringify(wantedAttribute)).toBe(expectedJson);
+  });
+
   it('should build a wanted attribute with optional behaviour', () => {
     const wantedAttribute = new WantedAttributeBuilder()
       .withName(TEST_NAME)

--- a/types/src/digital_identity_service/policy/wanted.attribute.builder.d.ts
+++ b/types/src/digital_identity_service/policy/wanted.attribute.builder.d.ts
@@ -26,6 +26,23 @@ declare class WantedAttributeBuilder {
     withAcceptSelfAsserted(acceptSelfAsserted?: boolean): this;
     acceptSelfAsserted: boolean;
     /**
+     * @param {string} alternativeName
+     * @returns this
+     */
+    withAlternativeName(alternativeName: string): this;
+    alternativeNames: any;
+    /**
+     * @param {string[]} alternativeNames
+     * @returns this
+     */
+    withAlternativeNames(alternativeNames: string[]): this;
+    /**
+     * @param {boolean} [optional=true]
+     * @returns this
+     */
+    withOptional(optional?: boolean): this;
+    optional: boolean;
+    /**
      * @returns {WantedAttribute}
      */
     build(): WantedAttribute;

--- a/types/src/digital_identity_service/policy/wanted.attribute.d.ts
+++ b/types/src/digital_identity_service/policy/wanted.attribute.d.ts
@@ -5,8 +5,10 @@ declare class WantedAttribute {
      * @param {string|null} derivation
      * @param {boolean|null} acceptSelfAsserted
      * @param {Constraints|null} constraints
+     * @param {string[]|null} alternativeNames
+     * @param {boolean|null} optional
      */
-    constructor(name: string, derivation?: string | null, acceptSelfAsserted?: boolean | null, constraints?: Constraints | null);
+    constructor(name: string, derivation?: string | null, acceptSelfAsserted?: boolean | null, constraints?: Constraints | null, alternativeNames?: string[] | null, optional?: boolean | null);
     /** @private */
     private name;
     /** @private */
@@ -15,6 +17,10 @@ declare class WantedAttribute {
     private acceptSelfAsserted;
     /** @private */
     private constraints;
+    /** @private */
+    private alternativeNames;
+    /** @private */
+    private optional;
     /**
      * Name identifying the WantedAttribute
      *
@@ -44,6 +50,20 @@ declare class WantedAttribute {
      * @returns {boolean}
      */
     getAcceptSelfAsserted(): boolean;
+    /**
+     * Accept alternative names.
+     *
+     * These are names of attributes that can be used as fallback
+     *
+     * @returns {string[]}
+     */
+    getAlternativeNames(): string[];
+    /**
+     * Whether the attribute is wanted optionally
+     *
+     * @returns {boolean}
+     */
+    getOptional(): boolean;
     /**
      * Returns serialized data for JSON.stringify()
      */


### PR DESCRIPTION
Added in `digital_identity_service` the wanted attribute extra options (`alternative name`, `optional`)