### PR TITLE
SDK-2588 Extend parsing of age verification attribute name

### DIFF
--- a/src/data_type/age.verification.js
+++ b/src/data_type/age.verification.js
@@ -18,14 +18,16 @@ class AgeVerification {
   constructor(name, value) {
     Validation.isString(name, 'name');
     Validation.oneOf(value, ['true', 'false'], 'value');
-    Validation.matchesPattern(name, /^[^:]+:(?!.*:)[0-9]+$/, 'attribute.name');
+    Validation.matchesPattern(name, /^[^:]+:[0-9]+(?::[0-9]+)?$/, 'attribute.name');
 
-    const split = name.split(':');
+    const [type, age, ageBuffer] = name.split(':');
     /** @private */
-    this.checkType = split[0];
+    this.checkType = type;
 
     /** @private */
-    this.age = parseInt(split[1], 10);
+    this.age = parseInt(age, 10);
+    /** @private */
+    this.ageBuffer = ageBuffer ? parseInt(ageBuffer, 10) : undefined;
     /** @private */
     this.result = value === 'true';
   }
@@ -48,6 +50,15 @@ class AgeVerification {
    */
   getAge() {
     return this.age;
+  }
+
+  /**
+   * The age buffer allowed
+   *
+   * @returns {number}
+   */
+  getAgeBuffer() {
+    return this.ageBuffer;
   }
 
   /**

--- a/tests/data_type/age.verification.spec.js
+++ b/tests/data_type/age.verification.spec.js
@@ -1,7 +1,7 @@
 const { AgeVerification } = require('../../src/data_type/age.verification');
 const { ATTR_AGE_OVER, ATTR_AGE_UNDER } = require('../../src/yoti_common/constants');
 
-const EXPECTED_PATTERN = /^[^:]+:(?!.*:)[0-9]+$/;
+const EXPECTED_PATTERN = /^[^:]+:[0-9]+(?::[0-9]+)?$/;
 
 describe('AgeVerification', () => {
   describe('when malformed age derivation is provided', () => {
@@ -15,7 +15,7 @@ describe('AgeVerification', () => {
         ':age_over:18',
         'age_over::18',
         'age_over:18:',
-        'age_over:18:21',
+        'age_over:18:21:',
       ].forEach((name) => {
         expect(() => new AgeVerification(name, 'true'))
           .toThrow(new TypeError(`'attribute.name' value '${name}' does not match format '${EXPECTED_PATTERN}'`));
@@ -45,6 +45,23 @@ describe('AgeVerification', () => {
     });
     it('should parse age', () => {
       expect(ageVerification.getAge()).toBe(21);
+    });
+    it('should parse result', () => {
+      expect(ageVerification.getResult()).toBe(true);
+    });
+  });
+
+  describe(`when well formed age derivation is provided (with age buffer): ${ATTR_AGE_OVER}21:5`, () => {
+    const ageVerification = new AgeVerification(`${ATTR_AGE_OVER}21:5`, 'true');
+
+    it('should parse check type', () => {
+      expect(ageVerification.getCheckType()).toBe('age_over');
+    });
+    it('should parse age', () => {
+      expect(ageVerification.getAge()).toBe(21);
+    });
+    it('should parse age buffer', () => {
+      expect(ageVerification.getAgeBuffer()).toBe(5);
     });
     it('should parse result', () => {
       expect(ageVerification.getResult()).toBe(true);

--- a/types/src/data_type/age.verification.d.ts
+++ b/types/src/data_type/age.verification.d.ts
@@ -12,6 +12,8 @@ export class AgeVerification {
     /** @private */
     private age;
     /** @private */
+    private ageBuffer;
+    /** @private */
     private result;
     /**
      * The type of age check performed, as specified on Yoti Hub.
@@ -27,6 +29,12 @@ export class AgeVerification {
      * @returns {number}
      */
     getAge(): number;
+    /**
+     * The age buffer allowed
+     *
+     * @returns {number}
+     */
+    getAgeBuffer(): number;
     /**
      * Whether the profile passed the age check.
      *


### PR DESCRIPTION
Updated the data_type `AgeVerification` to handle the name parsing so it accepts an optional additional value (an age buffer - literally).