### PR TITLE
SDK-2587 Add "optional" and "alternative_names" for share v1

### DIFF
--- a/src/dynamic_sharing_service/policy/wanted.attribute.builder.js
+++ b/src/dynamic_sharing_service/policy/wanted.attribute.builder.js
@@ -43,6 +43,30 @@ module.exports = class WantedAttributeBuilder {
   }
 
   /**
+   * @param {string} alternativeName
+   */
+  withAlternativeName(alternativeName) {
+    this.alternativeNames = [...(this.alternativeNames || []), alternativeName];
+    return this;
+  }
+
+  /**
+   * @param {string[]} alternativeNames
+   */
+  withAlternativeNames(alternativeNames) {
+    this.alternativeNames = alternativeNames;
+    return this;
+  }
+
+  /**
+   * @param {boolean} [optional=true]
+   */
+  withOptional(optional = true) {
+    this.optional = optional;
+    return this;
+  }
+
+  /**
    * @returns {WantedAttribute}
    */
   build() {
@@ -50,7 +74,9 @@ module.exports = class WantedAttributeBuilder {
       this.name,
       this.derivation,
       this.acceptSelfAsserted,
-      this.constraints
+      this.constraints,
+      this.alternativeNames,
+      this.optional
     );
   }
 };

--- a/src/dynamic_sharing_service/policy/wanted.attribute.js
+++ b/src/dynamic_sharing_service/policy/wanted.attribute.js
@@ -14,8 +14,11 @@ module.exports = class WantedAttribute {
    * @param {string|null} derivation
    * @param {boolean|null} acceptSelfAsserted
    * @param {Constraints|null} constraints
+   * @param {string[]|null} alternativeNames
+   * @param {boolean|null} optional
    */
-  constructor(name, derivation = null, acceptSelfAsserted = null, constraints = null) {
+  // eslint-disable-next-line max-len
+  constructor(name, derivation = null, acceptSelfAsserted = null, constraints = null, alternativeNames = null, optional = null) {
     Validation.isString(name, 'name');
     Validation.notNullOrEmpty(name, 'name');
     /** @private */
@@ -38,6 +41,18 @@ module.exports = class WantedAttribute {
     }
     /** @private */
     this.constraints = constraints;
+
+    if (alternativeNames !== null) {
+      Validation.isArrayOfStrings(alternativeNames, 'alternativeNames');
+    }
+    /** @private */
+    this.alternativeNames = alternativeNames;
+
+    if (optional !== null) {
+      Validation.isBoolean(optional, 'optional');
+    }
+    /** @private */
+    this.optional = optional;
   }
 
   /**
@@ -82,6 +97,26 @@ module.exports = class WantedAttribute {
   }
 
   /**
+   * Accept alternative names.
+   *
+   * These are names of attributes that can be used as fallback
+   *
+   * @returns {string[]}
+   */
+  getAlternativeNames() {
+    return this.alternativeNames;
+  }
+
+  /**
+   * Whether the attribute is wanted optionally
+   *
+   * @returns {boolean}
+   */
+  getOptional() {
+    return this.optional;
+  }
+
+  /**
    * @returns {Object} data for JSON.stringify()
    */
   toJSON() {
@@ -100,6 +135,14 @@ module.exports = class WantedAttribute {
 
     if ((typeof this.getAcceptSelfAsserted()) === 'boolean') {
       json.accept_self_asserted = this.getAcceptSelfAsserted();
+    }
+
+    if (this.getAlternativeNames() !== null) {
+      json.alternative_names = this.getAlternativeNames();
+    }
+
+    if (this.getOptional() !== null) {
+      json.optional = this.getOptional();
     }
 
     return json;

--- a/tests/dynamic_sharing_service/policy/wanted.attribute.builder.spec.js
+++ b/tests/dynamic_sharing_service/policy/wanted.attribute.builder.spec.js
@@ -127,4 +127,64 @@ describe('WantedAttributeBuilder', () => {
     expect(wantedAttribute).toBeInstanceOf(WantedAttribute);
     expect(JSON.stringify(wantedAttribute)).toBe(expectedJson);
   });
+
+  it('should build a wanted attribute with alternative name', () => {
+    const wantedAttribute = new WantedAttributeBuilder()
+      .withName(TEST_NAME)
+      .withAlternativeName(`alt-${TEST_NAME}`)
+      .build();
+
+    const expectedJson = JSON.stringify({
+      name: TEST_NAME,
+      optional: false,
+      alternative_names: [`alt-${TEST_NAME}`],
+    });
+    expect(wantedAttribute).toBeInstanceOf(WantedAttribute);
+    expect(JSON.stringify(wantedAttribute)).toBe(expectedJson);
+  });
+
+  it('should build a wanted attribute with alternative names', () => {
+    const wantedAttribute = new WantedAttributeBuilder()
+      .withName(TEST_NAME)
+      .withAlternativeNames([`${TEST_NAME}-alt1`, `${TEST_NAME}-alt2`])
+      .build();
+
+    const expectedJson = JSON.stringify({
+      name: TEST_NAME,
+      optional: false,
+      alternative_names: [`${TEST_NAME}-alt1`, `${TEST_NAME}-alt2`],
+    });
+    expect(wantedAttribute).toBeInstanceOf(WantedAttribute);
+    expect(JSON.stringify(wantedAttribute)).toBe(expectedJson);
+  });
+
+  it('should build a wanted attribute with alternative names using both methods', () => {
+    const wantedAttribute = new WantedAttributeBuilder()
+      .withName(TEST_NAME)
+      .withAlternativeNames([`${TEST_NAME}-alt1`, `${TEST_NAME}-alt2`])
+      .withAlternativeName(`${TEST_NAME}-extra`)
+      .build();
+
+    const expectedJson = JSON.stringify({
+      name: TEST_NAME,
+      optional: false,
+      alternative_names: [`${TEST_NAME}-alt1`, `${TEST_NAME}-alt2`, `${TEST_NAME}-extra`],
+    });
+    expect(wantedAttribute).toBeInstanceOf(WantedAttribute);
+    expect(JSON.stringify(wantedAttribute)).toBe(expectedJson);
+  });
+
+  it('should build a wanted attribute with optional behaviour', () => {
+    const wantedAttribute = new WantedAttributeBuilder()
+      .withName(TEST_NAME)
+      .withOptional(true)
+      .build();
+
+    const expectedJson = JSON.stringify({
+      name: TEST_NAME,
+      optional: true,
+    });
+    expect(wantedAttribute).toBeInstanceOf(WantedAttribute);
+    expect(JSON.stringify(wantedAttribute)).toBe(expectedJson);
+  });
 });

--- a/types/src/dynamic_sharing_service/policy/wanted.attribute.builder.d.ts
+++ b/types/src/dynamic_sharing_service/policy/wanted.attribute.builder.d.ts
@@ -23,6 +23,20 @@ declare class WantedAttributeBuilder {
     withAcceptSelfAsserted(acceptSelfAsserted?: boolean): this;
     acceptSelfAsserted: boolean;
     /**
+     * @param {string} alternativeName
+     */
+    withAlternativeName(alternativeName: string): this;
+    alternativeNames: any;
+    /**
+     * @param {string[]} alternativeNames
+     */
+    withAlternativeNames(alternativeNames: string[]): this;
+    /**
+     * @param {boolean} [optional=true]
+     */
+    withOptional(optional?: boolean): this;
+    optional: boolean;
+    /**
      * @returns {WantedAttribute}
      */
     build(): WantedAttribute;

--- a/types/src/dynamic_sharing_service/policy/wanted.attribute.d.ts
+++ b/types/src/dynamic_sharing_service/policy/wanted.attribute.d.ts
@@ -5,8 +5,10 @@ declare class WantedAttribute {
      * @param {string|null} derivation
      * @param {boolean|null} acceptSelfAsserted
      * @param {Constraints|null} constraints
+     * @param {string[]|null} alternativeNames
+     * @param {boolean|null} optional
      */
-    constructor(name: string, derivation?: string | null, acceptSelfAsserted?: boolean | null, constraints?: Constraints | null);
+    constructor(name: string, derivation?: string | null, acceptSelfAsserted?: boolean | null, constraints?: Constraints | null, alternativeNames?: string[] | null, optional?: boolean | null);
     /** @private */
     private name;
     /** @private */
@@ -15,6 +17,10 @@ declare class WantedAttribute {
     private acceptSelfAsserted;
     /** @private */
     private constraints;
+    /** @private */
+    private alternativeNames;
+    /** @private */
+    private optional;
     /**
      * Name identifying the WantedAttribute
      *
@@ -44,6 +50,20 @@ declare class WantedAttribute {
      * @returns {boolean}
      */
     getAcceptSelfAsserted(): boolean;
+    /**
+     * Accept alternative names.
+     *
+     * These are names of attributes that can be used as fallback
+     *
+     * @returns {string[]}
+     */
+    getAlternativeNames(): string[];
+    /**
+     * Whether the attribute is wanted optionally
+     *
+     * @returns {boolean}
+     */
+    getOptional(): boolean;
     /**
      * @returns {Object} data for JSON.stringify()
      */


### PR DESCRIPTION
Can now set for **dynamic_sharing_service** policy with attributes that have alternative names, or that are optional:


```ts
    const wantedAttribute = new WantedAttributeBuilder()
      .withName("common_name")
      .withAlternativeName("alt-name-1")
      .build()
```
or
```ts
    const wantedAttribute = new WantedAttributeBuilder()
      .withName("common_name")
      .withAlternativeNames(["alt-name-1", "alt-name-2"])
      .build()
```

and

```ts
    const wantedAttribute = new WantedAttributeBuilder()
      .withName("some_attribute_name")
      .withOptional(true)
      .build()
```

